### PR TITLE
Fix for memset warning.

### DIFF
--- a/src/AICastor.cpp
+++ b/src/AICastor.cpp
@@ -1817,7 +1817,7 @@ bool AICastor::enoughFreeWorkers()
 	static bool first=true;
 	if (first)
 	{
-		memset(oldEnough, 2, 1024);
+		memset(oldEnough, 2, 1024*sizeof(*oldEnough));
 		first=false;
 	}
 	if ((oldEnough[buildsAmount]==2) || (enough!=oldEnough[buildsAmount]))


### PR DESCRIPTION
memset is called to filll a int array of size 1024 but the third parameter (`n`) is in bytes, so I changed the third argument to multiply by `sizeof(*oldEnough)` which will tell memset the total size of the array. I could've used `sizeof(int)` but then the type would need to be changed in two places if the type of the array changed.

Compiler warning:
```
src/AICastor.cpp: In member function 'bool AICastor::enoughFreeWorkers()':
src/AICastor.cpp:1820:28: warning: 'memset' used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
   memset(oldEnough, 2, 1024);
                            ^
```