### PR TITLE
Fix handling of quit shortcut keys in SDL2.

### DIFF
--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -487,7 +487,7 @@ namespace GAGGUI
 					{
 						//Manual integration of cmd+q and alt f4
 #						ifdef USE_OSX
-						if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_META)
+						if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_GUI)
 						{
 							run=false;
 							returnCode=-1;

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -118,7 +118,7 @@ namespace GAGGUI
 				if(event.type == SDL_KEYDOWN)
 				{
 #					ifdef USE_OSX
-					if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_META)
+					if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_GUI)
 					{
 						break;
 					}

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -74,7 +74,7 @@ void FertilityCalculatorDialog::execute()
 			if(event.type == SDL_KEYDOWN)
 			{
 #ifdef USE_OSX
-				if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_META)
+				if(event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_GUI)
 				{
 					break;
 				}

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -435,7 +435,7 @@ void GameGUI::step(void)
 			wasMouseMotion=true;
 		}
 #		ifdef USE_OSX
-		else if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_META)
+		else if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_GUI)
 		{
 			isRunning=false;
 			exitGlobCompletely=true;

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1650,7 +1650,7 @@ void MapEdit::processEvent(SDL_Event& event)
 		doFullQuit=true;
 	}
 #	ifdef USE_OSX
-	else if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_META)
+	else if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_q && SDL_GetModState() & KMOD_GUI)
 	{
 		doFullQuit=true;
 	}

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -71,8 +71,8 @@ void YOGClientGameConnectionDialog::execute()
 			if(event.type == SDL_KEYDOWN)
 			{
 #					ifdef USE_OSX
-				SDLMod modState = SDL_GetModState();
-				if(event.key.keysym.sym == SDLK_q && modState & KMOD_META)
+				SDL_Keymod modState = SDL_GetModState();
+				if(event.key.keysym.sym == SDLK_q && modState & KMOD_GUI)
 				{
 					break;
 				}
@@ -80,7 +80,7 @@ void YOGClientGameConnectionDialog::execute()
 				SDL_GetModState();
 #					endif
 #					ifdef USE_WIN32
-				SDLMod modState = SDL_GetModState();
+				SDL_Keymod modState = SDL_GetModState();
 				if(event.key.keysym.sym == SDLK_F4 && modState & KMOD_ALT)
 				{
 					break;


### PR DESCRIPTION
This was overlooked in the transition from SDL 1.2 to 2.

> SDLMod is now SDL_Keymod and its "META" keys (the "Windows" keys) are now called the "GUI" keys.
-- https://wiki.libsdl.org/MigrationGuide