### PR TITLE
Fix crash when pressing Print Screen key on Linux.

### DIFF
--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <valarray>
 #include <cstdlib>
+#include <memory>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -2187,12 +2188,13 @@ namespace GAGCore
 
 		// Fetch the surface to print
 		#ifdef HAVE_OPENGL
+		std::unique_ptr<DrawableSurface> toPrint = nullptr;
 		if (_gc->optionFlags & GraphicContext::USEGPU)
 		{
-			DrawableSurface toPrint(getW(), getH());
+			toPrint = std::make_unique<DrawableSurface>(getW(), getH());
 			glFlush();
-			toPrint.drawSurface(0, 0, this);
-			toPrintSurface = toPrint.sdlsurface;
+			toPrint->drawSurface(0, 0, this);
+			toPrintSurface = toPrint->sdlsurface;
 		}
 		else
 		#endif


### PR DESCRIPTION
In GraphicContext::printScreen, when OpenGL support is compiled in and enabled and the Print Screen key is pressed, `toPrint` variable goes out of scope but `toPrintSurface` still points to its `sdlsurface` member when calling `SDL_SaveBMP()`. When `toPrint` goes out of scope, it is destroyed and its destructor frees sdlsurface, and then toPrintSurface points to an invalid surface. The game then crashes in SDL_SaveBMP because an invalid surface is passed to SDL_SaveBMP().

I changed it from a stack allocated variable to a dynamically allocated variable in the enclosing scope; this seems to fix the bug.

Fixes #47.