### PR TITLE
Cleaned-up Map::cases.

### DIFF
--- a/src/AICastor.cpp
+++ b/src/AICastor.cpp
@@ -2003,11 +2003,11 @@ void AICastor::computeObstacleUnitMap()
 	//int wMask=map->wMask;
 	//int hMask=map->hMask;
 	size_t size=w*h;
-	Case *cases=map->cases;
+	const auto& cases=map->cases;
 	Uint32 teamMask=team->me;
 	for (size_t i=0; i<size; i++)
 	{
-		Case c=cases[i];
+		const auto& c=cases[i];
 		if (c.building!=NOGBID)
 			obstacleUnitMap[i]=0;
 		else if (c.ressource.type!=NO_RES_TYPE)
@@ -2033,10 +2033,10 @@ void AICastor::computeObstacleBuildingMap()
 	//int hDec=map->hDec;
 	//int wDec=map->wDec;
 	size_t size=w*h;
-	Case *cases=map->cases;
+	const auto& cases=map->cases;
 	for (size_t i=0; i<size; i++)
 	{
-		Case c=cases[i];
+		const Case& c=cases[i];
 		if (c.building!=NOGBID)
 			obstacleBuildingMap[i]=0;
 		else  if (c.terrain>=16) // if (!isGrass)
@@ -2102,7 +2102,7 @@ void AICastor::computeBuildingNeighbourMapOfBuilding(int bx, int by, int bw, int
 	
 	//size_t size=w*h;
 	Uint8 *gradient=buildingNeighbourMap;
-	Case *cases=map->cases;
+	const auto& cases=map->cases;
 	
 	//Uint8 *wheatGradient=map->ressourcesGradient[team->teamNumber][CORN][canSwim];
 	
@@ -2169,7 +2169,7 @@ void AICastor::computeBuildingNeighbourMapOfBuilding(int bx, int by, int bw, int
 		gradient[((bx+bw)&wMask)+(((by+bh)&hMask)<<wDec)]|=1;
 	}
 	
-	// At a range of 0 space case (neignbours), without corners,
+	// At a range of 0 space case (neighbours), without corners,
 	// we increment (bit 1 to 3), and dirty bit 0 in case:
 	for (int xi=bx-dw+1; xi<bx+bw; xi++)
 	{
@@ -2436,7 +2436,7 @@ fprintf(logFile,  "computeHydratationMap()...\n");
 	
 	Uint16 *gradient=(Uint16 *)malloc(2*size);
 	memset(gradient, 0, 2*size);
-	Case *cases=map->cases;
+	const auto& cases=map->cases;
 	static const int range=16;
 	for (int y=0; y<h; y++)
 		for (int x=0; x<w; x++)
@@ -2490,7 +2490,7 @@ void AICastor::computeNotGrassMap()
 	
 	memset(notGrassMap, 0, size);
 	
-	Case *cases=map->cases;
+	const auto& cases=map->cases;
 	for (size_t i=0; i<size; i++)
 	{
 		Uint16 t=cases[i].terrain;
@@ -2906,7 +2906,7 @@ void AICastor::computeRessourcesCluster()
 	fprintf(logFile,  "computeRessourcesCluster()\n");
 	int w=map->w;
 	int h=map->h;
-	int wMask=map->wMask;
+	//int wMask=map->wMask;
 	int hMask=map->hMask;
 	size_t size=w*h;
 	
@@ -2921,8 +2921,8 @@ void AICastor::computeRessourcesCluster()
 	{
 		for (int x=0; x<w; x++)
 		{
-			Case *c=map->cases+w*(y&hMask)+(x&wMask); // case
-			Ressource r=c->ressource; // ressource
+			const auto& c = map->cases[map->coordToIndex(x, y)]; // case
+			const auto& r=c.ressource; // ressource
 			Uint8 rt=r.type; // ressources type
 			
 			int rci=x+y*w; // ressource cluster index

--- a/src/Map.h
+++ b/src/Map.h
@@ -49,24 +49,24 @@ class MapHeader;
 // a 1x1 piece of map
 struct Case
 {
-	Uint16 terrain;
-	Uint16 building;
+	Uint16 terrain = 0; // default, not really meaningful.
+	Uint16 building = NOGBID;
 
 	Ressource ressource;
 
-	Uint16 groundUnit;
-	Uint16 airUnit;
+	Uint16 groundUnit = NOGUID;
+	Uint16 airUnit = NOGUID;
 
-	Uint32 forbidden; // This is a mask, one bit by team, 1=forbidden, 0=allowed
+	Uint32 forbidden = 0; // This is a mask, one bit by team, 1=forbidden, 0=allowed
 	///The difference between forbidden zone and hidden forbidden zone is that hidden forbidden zone
 	///is put there by the game engine and is not draw to the screen.
-	Uint32 guardArea; // This is a mask, one bit by team, 1=guard area, 0=normal
-	Uint32 clearArea; // This is a mask, one bit by team, 1=clear area, 0=normal
+	Uint32 guardArea = 0; // This is a mask, one bit by team, 1=guard area, 0=normal
+	Uint32 clearArea = 0; // This is a mask, one bit by team, 1=clear area, 0=normal
 
-	Uint16 scriptAreas; // This is also a mask. A single bit represents an area #n, on or off for the square
-	Uint8 canRessourcesGrow; // This is a boolean, it represents whether ressources are allowed to grow into this location.
+	Uint16 scriptAreas = 0; // This is also a mask. A single bit represents an area #n, on or off for the square
+	Uint8 canRessourcesGrow = 1; // This is a boolean, it represents whether ressources are allowed to grow into this location.
 	
-	Uint16 fertility; // This is a value that represents the fertility of this square, the chance that wheat will grow on it
+	Uint16 fertility = 0; // This is a value that represents the fertility of this square, the chance that wheat will grow on it
 };
 
 /// Types of areas
@@ -138,8 +138,9 @@ public:
 	//! Return the number of sectors on y, which corresponds to the sector map height
 	int getSectorH(void) const { return hSector; }
 
+	/// Return an index into map arrays for a given position, wrap-safe
 	size_t coordToIndex(int x, int y) {
-		return ((y&hMask)<<wDec)+(x&wMask);
+		return ((y & hMask) << wDec) + (x & wMask);
 	}
 
 	///Returns a normalized version of the x cordinate, taking into account that x coordinates wrap around
@@ -174,7 +175,7 @@ public:
 	//! Make the building at (x, y) visible for all teams in sharedVision (mask).
 	void setMapBuildingsDiscovered(int x, int y, Uint32 sharedVision, Team *teams[Team::MAX_COUNT])
 	{
-		Uint16 bgid = (cases+coordToIndex(x, y))->building;
+		Uint16 bgid = cases[coordToIndex(x, y)].building;
 		if (bgid != NOGBID)
 		{
 			int id = Building::GIDtoID(bgid);
@@ -340,9 +341,9 @@ public:
 		return cases[coordToIndex(x, y)].ressource;
 	}
 	
-	Ressource getRessource(unsigned pos)
+	Ressource getRessource(size_t pos)
 	{
-		return (cases+pos)->ressource;
+		return cases[pos].ressource;
 	}
 	
 	//Returns the combined forbidden and hidden foribidden masks
@@ -759,7 +760,7 @@ protected:
 public:
 	Game *game;
 public:
-	Case *cases;
+	std::vector<Case> cases;
 	Sint32 w, h;
 	Sint32 wMask, hMask;
 	Sint32 wDec, hDec;

--- a/src/Ressource.h
+++ b/src/Ressource.h
@@ -30,14 +30,14 @@
 //! Either a ressource type is NO_RES_TYPE and all others fields are zero, or the ressource has a valid type and amount is NOT zero. This constraint does not apply if a ressource is eternal.
 struct Ressource
 {
-	Uint8 type;
-	Uint8 variety;
-	Uint8 amount;
-	Uint8 animation;
+	Uint8 type = NO_RES_TYPE;
+	Uint8 variety = 0;
+	Uint8 amount = 0;
+	Uint8 animation = 0;
 	
 	void clear() {type=NO_RES_TYPE; variety = 0;  amount = 0;  animation = 0; }
 	//void setUint32(Uint32 i) { animation=i&0xFF; amount=(i>>8)&0xFF; variety=(i>>16)&0xFF; type=(i>>24)&0xFF; }
-	Uint32 getUint32() { return animation | (amount<<8) | (variety<<16) | (type<<24); }
+	Uint32 getUint32() const { return animation | (amount<<8) | (variety<<16) | (type<<24); }
 };
 
 std::string getRessourceName(int type);


### PR DESCRIPTION
This PR updates `Map::cases` to modern C++, using `std::vector` for storage and (const) reference when accessing it. The changes are not pedantic for using the cleanest modern patterns, but rather pragmatic to improve code readability, maintainability and type safety while having somewhat minimal changes at that point.

Any wants to review and comments and this new style is welcome. 