### PR TITLE
Voicerecorder bug fixes

### DIFF
--- a/src/VoiceRecorder.cpp
+++ b/src/VoiceRecorder.cpp
@@ -415,7 +415,7 @@ VoiceRecorder::~VoiceRecorder()
 		SDL_DestroyMutex(ordersMutex);
 	#endif
 	
-	speex_bits_reset(&bits);
+	speex_bits_destroy(&bits);
 	// destroy the decoder
 	speex_encoder_destroy(speexEncoderState);
 }

--- a/src/VoiceRecorder.cpp
+++ b/src/VoiceRecorder.cpp
@@ -97,7 +97,7 @@ int PaSpeexEncodeCallback( const void *input, void *output, unsigned long frameC
 	
 	const short* inBuffer = reinterpret_cast<const short*>(input);
 	short* buffer = recorder->buffer;
-	for(int i=0; i<frameCount; ++i)
+	for(unsigned long i=0; i<frameCount; ++i)
 		buffer[i] = inBuffer[i];
 	for(int i=frameCount; i<recorder->frameSize; ++i)
 		buffer[i] = 0;

--- a/src/VoiceRecorder.cpp
+++ b/src/VoiceRecorder.cpp
@@ -377,6 +377,7 @@ VoiceRecorder::VoiceRecorder()
 	#ifdef HAVE_PORTAUDIO
 		buffer = new short[frameSize];
 		frameCount=0;
+		stream = nullptr;
 		PaError err = Pa_Initialize();
 		if( err != paNoError )
 			return;
@@ -398,7 +399,9 @@ VoiceRecorder::~VoiceRecorder()
 {
 	recordingNow = false;
 	#ifdef HAVE_PORTAUDIO
-		PaError err = Pa_CloseStream( stream );
+		PaError err = paNoError;
+		if(stream)
+			err = Pa_CloseStream( stream );
 		if( err != paNoError )
 			printf(  "PortAudio error: %s\n", Pa_GetErrorText( err ) );
 		err = Pa_Terminate();

--- a/src/VoiceRecorder.cpp
+++ b/src/VoiceRecorder.cpp
@@ -22,6 +22,7 @@
 #include "VoiceRecorder.h"
 #include <assert.h>
 #include <stdio.h>
+#include <iostream>
 #include "Order.h"
 #include "Utilities.h"
 


### PR DESCRIPTION
Fixes:
* a crash when exiting the game if compiled with PortAudio support and `Pa_OpenDefaultStream()` fails with the error "Device unavailable". When this happens, the stream pointer is not initialized (wild pointer) and then the game crashes in `Pa_CloseStream()`.
* a memory leak (#43). Easily fixed by changing `speex_bits_reset` to `speex_bits_destroy` in the destructor.
* a compilation warning and error.