### PR TITLE
Fix crash in readdir emulation on Windows MSys2.

### DIFF
--- a/libgag/src/win32_dirent.cpp
+++ b/libgag/src/win32_dirent.cpp
@@ -28,7 +28,7 @@
 
 struct DIR
 {
-    long                handle; /* -1 for failed rewind */
+    intptr_t            handle; /* -1 for failed rewind */
     struct _finddata_t  info;
     struct dirent       result; /* d_name null iff first time */
     char                *name;  /* NTBS */


### PR DESCRIPTION
Globulation 2 master~9 (214dfb22) was crashing in ntdll!RtlEnterCriticalSection on MSys2 environment in Windows 10 because the handle passed to readdir was the wrong type. Windows doesn't have a native readdir function, so Glob2 implements it using _findnext64i32. _findnext64i32 expects the handle to be of type intptr_t but it was long instead.

I thought I made a pull request for this fix before but I had pushed the commit but forgot to make a pull request for it.

The type of _findnext64i32 is as follows:
```c++
int _findnext64i32(
   intptr_t handle,
   struct _finddata64i32_t *fileinfo
);
```


To reproduce:
1. Compile Globulation 2 in MSys2.
2. Start Globulation2
3. Click Load Game on main menu.

Actual results:
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ffd9279faad in ntdll!RtlEnterCriticalSection () from C:\WINDOWS\SYSTEM32\ntdll.dll
(gdb) bt
#0  0x00007ffd9279faad in ntdll!RtlEnterCriticalSection ()
   from C:\WINDOWS\SYSTEM32\ntdll.dll
#1  0x00007ffd8fed9b12 in KERNELBASE!FindNextFileW ()
   from C:\WINDOWS\System32\KernelBase.dll
#2  0x00007ffd8fed9988 in KERNELBASE!FindNextFileA ()
   from C:\WINDOWS\System32\KernelBase.dll
#3  0x00007ffd91886daa in msvcrt!_findnext64 ()
   from C:\WINDOWS\System32\msvcrt.dll
#4  0x00007ff6ca182e17 in _findnext64i32 (_FindHandle=<optimized out>,
    _FindData=0x2c011e1b038)
    at C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/stdio/_findnext64i32.c:8
#5  0x00007ff6ca175239 in readdir (dir=0x2c011e1b030)
    at libgag/src/win32_dirent.cpp:108
#6  0x00007ff6ca14d776 in GAGCore::FileManager::addListingForDir (
    this=0x2c0102adf20, realDir="./games", extension="game", dirs=true)
    at libgag/src/FileManager.cpp:489
#7  0x00007ff6ca14d903 in GAGCore::FileManager::initDirectoryListing (
    this=0x2c0102adf20, virtualDir="games", extension="game", dirs=true)
    at libgag/src/FileManager.cpp:549
#8  0x00007ff6ca15c019 in GAGGUI::FileList::generateList (this=0x2c011e1ae80)
    at libgag/src/GUIFileList.cpp:73
#9  0x00007ff6ca00dd0b in Glob2FileList::Glob2FileList (this=0x2c011e1ae80,
    x=20, y=60, w=180, h=400, hAlign=3, vAlign=3, font="standard",
    dir="games", extension="game", recurse=true)
    at src/GUIGlob2FileList.cpp:28
#10 0x00007ff6c9fa32b9 in ChooseMapScreen::ChooseMapScreen (
    this=0xd864df9360,
    directory=0x7ff6ca333b68 <boost::core::fp_nan+20> "games",
    extension=0x7ff6ca333b63 <boost::core::fp_nan+15> "game", recurse=true,
    alternateDirectory=0x7ff6ca333b75 <boost::core::fp_nan+33> "replays",
    alternateExtension=0x7ff6ca333b6e <boost::core::fp_nan+26> "replay",
    alternateRecurse=false) at src/ChooseMapScreen.cpp:43
#11 0x00007ff6c9fb2e97 in Engine::initLoadGame (this=0xd864dfa6f0)
    at src/Engine.cpp:163
#12 0x00007ff6ca007c48 in Glob2::run (this=0xd864dff89f, argc=1,
    argv=0x2c0100ca5a0) at src/Glob2.cpp:329
#13 0x00007ff6ca0080d8 in SDL_main (argc=1, argv=0x2c0100ca5a0)
    at src/Glob2.cpp:439
#14 0x00007ff6ca182166 in main_getcmdline ()
#15 0x00007ff6c9f313ae in __tmainCRTStartup ()
    at C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:329
#16 0x00007ff6c9f314c6 in WinMainCRTStartup ()
    at C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:176
(gdb) frame 5
#5  0x00007ff6ca175239 in readdir (dir=0x2c011e1b030)
    at libgag/src/win32_dirent.cpp:108
108             if(!dir->result.d_name || _findnext(dir->handle, &dir->info) != -1)
(gdb) print dir
$1 = (DIR *) 0x2c011e1b030
(gdb) ptype *dir
type = struct DIR {
    long handle;
    _finddata64i32_t info;
    dirent result;
    char *name;
}
(gdb) q
```