### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+
+services:
+- docker
+
+env:
+  matrix:
+   #- BUILD_IMG=ubuntu:16.04 DEPS=python3 # requires a manually installed scons version which works with Python 3
+   - BUILD_IMG=ubuntu:18.04 DEPS=python3
+   - BUILD_IMG=ubuntu:19.10 DEPS=python3
+   - BUILD_IMG=ubuntu:20.04
+   - BUILD_IMG=ubuntu:20.10
+
+script: docker run --rm=true -v $HOME:$HOME:rw $BUILD_IMG /bin/sh -c "sed -i '/^#\sdeb-src /s/^#//' /etc/apt/sources.list && apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get build-dep --yes glob2 && env DEBIAN_FRONTEND=noninteractive apt-get install --yes $DEPS && cd $PWD && /usr/bin/env python3 /usr/bin/scons -j16 && /usr/bin/env python3 /usr/bin/scons -j16 install"


### PR DESCRIPTION
Travis has already been suggested in https://github.com/Globulation2/glob2/pull/6/files, but I don't find the reason why it hasn't been included there and don't see any reason anyway.

[Build #8 on my fork shows that it's working](https://travis-ci.org/github/krichter722/glob2/builds/714164467) given that the Python 3 patch in #26 is merged.