### PR TITLE
Increase delay between two pools of the server socket.

### DIFF
--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -150,7 +150,7 @@ int YOGServer::run()
 	std::cout<<"Server started successfully."<<std::endl;
 	while(nl.isListening())
 	{
-		const int speed = 4;
+		const int speed = 20;
 		int startTick, endTick;
 		startTick = SDL_GetTicks();
 		update();


### PR DESCRIPTION
I did this years ago and don't remember why.
Probably to save some CPU time.