### PR TITLE
Polished the .desktop file

### DIFF
--- a/data/glob2.desktop
+++ b/data/glob2.desktop
@@ -10,4 +10,4 @@ Icon=glob2
 Terminal=false
 X-MultipleArgs=false
 Type=Application
-Categories=Application;Game;StrategyGame;
+Categories=Game;StrategyGame;

--- a/data/glob2.desktop
+++ b/data/glob2.desktop
@@ -2,6 +2,8 @@
 Version=1.0
 Encoding=UTF-8
 Name=Globulation 2
+GenericName=Real Time Strategy Game
+GenericName[de]=Echtzeit-Strategiespiel
 Comment=An innovative new strategy game
 Exec=glob2
 Icon=glob2
@@ -9,4 +11,3 @@ Terminal=false
 X-MultipleArgs=false
 Type=Application
 Categories=Application;Game;StrategyGame;
-GenericName[en_US]=


### PR DESCRIPTION
I am currently packaging your game for @openSUSE and ran into this error that every distribution seems to patch on their own:

```
invalid-desktopfile /usr/share/applications/glob2.desktop key "GenericName[en_US]" in group "Desktop Entry" is a localized key, but there is no non-localized key "GenericName"
[   56s] .desktop file is not valid, check with desktop-file-validate
```