### PR TITLE
Implement resizable GUI

### DIFF
--- a/glob2.vcxproj
+++ b/glob2.vcxproj
@@ -262,6 +262,7 @@
     <ClCompile Include="gnupg\sha1.c" />
     <ClCompile Include="libgag\src\BinaryStream.cpp" />
     <ClCompile Include="libgag\src\CursorManager.cpp" />
+    <ClCompile Include="libgag\src\EventListener.cpp" />
     <ClCompile Include="libgag\src\FileManager.cpp">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug SDL|Win32'">ZLIB_WINAPI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug SDL|x64'">ZLIB_WINAPI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -507,6 +508,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="libgag\include\DX9GraphicContext.h" />
+    <ClInclude Include="libgag\include\EventListener.h" />
     <ClInclude Include="libgag\include\FileManager.h" />
     <ClInclude Include="libgag\include\GAG.h" />
     <ClInclude Include="libgag\include\GAGSys.h" />

--- a/libgag/include/CursorManager.h
+++ b/libgag/include/CursorManager.h
@@ -67,6 +67,7 @@ namespace GAGCore
 		CursorManager();
 		//! Load the cursor sprites
 		void load(void);
+		void reinitTextures(void);
 		//! Select the next type given the mouse position
 		void nextTypeFromMouse(DrawableSurface *ds, int x, int y, bool button);
 		//! Manually set the next type

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -10,9 +10,12 @@ public:
 	EventListener(GraphicContext* gfx);
 	void run();
 	bool isRunning();
+	int poll(SDL_Event* e);
+	static EventListener *instance();
 	~EventListener();
 private:
 	GraphicContext* gfx;
+	static EventListener* el;
 	bool quit, done;
 };
 }

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -54,6 +54,8 @@ private:
 	static EventListener* el;
 	std::atomic<bool> quit, done;
 	std::atomic<int> depth;
+
+	static std::mutex queueMutex; // used when pushing/popping queue.
 };
 }
 #endif //__EVENTLISTENER_H

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -3,12 +3,14 @@
 #include "GraphicContext.h"
 #include <SDL.h>
 #include <deque>
+#include <atomic>
 namespace GAGCore {
 extern std::deque<SDL_Event> events;
 class EventListener {
 public:
 	EventListener(GraphicContext* gfx);
 	void run();
+	void stop();
 	bool isRunning();
 	int poll(SDL_Event* e);
 	static EventListener *instance();
@@ -16,7 +18,7 @@ public:
 private:
 	GraphicContext* gfx;
 	static EventListener* el;
-	bool quit, done;
+	std::atomic<bool> quit, done;
 };
 }
 #endif //__EVENTLISTENER_H

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -40,6 +40,7 @@ public:
 	static std::condition_variable startedCond;
 	static std::mutex doneMutex;
 	static std::condition_variable doneCond;
+	static std::mutex renderMutex;
 	void setPainter(std::function<void()> f);
 	void paint();
 private:

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -41,10 +41,11 @@ public:
 	static std::condition_variable startedCond;
 	static std::mutex doneMutex;
 	static std::condition_variable doneCond;
-	static std::mutex renderMutex;
+	static std::recursive_mutex renderMutex;
 	void setPainter(std::function<void()> f);
 	void addPainter(const std::string& name, std::function<void()> f);
 	void removePainter(const std::string& name);
+	static void ensureContext();
 	void paint();
 private:
 	std::function<void()> painter;

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -1,0 +1,15 @@
+#include "GraphicContext.h"
+#include <SDL.h>
+#include <deque>
+namespace GAGCore {
+extern std::deque<SDL_Event> events;
+class EventListener {
+public:
+	EventListener(GraphicContext* gfx);
+	void run();
+	~EventListener();
+private:
+	GraphicContext* gfx;
+	bool quit, done;
+};
+}

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -26,6 +26,11 @@
 #include <condition_variable>
 #include <functional>
 #include <map>
+
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+#define WINDOWS_OR_MINGW 1
+#endif
+
 namespace GAGCore {
 extern std::deque<SDL_Event> events;
 class EventListener {

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <functional>
+#include <map>
 namespace GAGCore {
 extern std::deque<SDL_Event> events;
 class EventListener {
@@ -42,9 +43,12 @@ public:
 	static std::condition_variable doneCond;
 	static std::mutex renderMutex;
 	void setPainter(std::function<void()> f);
+	void addPainter(const std::string& name, std::function<void()> f);
+	void removePainter(const std::string& name);
 	void paint();
 private:
 	std::function<void()> painter;
+	std::multimap<const std::string, std::function<void()> > painters;
 	GraphicContext* gfx;
 	static EventListener* el;
 	std::atomic<bool> quit, done;

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -52,6 +52,7 @@ private:
 	GraphicContext* gfx;
 	static EventListener* el;
 	std::atomic<bool> quit, done;
+	std::atomic<int> depth;
 };
 }
 #endif //__EVENTLISTENER_H

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
+#include <functional>
 namespace GAGCore {
 extern std::deque<SDL_Event> events;
 class EventListener {
@@ -39,7 +40,10 @@ public:
 	static std::condition_variable startedCond;
 	static std::mutex doneMutex;
 	static std::condition_variable doneCond;
+	void setPainter(std::function<void()> f);
+	void paint();
 private:
+	std::function<void()> painter;
 	GraphicContext* gfx;
 	static EventListener* el;
 	std::atomic<bool> quit, done;

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -39,6 +39,7 @@ public:
 	void run();
 	void stop();
 	bool isRunning();
+	bool isResizing();
 	int poll(SDL_Event* e);
 	static EventListener *instance();
 	~EventListener();

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -20,7 +20,7 @@
 #define __EVENTLISTENER_H
 #include "GraphicContext.h"
 #include <SDL.h>
-#include <deque>
+#include <queue>
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
@@ -32,7 +32,7 @@
 #endif
 
 namespace GAGCore {
-extern std::deque<SDL_Event> events;
+extern std::queue<SDL_Event> events;
 class EventListener {
 public:
 	EventListener(GraphicContext* gfx);

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -1,3 +1,21 @@
+/*
+  Copyright (C) 2022 Nathan Mills
+  for any question or comment contact us at <the dot true dot nathan dot mills at gmail dot com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 #ifndef __EVENTLISTENER_H
 #define __EVENTLISTENER_H
 #include "GraphicContext.h"

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -1,3 +1,5 @@
+#ifndef __EVENTLISTENER_H
+#define __EVENTLISTENER_H
 #include "GraphicContext.h"
 #include <SDL.h>
 #include <deque>
@@ -7,9 +9,11 @@ class EventListener {
 public:
 	EventListener(GraphicContext* gfx);
 	void run();
+	bool isRunning();
 	~EventListener();
 private:
 	GraphicContext* gfx;
 	bool quit, done;
 };
 }
+#endif //__EVENTLISTENER_H

--- a/libgag/include/EventListener.h
+++ b/libgag/include/EventListener.h
@@ -4,6 +4,8 @@
 #include <SDL.h>
 #include <deque>
 #include <atomic>
+#include <mutex>
+#include <condition_variable>
 namespace GAGCore {
 extern std::deque<SDL_Event> events;
 class EventListener {
@@ -15,6 +17,10 @@ public:
 	int poll(SDL_Event* e);
 	static EventListener *instance();
 	~EventListener();
+	static std::mutex startMutex;
+	static std::condition_variable startedCond;
+	static std::mutex doneMutex;
+	static std::condition_variable doneCond;
 private:
 	GraphicContext* gfx;
 	static EventListener* el;

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -318,6 +318,7 @@ namespace GAGCore
 	protected:
 		//! the minimum acceptable resolution
 		int minW, minH;
+		int prevW, prevH;
 		SDL_Window *window = nullptr;
 		SDL_GLContext context = nullptr;
 		friend class DrawableSurface;
@@ -335,6 +336,9 @@ namespace GAGCore
 		// modifiers
 		virtual bool setRes(int w, int h, Uint32 flags);
 		virtual void setRes(int w, int h) { setRes(w, h, optionFlags); }
+		virtual SDL_Rect getRes();
+		virtual bool resChanged();
+		virtual void createGLContext();
 		virtual void setClipRect(int x, int y, int w, int h);
 		virtual void setClipRect(void);
 		virtual void nextFrame(void);

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -156,6 +156,7 @@ namespace GAGCore
 	protected:
 		friend struct Color;
 		friend class GraphicContext;
+		friend class Sprite;
 		//! the underlying software SDL surface
 		SDL_Surface *sdlsurface;
 		//! The clipping rect, we do not draw outside it
@@ -447,6 +448,8 @@ namespace GAGCore
 		
 		//! Load a sprite from the file, return true if any frame have been loaded
 		bool load(const std::string filename);
+
+		void reinit();
 	
 		//! Set the (r,g,b) color to a sprite's base color
 		virtual void setBaseColor(Uint8 r, Uint8 g, Uint8 b) { actColor = Color(r, g, b); }

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -336,6 +336,7 @@ namespace GAGCore
 		// modifiers
 		virtual bool setRes(int w, int h, Uint32 flags);
 		virtual void setRes(int w, int h) { setRes(w, h, optionFlags); }
+		virtual SDL_Surface *getOrCreateSurface(int w, int h, Uint32 flags);
 		virtual SDL_Rect getRes();
 		virtual bool resChanged();
 		virtual void createGLContext();

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -339,6 +339,8 @@ namespace GAGCore
 		virtual SDL_Rect getRes();
 		virtual bool resChanged();
 		virtual void createGLContext();
+		virtual void unsetContext();
+		void resetMatrices();
 		virtual void setClipRect(int x, int y, int w, int h);
 		virtual void setClipRect(void);
 		virtual void nextFrame(void);

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -328,6 +328,7 @@ namespace GAGCore
 		std::string windowTitle;
 		std::string appIcon;
 		int resizeTimer;
+		Sint64 framesDrawn, frameStartResize, frameStopResize;
 		
 	public:
 		//! Constructor. Create a new window of size (w,h). If useGPU is true, use GPU for accelerated 2D (OpenGL or DX)
@@ -345,6 +346,7 @@ namespace GAGCore
 		virtual void unsetContext();
 		static GraphicContext* instance();
 		void resetMatrices();
+		bool isResizing();
 		virtual void setClipRect(int x, int y, int w, int h);
 		virtual void setClipRect(void);
 		virtual void nextFrame(void);

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -326,6 +326,7 @@ namespace GAGCore
 		Uint32 optionFlags;
 		std::string windowTitle;
 		std::string appIcon;
+		int resizeTimer;
 		
 	public:
 		//! Constructor. Create a new window of size (w,h). If useGPU is true, use GPU for accelerated 2D (OpenGL or DX)

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -340,6 +340,7 @@ namespace GAGCore
 		virtual bool resChanged();
 		virtual void createGLContext();
 		virtual void unsetContext();
+		static GraphicContext* instance();
 		void resetMatrices();
 		virtual void setClipRect(int x, int y, int w, int h);
 		virtual void setClipRect(void);

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -319,6 +319,7 @@ namespace GAGCore
 		//! the minimum acceptable resolution
 		int minW, minH;
 		SDL_Window *window = nullptr;
+		SDL_GLContext context = nullptr;
 		friend class DrawableSurface;
 		//! option flags
 		Uint32 optionFlags;

--- a/libgag/src/CursorManager.cpp
+++ b/libgag/src/CursorManager.cpp
@@ -46,6 +46,14 @@ namespace GAGCore
 		cursors.push_back(Toolkit::getSprite("data/gfx/cursor/mark"));
 		setDefaultColor();
 	}
+
+	void CursorManager::reinitTextures(void)
+	{
+		for (Sprite *cursor : cursors)
+		{
+			cursor->reinit();
+		}
+	}
 	
 	void CursorManager::nextTypeFromMouse(DrawableSurface *ds, int x, int y, bool button)
 	{

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -9,12 +9,15 @@ EventListener::EventListener(GraphicContext* gfx)
 	done = false;
 	quit = false;
 }
-EventListener::~EventListener()
+void EventListener::stop()
 {
 	quit = true;
 	while (!done) {
 		SDL_Delay(100);
 	}
+}
+EventListener::~EventListener()
+{
 }
 void EventListener::run()
 {

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -1,3 +1,21 @@
+/*
+  Copyright (C) 2022 Nathan Mills
+  for any question or comment contact us at <the dot true dot nathan dot mills at gmail dot com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
 #include "EventListener.h"
 namespace GAGCore {
 std::deque<SDL_Event> events = std::deque<SDL_Event>();

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -2,18 +2,23 @@
 namespace GAGCore {
 std::deque<SDL_Event> events = std::deque<SDL_Event>();
 EventListener* EventListener::el = nullptr;
+std::mutex EventListener::startMutex;
+std::condition_variable EventListener::startedCond;
+std::mutex EventListener::doneMutex;
+std::condition_variable EventListener::doneCond;
 EventListener::EventListener(GraphicContext* gfx)
 {
 	this->gfx = gfx;
 	el = this;
 	done = false;
-	quit = false;
+	quit = true;
 }
 void EventListener::stop()
 {
 	quit = true;
+	std::unique_lock lock(doneMutex);
 	while (!done) {
-		SDL_Delay(100);
+		doneCond.wait(lock);
 	}
 }
 EventListener::~EventListener()
@@ -21,15 +26,27 @@ EventListener::~EventListener()
 }
 void EventListener::run()
 {
+	{
+		std::unique_lock lock(startMutex);
+		quit = false;
+		startedCond.notify_one();
+	}
 	while (!quit)
 	{
 		SDL_Event event;
 		while (SDL_PollEvent(&event))
 		{
+			if (event.type == SDL_QUIT) {
+				quit = true;
+			}
 			events.push_back(event);
 		}
 	}
-	done = true;
+	{
+		std::unique_lock lock(doneMutex);
+		done = true;
+		doneCond.notify_one();
+	}
 }
 int EventListener::poll(SDL_Event* e)
 {

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -25,6 +25,7 @@ std::mutex EventListener::startMutex;
 std::condition_variable EventListener::startedCond;
 std::mutex EventListener::doneMutex;
 std::condition_variable EventListener::doneCond;
+std::mutex EventListener::renderMutex;
 
 #define SIZE_MOVE_TIMER_ID 1
 #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
@@ -52,12 +53,15 @@ EventListener::~EventListener()
 }
 void EventListener::setPainter(std::function<void()> f)
 {
+	std::unique_lock<std::mutex> lock(renderMutex);
 	painter = f;
 }
 void EventListener::paint()
 {
 	if (painter)
 	{
+		std::unique_lock<std::mutex> lock(renderMutex);
+		gfx->createGLContext();
 		painter();
 		gfx->nextFrame();
 	}

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -28,7 +28,7 @@
   The logic thread is started in Glob2::run.
 */
 namespace GAGCore {
-std::deque<SDL_Event> events = std::deque<SDL_Event>();
+std::queue<SDL_Event> events = std::queue<SDL_Event>();
 std::mutex EventListener::queueMutex;
 EventListener* EventListener::el = nullptr;
 std::mutex EventListener::startMutex;
@@ -201,7 +201,7 @@ void EventListener::run()
 #endif
 			{
 				std::lock_guard<std::mutex> lock(queueMutex);
-				events.push_back(event);
+				events.push(event);
 			}
 		}
 	}
@@ -220,7 +220,7 @@ int EventListener::poll(SDL_Event* e)
 	std::lock_guard<std::mutex> lock(queueMutex);
 	if (events.size()) {
 		*e = events.front();
-		events.pop_front();
+		events.pop();
 		return 1;
 	}
 	return 0;

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -1,9 +1,11 @@
 #include "EventListener.h"
 namespace GAGCore {
 std::deque<SDL_Event> events = std::deque<SDL_Event>();
+EventListener* EventListener::el = nullptr;
 EventListener::EventListener(GraphicContext* gfx)
 {
 	this->gfx = gfx;
+	el = this;
 	done = false;
 	quit = false;
 }
@@ -25,6 +27,19 @@ void EventListener::run()
 		}
 	}
 	done = true;
+}
+int EventListener::poll(SDL_Event* e)
+{
+	if (events.size()) {
+		*e = events.front();
+		events.pop_front();
+		return 1;
+	}
+	return 0;
+}
+EventListener *EventListener::instance()
+{
+	return el;
 }
 bool EventListener::isRunning()
 {

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "EventListener.h"
+#include <SDL_syswm.h>
 namespace GAGCore {
 std::deque<SDL_Event> events = std::deque<SDL_Event>();
 EventListener* EventListener::el = nullptr;
@@ -24,7 +25,14 @@ std::mutex EventListener::startMutex;
 std::condition_variable EventListener::startedCond;
 std::mutex EventListener::doneMutex;
 std::condition_variable EventListener::doneCond;
+
+#define SIZE_MOVE_TIMER_ID 1
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+#define WINDOWS_OR_MINGW 1
+#endif
+
 EventListener::EventListener(GraphicContext* gfx)
+: painter(nullptr)
 {
 	this->gfx = gfx;
 	el = this;
@@ -42,6 +50,45 @@ void EventListener::stop()
 EventListener::~EventListener()
 {
 }
+void EventListener::setPainter(std::function<void()> f)
+{
+	painter = f;
+}
+void EventListener::paint()
+{
+	if (painter)
+	{
+		painter();
+		gfx->nextFrame();
+	}
+}
+//https://stackoverflow.com/a/51597338/8890345
+#ifdef WINDOWS_OR_MINGW
+bool sizeMoveTimerRunning = false;
+int eventWatch(void* self, SDL_Event* event) {
+	if (event->type == SDL_SYSWMEVENT)
+	{
+		const auto &winMessage = event->syswm.msg->msg.win;
+		if (winMessage.msg == WM_ENTERSIZEMOVE)
+		{
+			// the user started dragging, so create the timer (with the minimum timeout)
+			// if you have vsync enabled, then this shouldn't render unnecessarily
+			sizeMoveTimerRunning = SetTimer(GetActiveWindow(), SIZE_MOVE_TIMER_ID, USER_TIMER_MINIMUM, nullptr);
+		}
+		else if (winMessage.msg == WM_TIMER)
+		{
+			if (winMessage.wParam == SIZE_MOVE_TIMER_ID)
+			{
+				// call your render function
+				EventListener *el = reinterpret_cast<EventListener*>(self);
+				if (el)
+					el->paint();
+			}
+		}
+	}
+	return 0;
+}
+#endif
 void EventListener::run()
 {
 	{
@@ -49,6 +96,10 @@ void EventListener::run()
 		quit = false;
 		startedCond.notify_one();
 	}
+#ifdef WINDOWS_OR_MINGW
+	SDL_AddEventWatch(eventWatch, this); // register the event watch function
+	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE); // we need the native Windows events, so we can listen to WM_ENTERSIZEMOVE and WM_TIMER
+#endif
 	while (!quit)
 	{
 		SDL_Event event;
@@ -57,6 +108,27 @@ void EventListener::run()
 			if (event.type == SDL_QUIT) {
 				quit = true;
 			}
+			if (event.type == SDL_WINDOWEVENT &&
+				(event.window.event == SDL_WINDOWEVENT_RESIZED ||
+				 event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED))
+			{
+				/*glClearColor (0.0f, 0.0f, 0.0f, 1.0f );
+				glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+				SDL_GL_SwapWindow(_gc->window);*/
+				/*if (painter)
+				{
+					painter();
+					gfx->nextFrame();
+				}*/
+			}
+#ifdef WINDOWS_OR_MINGW
+			if (sizeMoveTimerRunning)
+			{
+				// modal drag/size loop ended, so kill the timer
+				KillTimer(GetActiveWindow(), SIZE_MOVE_TIMER_ID);
+				sizeMoveTimerRunning = false;
+			}
+#endif
 			events.push_back(event);
 		}
 	}

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -26,4 +26,8 @@ void EventListener::run()
 	}
 	done = true;
 }
+bool EventListener::isRunning()
+{
+	return !quit;
+}
 }

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -30,9 +30,6 @@ std::condition_variable EventListener::doneCond;
 std::recursive_mutex EventListener::renderMutex;
 
 #define SIZE_MOVE_TIMER_ID 1
-#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
-#define WINDOWS_OR_MINGW 1
-#endif
 
 // The depth variable is used to return early when indirect recursion happens
 EventListener::EventListener(GraphicContext* gfx)

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -34,7 +34,7 @@ EventListener::EventListener(GraphicContext* gfx)
 void EventListener::stop()
 {
 	quit = true;
-	std::unique_lock lock(doneMutex);
+	std::unique_lock<std::mutex> lock(doneMutex);
 	while (!done) {
 		doneCond.wait(lock);
 	}
@@ -45,7 +45,7 @@ EventListener::~EventListener()
 void EventListener::run()
 {
 	{
-		std::unique_lock lock(startMutex);
+		std::unique_lock<std::mutex> lock(startMutex);
 		quit = false;
 		startedCond.notify_one();
 	}
@@ -61,7 +61,7 @@ void EventListener::run()
 		}
 	}
 	{
-		std::unique_lock lock(doneMutex);
+		std::unique_lock<std::mutex> lock(doneMutex);
 		done = true;
 		doneCond.notify_one();
 	}

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -1,0 +1,29 @@
+#include "EventListener.h"
+namespace GAGCore {
+std::deque<SDL_Event> events = std::deque<SDL_Event>();
+EventListener::EventListener(GraphicContext* gfx)
+{
+	this->gfx = gfx;
+	done = false;
+	quit = false;
+}
+EventListener::~EventListener()
+{
+	quit = true;
+	while (!done) {
+		SDL_Delay(100);
+	}
+}
+void EventListener::run()
+{
+	while (!quit)
+	{
+		SDL_Event event;
+		while (SDL_PollEvent(&event))
+		{
+			events.push_back(event);
+		}
+	}
+	done = true;
+}
+}

--- a/libgag/src/EventListener.cpp
+++ b/libgag/src/EventListener.cpp
@@ -129,8 +129,8 @@ void EventListener::paint()
 //! Handle user resizing the game window on Microsoft Windows.
 // TODO: Handle window resizing on macOS
 //https://stackoverflow.com/a/51597338/8890345
-#ifdef WINDOWS_OR_MINGW
 bool sizeMoveTimerRunning = false;
+#ifdef WINDOWS_OR_MINGW
 int eventWatch(void* self, SDL_Event* event) {
 	if (event->type == SDL_SYSWMEVENT)
 	{
@@ -156,6 +156,10 @@ int eventWatch(void* self, SDL_Event* event) {
 }
 #endif
 
+bool EventListener::isResizing()
+{
+	return sizeMoveTimerRunning;
+}
 /** Listens for events and adds them to a queue.
  *  Call EventListener::poll to get an event from the queue.
  */

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -415,6 +415,7 @@ namespace GAGGUI
 	
 	Screen::~Screen()
 	{
+		EventListener::instance()->removePainter("Screen");
 		for (std::set<Widget *>::iterator it=widgets.begin(); it!=widgets.end(); ++it)
 		{
 			delete (*it);
@@ -427,6 +428,7 @@ namespace GAGGUI
 		Sint32 frameWaitTime;
 		
 		this->gfx = gfx;
+		EventListener::instance()->addPainter("Screen", std::bind(&Screen::dispatchPaint, this));
 	
 		// init widgets
 		dispatchInit();

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -530,10 +530,7 @@ namespace GAGGUI
 				dispatchEvents(&windowEvent);
 				
 			// draw
-			{
-				std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
-				dispatchPaint();
-			}
+			dispatchPaint();
 	
 			// wait timer
 			frameWaitTime=SDL_GetTicks()-frameStartTime;
@@ -680,6 +677,8 @@ namespace GAGGUI
 	void Screen::dispatchPaint(void)
 	{
 		assert(gfx);
+		std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
+		EventListener::ensureContext();
 		gfx->setClipRect();
 		paint();
 		for (std::set<Widget *>::iterator it=widgets.begin(); it!=widgets.end(); ++it)

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -516,6 +516,12 @@ namespace GAGGUI
 					break;
 				}
 			}
+			GraphicContext* gfxCasted = dynamic_cast<GraphicContext*>(gfx);
+			if (gfxCasted && gfxCasted->resChanged()) {
+				SDL_Rect r = gfxCasted->getRes();
+				gfx->setRes(r.w, r.h);
+				onAction(NULL, SCREEN_RESIZED, gfx->getW(), gfx->getH());
+			}
 			if (hadLastMouseMotion)
 				dispatchEvents(&lastMouseMotion);
 			if (wasWindowEvent)

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -530,7 +530,10 @@ namespace GAGGUI
 				dispatchEvents(&windowEvent);
 				
 			// draw
-			dispatchPaint();
+			{
+				std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
+				dispatchPaint();
+			}
 	
 			// wait timer
 			frameWaitTime=SDL_GetTicks()-frameStartTime;

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -516,9 +516,9 @@ namespace GAGGUI
 					break;
 				}
 			}
-			GraphicContext* gfxCasted = dynamic_cast<GraphicContext*>(gfx);
-			if (gfxCasted && gfxCasted->resChanged()) {
-				SDL_Rect r = gfxCasted->getRes();
+			GraphicContext* gfx = GraphicContext::instance();
+			if (gfx->resChanged()) {
+				SDL_Rect r = gfx->getRes();
 				gfx->setRes(r.w, r.h);
 				onAction(NULL, SCREEN_RESIZED, gfx->getW(), gfx->getH());
 			}

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -470,12 +470,13 @@ namespace GAGGUI
 					{
 						windowEvent=event;
 						wasWindowEvent=true;
-					}
-					break;
-					case SDL_WINDOWEVENT_RESIZED:
-					{
-						// FIXME: window resize is broken
-						// gfx->setRes(event.window.data1, event.window.data2);
+						if (event.window.event == SDL_WINDOWEVENT_RESIZED)
+						{
+
+							// FIXME: window resize is broken
+							gfx->setRes(event.window.data1, event.window.data2);
+							onAction(NULL, SCREEN_RESIZED, gfx->getW(), gfx->getH());
+						}
 					}
 					break;
 					case SDL_WINDOWEVENT_SIZE_CHANGED:

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <GraphicContext.h>
 #include <cmath>
+#include <EventListener.h>
 
 #include <Toolkit.h>
 
@@ -449,7 +450,8 @@ namespace GAGGUI
 			SDL_Event lastMouseMotion, windowEvent, event;
 			bool hadLastMouseMotion=false;
 			bool wasWindowEvent=false;
-			while (SDL_PollEvent(&event))
+			EventListener* el = EventListener::instance();
+			while (el->poll(&event))
 			{
 				switch (event.type)
 				{

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -24,6 +24,7 @@
 #include <Toolkit.h>
 #include <GraphicContext.h>
 #include <algorithm>
+#include <EventListener.h>
 
 using namespace GAGCore;
 
@@ -110,7 +111,8 @@ namespace GAGGUI
 		while(mbs->endValue<0)
 		{
 			Sint32 time = SDL_GetTicks();
-			while (SDL_PollEvent(&event))
+			EventListener* el = EventListener::instance();
+			while (el->poll(&event))
 			{
 				if (event.type==SDL_QUIT)
 					break;

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -2262,6 +2262,10 @@ namespace GAGCore
 			{
 				int mx, my;
 				unsigned b = SDL_GetMouseState(&mx, &my);
+				if (resizeTimer) {
+					std::lock_guard<std::recursive_mutex> lock(EventListener::renderMutex);
+					cursorManager.reinitTextures();
+				}
 				cursorManager.nextTypeFromMouse(this, mx, my, b != 0);
 				setClipRect();
 				cursorManager.draw(this, mx, my);

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -349,6 +349,8 @@ namespace GAGCore
 		#ifdef HAVE_OPENGL
 		if (_gc->optionFlags & GraphicContext::USEGPU)
 		{
+			std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
+			EventListener::ensureContext();
 			glState.setTexture(texture);
 
 			void *pixelsPtr;
@@ -2061,7 +2063,7 @@ namespace GAGCore
 	}
 
 	SDL_Surface* GraphicContext::getOrCreateSurface(int w, int h, Uint32 flags) {
-		std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
+		std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
 		if (flags & USEGPU)
 		{
 			if (sdlsurface)

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -1674,8 +1674,10 @@ namespace GAGCore
 		#ifdef HAVE_OPENGL
 		if (_gc->optionFlags & GraphicContext::USEGPU)
 		{
+			if (!resizeTimer && EventListener::instance()->isResizing())
+				resizeTimer++;
 			// upload
-			if (surface->dirty || EventListener::instance()->isResizing())
+			if (surface->dirty || resizeTimer)
 				surface->uploadToTexture();
 
 			// state change
@@ -1967,7 +1969,8 @@ namespace GAGCore
 
 	GraphicContext::GraphicContext(int w, int h, Uint32 flags, const std::string title, const std::string icon):
 		windowTitle(title),
-		appIcon(icon)
+		appIcon(icon),
+		resizeTimer(0)
 	{
 		// some assert on the universe's structure
 		assert(sizeof(Color) == 4);
@@ -2275,6 +2278,8 @@ namespace GAGCore
 			{
 				SDL_UpdateWindowSurface(window);
 			}
+			if (resizeTimer)
+				resizeTimer--;
 		}
 	}
 

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -1920,6 +1920,7 @@ namespace GAGCore
 	{
 		minW = w;
 		minH = h;
+		SDL_SetWindowMinimumSize(window, minW, minH);
 	}
 
 	VideoModes GraphicContext::listVideoModes() const

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -2006,6 +2006,32 @@ namespace GAGCore
 			fprintf(stderr, "Toolkit : Graphic Context destroyed\n");
 	}
 
+	void GraphicContext::createGLContext()
+	{
+		// enable GL context
+		if (optionFlags & USEGPU)
+		{
+			if (context)
+				SDL_GL_DeleteContext(context);
+			context = SDL_GL_CreateContext(window);
+			SDL_GL_MakeCurrent(window, context);
+		}
+	}
+	bool GraphicContext::resChanged()
+	{
+		int w, h;
+		SDL_GetWindowSize(window, &w, &h);
+		return prevW != w || prevH != h;
+	}
+	SDL_Rect GraphicContext::getRes()
+	{
+		int w, h;
+		SDL_Rect r;
+		SDL_GetWindowSize(window, &w, &h);
+		r = {0, 0, w, h};
+		return r;
+	}
+
 	bool GraphicContext::setRes(int w, int h, Uint32 flags)
 	{
 		// check dimension
@@ -2021,6 +2047,9 @@ namespace GAGCore
 				fprintf(stderr, "Toolkit : Screen height %d is too small, set to min %d\n", h, minH);
 			h = minH;
 		}
+
+		prevW = w;
+		prevH = h;
 
 		// set flags
 		optionFlags = flags;

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -1675,7 +1675,7 @@ namespace GAGCore
 		if (_gc->optionFlags & GraphicContext::USEGPU)
 		{
 			// upload
-			if (surface->dirty)
+			if (surface->dirty || EventListener::instance()->isResizing())
 				surface->uploadToTexture();
 
 			// state change

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -21,6 +21,7 @@
 #include <Toolkit.h>
 #include <FileManager.h>
 #include <SupportFunctions.h>
+#include "EventListener.h"
 #include <assert.h>
 #include <string>
 #include <sstream>
@@ -2060,6 +2061,7 @@ namespace GAGCore
 	}
 
 	SDL_Surface* GraphicContext::getOrCreateSurface(int w, int h, Uint32 flags) {
+		std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
 		if (flags & USEGPU)
 		{
 			if (sdlsurface)

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -2076,6 +2076,7 @@ namespace GAGCore
 
 	bool GraphicContext::setRes(int w, int h, Uint32 flags)
 	{
+		static bool isLoading = true;
 		// check dimension
 		if (minW && (w < minW))
 		{
@@ -2099,8 +2100,14 @@ namespace GAGCore
 		if (flags & FULLSCREEN)
 			sdlFlags |= SDL_WINDOW_FULLSCREEN;
 		// FIXME: window resize is broken
-		if (flags & RESIZABLE)
+		if (flags & RESIZABLE && !isLoading)
+		{
 			sdlFlags |= SDL_WINDOW_RESIZABLE;
+		}
+		else
+		{
+			isLoading = false;
+		}
 		#ifdef HAVE_OPENGL
 		if (flags & USEGPU)
 		{
@@ -2115,6 +2122,7 @@ namespace GAGCore
 		// if window exists, resize it
 		if (window) {
 			SDL_SetWindowSize(window, w, h);
+			SDL_SetWindowResizable(window, SDL_TRUE);
 			getOrCreateSurface(w, h, flags);
 #ifdef HAVE_OPENGL
 			if (flags & USEGPU)

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -2007,8 +2007,12 @@ namespace GAGCore
 			fprintf(stderr, "Toolkit : Graphic Context destroyed\n");
 	}
 
-	std::mutex m;
+	GraphicContext* GraphicContext::instance()
+	{
+		return _gc;
+	}
 
+	std::mutex m;
 	void GraphicContext::createGLContext()
 	{
 		// enable GL context

--- a/libgag/src/SConscript
+++ b/libgag/src/SConscript
@@ -7,7 +7,8 @@ GUITextArea.cpp     GUIText.cpp           GUITextInput.cpp  GUIImage.cpp
 GUIProgressBar.cpp  KeyPress.cpp          Sprite.cpp        StreamBackend.cpp
 Stream.cpp          StreamFilter.cpp      StringTable.cpp   SupportFunctions.cpp
 TextStream.cpp      Toolkit.cpp           TrueTypeFont.cpp  win32_dirent.cpp
-GUITabScreen.cpp    GUITabScreenWindow.cpp  TextSort.cpp    GUICheckList.cpp  
+GUITabScreen.cpp    GUITabScreenWindow.cpp  TextSort.cpp    GUICheckList.cpp
+EventListener.cpp
 """)
 
 libgag_just_server = Split("""

--- a/libgag/src/Sprite.cpp
+++ b/libgag/src/Sprite.cpp
@@ -81,8 +81,15 @@ namespace GAGCore
 		}
 		for (RotatedImage* turned : rotated)
 		{
-			if (turned && turned->orig)
-				turned->orig->uploadToTexture();
+			if (turned)
+			{
+				if (turned->orig)
+					turned->orig->uploadToTexture();
+				for (auto& pair : turned->rotationMap)
+				{
+					pair.second->uploadToTexture();
+				}
+			}
 		}
 	}
 	

--- a/libgag/src/Sprite.cpp
+++ b/libgag/src/Sprite.cpp
@@ -70,6 +70,21 @@ namespace GAGCore
 		
 		return getFrameCount() > 0;
 	}
+
+	void Sprite::reinit()
+	{
+		
+		for (DrawableSurface* image : images)
+		{
+			if (image)
+				image->uploadToTexture();
+		}
+		for (RotatedImage* turned : rotated)
+		{
+			if (turned && turned->orig)
+				turned->orig->uploadToTexture();
+		}
+	}
 	
 	DrawableSurface *Sprite::getRotatedSurface(int index)
 	{

--- a/libgag/src/Toolkit.cpp
+++ b/libgag/src/Toolkit.cpp
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <iostream>
 #include "TrueTypeFont.h"
+#include "EventListener.h"
 
 #ifndef YOG_SERVER_ONLY
 #include <GraphicContext.h>
@@ -77,6 +78,13 @@ namespace GAGCore
 		}
 		
 		#ifndef YOG_SERVER_ONLY
+		EventListener *el = EventListener::instance();
+		if (el)
+		{
+			el->stop();
+			delete el;
+			el = NULL;
+		}
 		if (gc)
 		{
 			delete gc;

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -35,6 +35,7 @@
 #include "GameGUILoadSave.h"
 #include "StreamBackend.h"
 #include "ReplayWriter.h"
+#include "EventListener.h"
 
 EndGameStat::EndGameStat(int x, int y, int w, int h, Uint32 hAlign, Uint32 vAlign, Game *game)
 {
@@ -567,7 +568,8 @@ void EndGameScreen::saveReplay(const char *dir, const char *ext)
 	while(loadSaveScreen->endValue<0)
 	{
 		int time = SDL_GetTicks();
-		while (SDL_PollEvent(&event))
+		EventListener *el = EventListener::instance();
+		while (el->poll(&event))
 		{
 			loadSaveScreen->translateAndProcessEvent(&event);
 		}

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -507,13 +507,13 @@ int Engine::run(void)
 				if (nextGuiStep == 0)
 				{
 					// we draw
-					static bool isPainterSet = false;
-					if (!isPainterSet)
+					if (!gui.isRegistered)
 					{
+						std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
 						EventListener::instance()->addPainter("GameGUI", std::bind(&GameGUI::drawAll, &gui, gui.localTeamNo));
-						isPainterSet = true;
+						gui.isRegistered = true;
 					}
-					std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
+					std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
 					globalContainer->gfx->createGLContext();
 					gui.drawAll(gui.localTeamNo);
 					globalContainer->gfx->nextFrame();

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -507,6 +507,14 @@ int Engine::run(void)
 				if (nextGuiStep == 0)
 				{
 					// we draw
+					static bool isPainterSet = false;
+					if (!isPainterSet)
+					{
+						EventListener::instance()->setPainter(std::bind(GameGUI::drawAll, &gui, gui.localTeamNo));
+						isPainterSet = true;
+					}
+					std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);
+					globalContainer->gfx->createGLContext();
 					gui.drawAll(gui.localTeamNo);
 					globalContainer->gfx->nextFrame();
 				}

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -510,7 +510,7 @@ int Engine::run(void)
 					static bool isPainterSet = false;
 					if (!isPainterSet)
 					{
-						EventListener::instance()->setPainter(std::bind(GameGUI::drawAll, &gui, gui.localTeamNo));
+						EventListener::instance()->addPainter("GameGUI", std::bind(&GameGUI::drawAll, &gui, gui.localTeamNo));
 						isPainterSet = true;
 					}
 					std::unique_lock<std::mutex> lock(EventListener::instance()->renderMutex);

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include "StringTable.h"
 #include "Toolkit.h"
+#include "EventListener.h"
 
 using namespace GAGCore;
 using namespace GAGGUI;
@@ -66,7 +67,8 @@ void FertilityCalculatorDialog::execute()
 	while(endValue<0)
 	{
 		Sint32 time = SDL_GetTicks();
-		while (SDL_PollEvent(&event))
+		EventListener *el = EventListener::instance();
+		while (el->poll(&event))
 		{
 			if (event.type==SDL_QUIT)
 				break;

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -1117,26 +1117,26 @@ void GameGUI::processEvent(SDL_Event *event)
 	else if (event->type==SDL_WINDOWEVENT)
 	{
 		handleActivation(event->window.data1, event->window.data2);
+		if (event->window.event == SDL_WINDOWEVENT_RESIZED || event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+		{
+			// FIXME: window resize is broken
+			int newW=event->window.data1;
+			int newH=event->window.data2;
+			newW&=(~(0x1F));
+			newH&=(~(0x1F));
+			if (newW<640)
+				newW=640;
+			if (newH<480)
+				newH=480;
+			printf("New size : %dx%d\n", newW, newH);
+			globalContainer->gfx->setRes(newW, newH);
+		}
 	}
 	else if (event->type==SDL_QUIT)
 	{
 		exitGlobCompletely=true;
 		orderQueue.push_back(shared_ptr<Order>(new PlayerQuitsGameOrder(localPlayer)));
 		flushOutgoingAndExit=true;
-	}
-	else if (event->type==SDL_WINDOWEVENT_RESIZED)
-	{
-		// FIXME: window resize is broken
-		/*int newW=event->window.data1;
-		int newH=event->window.data2;
-		newW&=(~(0x1F));
-		newH&=(~(0x1F));
-		if (newW<640)
-			newW=640;
-		if (newH<480)
-			newH=480;
-		printf("New size : %dx%d\n", newW, newH);
-		globalContainer->gfx->setRes(newW, newH);*/
 	}
 }
 

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -4385,7 +4385,6 @@ void GameGUI::drawInGameScrollableText(void)
 
 void GameGUI::drawAll(int team)
 {
-	EventListener::instance()->setPainter(std::bind(&GameGUI::drawAll, this, team));
 	// draw the map
 	Uint32 drawOptions =	(drawHealthFoodBar ? Game::DRAW_HEALTH_FOOD_BAR : 0) |
 								(drawPathLines ?  Game::DRAW_PATH_LINE : 0) |

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -191,7 +191,7 @@ GameGUI::GameGUI()
 
 GameGUI::~GameGUI()
 {
-	EventListener::instance()->setPainter(nullptr);
+	EventListener::instance()->removePainter("GameGUI");
 	for (ParticleSet::iterator it = particles.begin(); it != particles.end(); ++it)
 		delete *it;
 }

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -184,7 +184,7 @@ GameGUI::GameGUI()
 	         128, // width
 	         128, //height
 	         Minimap::ShowFOW), // minimap mode
-	  
+	  isRegistered(false),
 	  ghostManager(game)
 {
 }
@@ -4385,6 +4385,8 @@ void GameGUI::drawInGameScrollableText(void)
 
 void GameGUI::drawAll(int team)
 {
+	std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
+	EventListener::ensureContext();
 	// draw the map
 	Uint32 drawOptions =	(drawHealthFoodBar ? Game::DRAW_HEALTH_FOOD_BAR : 0) |
 								(drawPathLines ?  Game::DRAW_PATH_LINE : 0) |

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -191,6 +191,7 @@ GameGUI::GameGUI()
 
 GameGUI::~GameGUI()
 {
+	EventListener::instance()->setPainter(nullptr);
 	for (ParticleSet::iterator it = particles.begin(); it != particles.end(); ++it)
 		delete *it;
 }
@@ -4384,6 +4385,7 @@ void GameGUI::drawInGameScrollableText(void)
 
 void GameGUI::drawAll(int team)
 {
+	EventListener::instance()->setPainter(std::bind(&GameGUI::drawAll, this, team));
 	// draw the map
 	Uint32 drawOptions =	(drawHealthFoodBar ? Game::DRAW_HEALTH_FOOD_BAR : 0) |
 								(drawPathLines ?  Game::DRAW_PATH_LINE : 0) |

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -55,6 +55,7 @@
 #include "ReplayWriter.h"
 #include "config.h"
 #include "Order.h"
+#include "EventListener.h"
 
 #include <SDL_keycode.h>
 
@@ -388,7 +389,8 @@ void GameGUI::step(void)
 	bool wasWindowEvent=false;
 	int oldMouseMapX = -1, oldMouseMapY = -1; // hopefully the values here will never matter
 	// we get all pending events but for mousemotion we only keep the last one
-	while (SDL_PollEvent(&event))
+	EventListener *el = EventListener::instance();
+	while (el->poll(&event))
 	{
 		if (event.type==SDL_MOUSEMOTION)
 		{

--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -56,6 +56,7 @@
 #include "config.h"
 #include "Order.h"
 #include "EventListener.h"
+#include "SDLGraphicContext.h"
 
 #include <SDL_keycode.h>
 
@@ -476,6 +477,11 @@ void GameGUI::step(void)
 		{
 			processEvent(&event);
 		}
+	}
+	GraphicContext* gfx = GraphicContext::instance();
+	if (gfx->resChanged()) {
+		SDL_Rect r = gfx->getRes();
+		gfx->setRes(r.w, r.h);
 	}
 	if (wasMouseMotion)
 		processEvent(&mouseMotionEvent);

--- a/src/GameGUI.h
+++ b/src/GameGUI.h
@@ -201,6 +201,10 @@ public:
 	bool hardPause;
 	bool isRunning;
 	bool notmenu;
+
+	// isRegistered tracks whether this instance of GameGUI has been registered with EventListener.
+	bool isRegistered;
+
 	//! true if user close the glob2 window.
 	bool exitGlobCompletely;
 	//! true if the game needs to flush all outgoing orders and exit

--- a/src/Glob2.cpp
+++ b/src/Glob2.cpp
@@ -235,7 +235,7 @@ int Glob2::run(int argc, char *argv[])
 		globalContainer->mainthr = std::this_thread::get_id();
 		globalContainer->mainthrSet = true;
 		if (!globalContainer->hostServer && !globalContainer->runNoX) {
-			globalContainer->otherthread = new std::thread(&Glob2::run, this, argc, argv);
+			globalContainer->logicThread = new std::thread(&Glob2::run, this, argc, argv);
 		}
 	}
 	if (!globalContainer->hostServer &&
@@ -447,8 +447,8 @@ int Glob2::run(int argc, char *argv[])
 		}
 	}
 
-	// quit event loop so otherthread can be joined by main thread
-	if (globalContainer->otherthread)
+	// quit event loop so logic thread can be joined by main thread
+	if (globalContainer->logicThread)
 	{
 		EventListener *el = EventListener::instance();
 		el->stop();

--- a/src/Glob2.h
+++ b/src/Glob2.h
@@ -37,6 +37,7 @@ public:
 	///Generates random maps non stop until the game crashes
 	int runTestMapGeneration();
 	int run(int argc, char *argv[]);
+	void finish();
 };
 
 #endif

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -529,8 +529,11 @@ void GlobalContainer::loadClient(bool runEventListener)
 			exit(0);
 		}
 		
-		while (!el || !el->isRunning()) {
-			SDL_Delay(100);
+		{
+			std::unique_lock lock(EventListener::startMutex);
+			while (!el || !el->isRunning()) {
+				EventListener::startedCond.wait(lock);
+			}
 		}
 		gfx->createGLContext();
 		// load data required for drawing progress screen

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -130,7 +130,7 @@ GlobalContainer::GlobalContainer(void)
 	replayShowFlags = true;
 
 	mainthrSet = false;
-	otherthread = nullptr;
+	logicThread = nullptr;
 
 #ifndef YOG_SERVER_ONLY
 	replayReader = NULL;
@@ -524,8 +524,8 @@ void GlobalContainer::loadClient(bool runEventListener)
 			gfx->unsetContext();
 			el = new EventListener(gfx);
 			el->run();
-			otherthread->join();
-			delete otherthread;
+			logicThread->join();
+			delete logicThread;
 			return;
 		}
 		

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -26,6 +26,7 @@
 #include "GameGUIKeyActions.h"
 #include "Glob2Screen.h"
 #include "Glob2Style.h"
+#include "Glob2.h"
 #include "GlobalContainer.h"
 #include "Header.h"
 #include "IntBuildingType.h"
@@ -127,6 +128,9 @@ GlobalContainer::GlobalContainer(void)
 	replayVisibleTeams = 0xFFFFFFFF;
 	replayShowAreas = false;
 	replayShowFlags = true;
+
+	mainthrSet = false;
+	otherthread = nullptr;
 
 #ifndef YOG_SERVER_ONLY
 	replayReader = NULL;
@@ -520,6 +524,8 @@ void GlobalContainer::loadClient(bool runEventListener)
 			gfx->unsetContext();
 			el = new EventListener(gfx);
 			el->run();
+			otherthread->join();
+			delete otherthread;
 			exit(0);
 		}
 		

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -505,8 +505,9 @@ void GlobalContainer::updateLoadProgressScreen(int value)
 	gfx->nextFrame();
 }
 
+EventListener* el = NULL;
 // glob2-client specific actions here.
-void GlobalContainer::loadClient(void)
+void GlobalContainer::loadClient(bool runEventListener)
 {
 	if (!runNoX)
 	{
@@ -515,8 +516,10 @@ void GlobalContainer::loadClient(void)
 		gfx->setMinRes(640, 480);
 		//gfx->setQuality((settings.optionFlags & OPTION_LOW_SPEED_GFX) != 0 ? GraphicContext::LOW_QUALITY : GraphicContext::HIGH_QUALITY);
 		
-		EventListener el(gfx);
-		el.run();
+		if (runEventListener) {
+			el = new EventListener(gfx);
+			el->run();
+		}
 		
 		// load data required for drawing progress screen
 		title = new DrawableSurface("data/gfx/title.png");
@@ -624,31 +627,33 @@ void GlobalContainer::loadClient(void)
 }
 #endif  // !YOG_SERVER_ONLY
 
-void GlobalContainer::load(void)
+void GlobalContainer::load(bool runEventListener)
 {
-	// load texts
-	if (!Toolkit::getStringTable()->load("data/texts.list.txt"))
-	{
-		std::cerr << "Fatal error : while loading \"data/texts.list.txt\"" << std::endl;
-		assert(false);
-		exit(-1);
+	if (runEventListener) {
+		// load texts
+		if (!Toolkit::getStringTable()->load("data/texts.list.txt"))
+		{
+			std::cerr << "Fatal error : while loading \"data/texts.list.txt\"" << std::endl;
+			assert(false);
+			exit(-1);
+		}
+		// load texts
+		if (!Toolkit::getStringTable()->loadIncompleteList("data/texts.incomplete.txt"))
+		{
+			std::cerr << "Fatal error : while loading \"data/texts.incomplete.txt\"" << std::endl;
+			assert(false);
+			exit(-1);
+		}
+		
+		Toolkit::getStringTable()->setLang(Toolkit::getStringTable()->getLangCode(settings.language));
+		// load default unit types
+		Race::loadDefault();
+		// load resources types
+		ressourcesTypes.load("data/ressources.txt"); ///TODO: coding in english or french? english is resources, french is ressources
 	}
-	// load texts
-	if (!Toolkit::getStringTable()->loadIncompleteList("data/texts.incomplete.txt"))
-	{
-		std::cerr << "Fatal error : while loading \"data/texts.incomplete.txt\"" << std::endl;
-		assert(false);
-		exit(-1);
-	}
-	
-	Toolkit::getStringTable()->setLang(Toolkit::getStringTable()->getLangCode(settings.language));
-	// load default unit types
-	Race::loadDefault();
-	// load resources types
-	ressourcesTypes.load("data/ressources.txt"); ///TODO: coding in english or french? english is resources, french is ressources
 
 #ifndef YOG_SERVER_ONLY
-	loadClient();
+	loadClient(runEventListener);
 #endif  // !YOG_SERVER_ONLY
 }
 

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -511,16 +511,19 @@ void GlobalContainer::loadClient(bool runEventListener)
 {
 	if (!runNoX)
 	{
-		// create graphic context
-		gfx = Toolkit::initGraphic(settings.screenWidth, settings.screenHeight, settings.screenFlags, "Globulation 2", "glob 2");
-		gfx->setMinRes(640, 480);
-		//gfx->setQuality((settings.optionFlags & OPTION_LOW_SPEED_GFX) != 0 ? GraphicContext::LOW_QUALITY : GraphicContext::HIGH_QUALITY);
-		
 		if (runEventListener) {
+			// create graphic context
+			gfx = Toolkit::initGraphic(settings.screenWidth, settings.screenHeight, settings.screenFlags, "Globulation 2", "glob 2");
+			gfx->setMinRes(640, 480);
+			//gfx->setQuality((settings.optionFlags & OPTION_LOW_SPEED_GFX) != 0 ? GraphicContext::LOW_QUALITY : GraphicContext::HIGH_QUALITY);
+		
 			el = new EventListener(gfx);
 			el->run();
 		}
 		
+		while (!el || !el->isRunning()) {
+			SDL_Delay(100);
+		}
 		// load data required for drawing progress screen
 		title = new DrawableSurface("data/gfx/title.png");
 		terrain = Toolkit::getSprite("data/gfx/terrain");

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -530,7 +530,7 @@ void GlobalContainer::loadClient(bool runEventListener)
 		}
 		
 		{
-			std::unique_lock lock(EventListener::startMutex);
+			std::unique_lock<std::mutex> lock(EventListener::startMutex);
 			while (!el || !el->isRunning()) {
 				EventListener::startedCond.wait(lock);
 			}

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -16,11 +16,12 @@
   along with this program; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
-
+#include <thread>
 #include <Toolkit.h>
 #include <GAG.h>
 #include <GUIBase.h>
 
+#include "EventListener.h"
 #include "FileManager.h"
 #include "GameGUIKeyActions.h"
 #include "Glob2Screen.h"
@@ -513,6 +514,9 @@ void GlobalContainer::loadClient(void)
 		gfx = Toolkit::initGraphic(settings.screenWidth, settings.screenHeight, settings.screenFlags, "Globulation 2", "glob 2");
 		gfx->setMinRes(640, 480);
 		//gfx->setQuality((settings.optionFlags & OPTION_LOW_SPEED_GFX) != 0 ? GraphicContext::LOW_QUALITY : GraphicContext::HIGH_QUALITY);
+		
+		EventListener el(gfx);
+		el.run();
 		
 		// load data required for drawing progress screen
 		title = new DrawableSurface("data/gfx/title.png");

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -526,7 +526,7 @@ void GlobalContainer::loadClient(bool runEventListener)
 			el->run();
 			otherthread->join();
 			delete otherthread;
-			exit(0);
+			return;
 		}
 		
 		{

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -517,6 +517,7 @@ void GlobalContainer::loadClient(bool runEventListener)
 			gfx->setMinRes(640, 480);
 			//gfx->setQuality((settings.optionFlags & OPTION_LOW_SPEED_GFX) != 0 ? GraphicContext::LOW_QUALITY : GraphicContext::HIGH_QUALITY);
 		
+			gfx->unsetContext();
 			el = new EventListener(gfx);
 			el->run();
 			exit(0);

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -536,6 +536,8 @@ void GlobalContainer::loadClient(bool runEventListener)
 			}
 		}
 		gfx->createGLContext();
+		// Next line fixes white screen during loading screen in software rendered mode.
+		gfx->getOrCreateSurface(gfx->getW(), gfx->getH(), gfx->getOptionFlags());
 		// load data required for drawing progress screen
 		title = new DrawableSurface("data/gfx/title.png");
 		terrain = Toolkit::getSprite("data/gfx/terrain");

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -519,11 +519,13 @@ void GlobalContainer::loadClient(bool runEventListener)
 		
 			el = new EventListener(gfx);
 			el->run();
+			exit(0);
 		}
 		
 		while (!el || !el->isRunning()) {
 			SDL_Delay(100);
 		}
+		gfx->createGLContext();
 		// load data required for drawing progress screen
 		title = new DrawableSurface("data/gfx/title.png");
 		terrain = Toolkit::getSprite("data/gfx/terrain");

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -640,6 +640,7 @@ void GlobalContainer::loadClient(bool runEventListener)
 		Style::style = new Glob2Style;
 
 		updateLoadProgressScreen(100);
+		gfx->setRes(gfx->getW(), gfx->getH());
 	}
 }
 #endif  // !YOG_SERVER_ONLY

--- a/src/GlobalContainer.h
+++ b/src/GlobalContainer.h
@@ -142,8 +142,8 @@ public:
 	bool replayShowAreas; //!< Show areas of gui.localPlayer or not. Can be edited real-time.
 	bool replayShowFlags; //!< Show all flags or show none. Can be edited real-time.
 
-	// other thread handles events in the queue, game logic, rendering, etc.
-	std::thread* otherthread;
+	// logic thread handles events in the queue, game logic, rendering, etc.
+	std::thread* logicThread;
 	// main thread listens for SDL events and adds them to a queue
 	std::thread::id mainthr;
 	std::atomic<bool> mainthrSet;

--- a/src/GlobalContainer.h
+++ b/src/GlobalContainer.h
@@ -24,6 +24,8 @@
 #include "RessourcesTypes.h"
 #include "Settings.h"
 #include "EventListener.h"
+#include <thread>
+#include <atomic>
 
 namespace GAGCore
 {
@@ -139,6 +141,12 @@ public:
 	Uint32 replayVisibleTeams; //!< A mask of which teams can be seen in the replay. Can be edited real-time.
 	bool replayShowAreas; //!< Show areas of gui.localPlayer or not. Can be edited real-time.
 	bool replayShowFlags; //!< Show all flags or show none. Can be edited real-time.
+
+	// other thread handles events in the queue, game logic, rendering, etc.
+	std::thread* otherthread;
+	// main thread listens for SDL events and adds them to a queue
+	std::thread::id mainthr;
+	std::atomic<bool> mainthrSet;
 
 #ifndef YOG_SERVER_ONLY
 	ReplayReader *replayReader; //!< Reads and processes replay files, and outputs orders

--- a/src/GlobalContainer.h
+++ b/src/GlobalContainer.h
@@ -23,6 +23,7 @@
 #include "BuildingsTypes.h"
 #include "RessourcesTypes.h"
 #include "Settings.h"
+#include "EventListener.h"
 
 namespace GAGCore
 {
@@ -41,6 +42,7 @@ class UnitsSkins;
 class ReplayReader;
 class ReplayWriter;
 
+extern EventListener* el;
 class GlobalContainer
 {
 public:
@@ -59,9 +61,9 @@ public:
 
 	void parseArgs(int argc, char *argv[]);
 #ifndef YOG_SERVER_ONLY
-	void loadClient(void);
+	void loadClient(bool runEventListener);
 #endif  // !YOG_SERVER_ONLY
-	void load(void);
+	void load(bool runEventListener);
 
 	//void setUsername(const std::string &name);
 	//const std::string &getUsername(void) { return settings.getUsername(); }

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -37,6 +37,7 @@
 #include "Utilities.h"
 #include "FertilityCalculatorDialog.h"
 #include "GUIMessageBox.h"
+#include "EventListener.h"
 
 
 #define RIGHT_MENU_WIDTH 160
@@ -1236,7 +1237,8 @@ int MapEdit::run(void)
 	
 		// we get all pending events but for mousemotion we only keep the last one
 		SDL_Event event;
-		while (SDL_PollEvent(&event))
+		EventListener *el = EventListener::instance();
+		while (el->poll(&event))
 		{
  			processEvent(event);
 		}

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1207,6 +1207,50 @@ bool MapEdit::save(const std::string filename, const std::string name)
 	}
 }
 
+void MapEdit::draw(void)
+{
+	drawMap(0, 0, globalContainer->gfx->getW() - 0, globalContainer->gfx->getH(), true, true);
+
+	drawMenu();
+	drawMiniMap();
+	wasMinimapRendered = false;
+	drawWidgets();
+	if (showingMenuScreen)
+	{
+		globalContainer->gfx->setClipRect();
+		menuScreen->dispatchTimer(startTick);
+		menuScreen->dispatchPaint();
+		globalContainer->gfx->drawSurface((int)menuScreen->decX, (int)menuScreen->decY, menuScreen->getSurface());
+	}
+	if (showingLoad || showingSave)
+	{
+		globalContainer->gfx->setClipRect();
+		loadSaveScreen->dispatchTimer(startTick);
+		loadSaveScreen->dispatchPaint();
+		globalContainer->gfx->drawSurface((int)loadSaveScreen->decX, (int)loadSaveScreen->decY, loadSaveScreen->getSurface());
+	}
+	if (showingScriptEditor)
+	{
+		globalContainer->gfx->setClipRect();
+		scriptEditor->dispatchTimer(startTick);
+		scriptEditor->dispatchPaint();
+		globalContainer->gfx->drawSurface((int)scriptEditor->decX, (int)scriptEditor->decY, scriptEditor->getSurface());
+	}
+	if (showingTeamsEditor)
+	{
+		globalContainer->gfx->setClipRect();
+		teamsEditor->dispatchTimer(startTick);
+		teamsEditor->dispatchPaint();
+		globalContainer->gfx->drawSurface((int)teamsEditor->decX, (int)teamsEditor->decY, teamsEditor->getSurface());
+	}
+	if (isShowingAreaName)
+	{
+		globalContainer->gfx->setClipRect();
+		areaName->dispatchTimer(startTick);
+		areaName->dispatchPaint();
+		globalContainer->gfx->drawSurface((int)areaName->decX, (int)areaName->decY, areaName->getSurface());
+	}
+}
 
 
 int MapEdit::run(int sizeX, int sizeY, TerrainType terrainType)
@@ -1237,7 +1281,6 @@ int MapEdit::run(void)
 
 	bool isRunning=true;
 	int returnCode=0;
-	Uint32 startTick, endTick, deltaTick;
 	while (isRunning)
 	{
 		//SDL_Event event;
@@ -1289,49 +1332,8 @@ int MapEdit::run(void)
 				performAction("no ressource growth area drag motion");
 		}
 		
-		drawMap(0, 0, globalContainer->gfx->getW()-0, globalContainer->gfx->getH(), true, true);
-		
-		drawMenu();
-		drawMiniMap();
-		wasMinimapRendered=false;
-		drawWidgets();
-		if(showingMenuScreen)
-		{
-			globalContainer->gfx->setClipRect();
-			menuScreen->dispatchTimer(startTick);
-			menuScreen->dispatchPaint();
-			globalContainer->gfx->drawSurface((int)menuScreen->decX, (int)menuScreen->decY, menuScreen->getSurface());
-		}
-		if(showingLoad || showingSave)
-		{
-			globalContainer->gfx->setClipRect();
-			loadSaveScreen->dispatchTimer(startTick);
-			loadSaveScreen->dispatchPaint();
-			globalContainer->gfx->drawSurface((int)loadSaveScreen->decX, (int)loadSaveScreen->decY, loadSaveScreen->getSurface());
-		}
-		if(showingScriptEditor)
-		{
-			globalContainer->gfx->setClipRect();
-			scriptEditor->dispatchTimer(startTick);
-			scriptEditor->dispatchPaint();
-			globalContainer->gfx->drawSurface((int)scriptEditor->decX, (int)scriptEditor->decY, scriptEditor->getSurface());
-		}
-		if(showingTeamsEditor)
-		{
-			globalContainer->gfx->setClipRect();
-			teamsEditor->dispatchTimer(startTick);
-			teamsEditor->dispatchPaint();
-			globalContainer->gfx->drawSurface((int)teamsEditor->decX, (int)teamsEditor->decY, teamsEditor->getSurface());
-		}
-		if(isShowingAreaName)
-		{
-			globalContainer->gfx->setClipRect();
-			areaName->dispatchTimer(startTick);
-			areaName->dispatchPaint();
-			globalContainer->gfx->drawSurface((int)areaName->decX, (int)areaName->decY, areaName->getSurface());
-		}
-		
-		
+		draw();
+
 		globalContainer->gfx->nextFrame();
 		
 

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -38,6 +38,7 @@
 #include "FertilityCalculatorDialog.h"
 #include "GUIMessageBox.h"
 #include "EventListener.h"
+#include "SDLGraphicContext.h"
 
 
 #define RIGHT_MENU_WIDTH 160
@@ -58,6 +59,13 @@ void MapEditorWidget::drawSelf()
 		draw();
 }
 
+
+// If the window gets wider, we need to move the widgets further to the right.
+// Likewize, if the window becomes smaller, the widgets should move to the left.
+int MapEditorWidget::adjustX()
+{
+	return globalContainer->gfx->getW()-area.initialWindowWidth;
+}
 
 
 void MapEditorWidget::disable()
@@ -100,7 +108,7 @@ void BuildingSelectorWidget::draw()
 	int imgid = bt->miniSpriteImage;
 	int x, y;
 
-	x=area.x;
+	x=area.x+adjustX();
 	y=area.y;
 
 	Sprite *buildingSprite;
@@ -141,7 +149,7 @@ void TeamColorSelector::draw()
 {
 	for(int n=0; n<16; ++n)
 	{
-		const int xpos = area.x + (n%6)*16;
+		const int xpos = area.x + adjustX() + (n%6)*16;
 		const int ypos = area.y + (n/6)*16;
 		if(me.game.teams[n])
 		{
@@ -166,7 +174,7 @@ SingleLevelSelector::SingleLevelSelector(MapEdit& me, const widgetRectangle& are
 
 void SingleLevelSelector::draw()
 {
-	globalContainer->gfx->drawSprite(area.x, area.y, me.menu, 30+level-1, (level-1)==levelNum ? 128 : 255);
+	globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, me.menu, 30+level-1, (level-1)==levelNum ? 128 : 255);
 }
 
 
@@ -183,9 +191,9 @@ void PanelIcon::draw()
 {
 	// draw buttons
 	if (me.panelMode==panelModeHilight)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, iconNumber+1);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, iconNumber+1);
 	else
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, iconNumber);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, iconNumber);
 
 }
 
@@ -203,9 +211,9 @@ void MenuIcon::draw()
 {
 	// draw buttons
 	if (me.showingMenuScreen)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 7);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 7);
 	else
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 6);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 6);
 
 }
 
@@ -224,25 +232,25 @@ void ZoneSelector::draw()
 	bool isSelected=false;
 	if(zoneType==ForbiddenZone)
 	{
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 13);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 13);
 		if(me.brushType==MapEdit::ForbiddenBrush)
 			isSelected=true;
 	}
 	else if(zoneType==GuardingZone)
 	{
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 14);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 14);
 		if(me.brushType==MapEdit::GuardAreaBrush)
 			isSelected=true;
 	}
 	else if(zoneType==ClearingZone)
 	{
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 25);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 25);
 		if(me.brushType==MapEdit::ClearAreaBrush)
 			isSelected=true;
 	}
 	if(me.selectionMode==MapEdit::PlaceZone && isSelected)
 	{
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 22);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 22);
 	}
 }
 
@@ -258,7 +266,7 @@ BrushSelector::BrushSelector(MapEdit& me, const widgetRectangle& area, const std
 
 void BrushSelector::draw()
 {
-	brushTool.draw(area.x, area.y);
+	brushTool.draw(area.x+adjustX(), area.y);
 }
 
 
@@ -281,23 +289,23 @@ void UnitSelector::draw()
 	{
 		if(me.selectionMode==MapEdit::PlaceUnit && me.placingUnit==MapEdit::Worker)
 			drawSelection=true;
-		globalContainer->gfx->drawSprite(area.x, area.y, unitSprite, 64);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, unitSprite, 64);
 	}
 	else if(unitType==EXPLORER)
 	{
 		if(me.selectionMode==MapEdit::PlaceUnit && me.placingUnit==MapEdit::Explorer)
 			drawSelection=true;
-		globalContainer->gfx->drawSprite(area.x, area.y, unitSprite, 0);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, unitSprite, 0);
 	}
 	else if(unitType==WARRIOR)
 	{
 		if(me.selectionMode==MapEdit::PlaceUnit && me.placingUnit==MapEdit::Warrior)
 			drawSelection=true;
-		globalContainer->gfx->drawSprite(area.x, area.y, unitSprite, 256);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, unitSprite, 256);
 	}
 	if(drawSelection)
 	{
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 23);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 23);
 	}
 }
 
@@ -314,29 +322,29 @@ TerrainSelector::TerrainSelector(MapEdit& me, const widgetRectangle& area, const
 void TerrainSelector::draw()
 {
 	if(terrainType==Grass)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->terrain, 0);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->terrain, 0);
 	if(terrainType==Sand)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->terrain, 128);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->terrain, 128);
 	if(terrainType==Water)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->terrain, 259);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->terrain, 259);
 	if(terrainType==Wheat)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 19);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 19);
 	if(terrainType==Trees)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 2);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 2);
 	if(terrainType==Stone)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 34);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 34);
 	if(terrainType==Algae)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 44);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 44);
 	if(terrainType==Papyrus)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 24);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 24);
 	if(terrainType==CherryTree)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 54);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 54);
 	if(terrainType==OrangeTree)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 59);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 59);
 	if(terrainType==PruneTree)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 64);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->ressources, 64);
 	if(me.terrainType==terrainType)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 22);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 22);
 }
 
 
@@ -351,15 +359,15 @@ BlueButton::BlueButton(MapEdit& me, const widgetRectangle& area, const std::stri
 
 void BlueButton::draw()
 {
-	globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 12);
+	globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 12);
 	if(selected)
-		globalContainer->gfx->drawFilledRect(area.x+9, area.y+3, 94, 10, 128, 128, 192);
+		globalContainer->gfx->drawFilledRect(area.x+9+adjustX(), area.y+3, 94, 10, 128, 128, 192);
 
 	std::string translatedText;
 	translatedText=Toolkit::getStringTable()->getString(text.c_str());
 	int len=globalContainer->littleFont->getStringWidth(translatedText.c_str());
 	int h=globalContainer->littleFont->getStringHeight(translatedText.c_str());
-	globalContainer->gfx->drawString(area.x+9+((94-len)/2), area.y+((16-h)/2), globalContainer->littleFont, translatedText);
+	globalContainer->gfx->drawString(area.x+adjustX()+9+((94-len)/2), area.y+((16-h)/2), globalContainer->littleFont, translatedText);
 }
 
 
@@ -387,10 +395,10 @@ PlusIcon::PlusIcon(MapEdit& me, const widgetRectangle& area, const std::string& 
 
 void PlusIcon::draw()
 {
-	globalContainer->gfx->drawFilledRect(area.x, area.y, 32, 32, Color(75,0,200));
-	globalContainer->gfx->drawRect(area.x, area.y, 32, 32, Color::white);
-	globalContainer->gfx->drawFilledRect(area.x + 15, area.y + 6, 2, 20, Color::white);
-	globalContainer->gfx->drawFilledRect(area.x + 6, area.y + 15, 20, 2, Color::white);
+	globalContainer->gfx->drawFilledRect(area.x+adjustX(), area.y, 32, 32, Color(75,0,200));
+	globalContainer->gfx->drawRect(area.x+adjustX(), area.y, 32, 32, Color::white);
+	globalContainer->gfx->drawFilledRect(area.x+adjustX() + 15, area.y + 6, 2, 20, Color::white);
+	globalContainer->gfx->drawFilledRect(area.x+adjustX() + 6, area.y + 15, 20, 2, Color::white);
 }
 
 
@@ -405,9 +413,9 @@ MinusIcon::MinusIcon(MapEdit& me, const widgetRectangle& area, const std::string
 
 void MinusIcon::draw()
 {
-	globalContainer->gfx->drawFilledRect(area.x, area.y, 32, 32, Color(75,0,200));
-	globalContainer->gfx->drawRect(area.x, area.y, 32, 32, Color::white);
-	globalContainer->gfx->drawFilledRect(area.x + 6, area.y + 15, 20, 2, Color::white);
+	globalContainer->gfx->drawFilledRect(area.x+adjustX(), area.y, 32, 32, Color(75,0,200));
+	globalContainer->gfx->drawRect(area.x+adjustX(), area.y, 32, 32, Color::white);
+	globalContainer->gfx->drawFilledRect(area.x+adjustX() + 6, area.y + 15, 20, 2, Color::white);
 }
 
 
@@ -422,7 +430,7 @@ UnitInfoTitle::UnitInfoTitle(MapEdit& me, const widgetRectangle& area, const std
 
 void UnitInfoTitle::draw()
 {
-	const int xpos=area.x;
+	const int xpos=area.x+adjustX();
 	const int ypos=area.y;
 	Unit* u=unit;
 
@@ -468,7 +476,7 @@ UnitPicture::UnitPicture(MapEdit& me, const widgetRectangle& area, const std::st
 
 void UnitPicture::draw()
 {
-	const int xpos=area.x;
+	const int xpos=area.x+adjustX();
 	const int ypos=area.y;
 
 	// draw unit's image
@@ -537,7 +545,7 @@ FractionValueText::~FractionValueText()
 
 void FractionValueText::draw()
 {
-	globalContainer->gfx->drawString(area.x, area.y, globalContainer->littleFont, FormatableString("%0:  %1/%2").arg(Toolkit::getStringTable()->getString(label.c_str())).arg(*numerator).arg(*denominator).c_str());
+	globalContainer->gfx->drawString(area.x+adjustX(), area.y, globalContainer->littleFont, FormatableString("%0:  %1/%2").arg(Toolkit::getStringTable()->getString(label.c_str())).arg(*numerator).arg(*denominator).c_str());
 }
 
 
@@ -586,11 +594,11 @@ void ValueScrollBox::draw()
 	//Sometimes a scrollbox gets initiated with max-value 0. A turret construction site has 0/0 stone and 0/0 shots. To not run into arithmetic exceptions those cases are treated here.
 	if((*max) != 0)
 	{
-		globalContainer->gfx->setClipRect(area.x, area.y, 112, 16);
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 9);
+		globalContainer->gfx->setClipRect(area.x+adjustX(), area.y, 112, 16);
+		globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 9);
 		int size=((*value)*92)/(*max);
-		globalContainer->gfx->setClipRect(area.x+10, area.y, size, 16);
-		globalContainer->gfx->drawSprite(area.x+10, area.y+3, globalContainer->gamegui, 10);
+		globalContainer->gfx->setClipRect(area.x+10+adjustX(), area.y, size, 16);
+		globalContainer->gfx->drawSprite(area.x+10+adjustX(), area.y+3, globalContainer->gamegui, 10);
 		globalContainer->gfx->setClipRect();
 	}
 }
@@ -658,7 +666,7 @@ void BuildingInfoTitle::draw()
 
 	globalContainer->littleFont->pushStyle(Font::Style(Font::STYLE_NORMAL, r, g, b));
 	int titleLen = globalContainer->littleFont->getStringWidth(title.c_str());
-	int titlePos = area.x+((area.width-titleLen)/2);
+	int titlePos = area.x+adjustX()+((area.width-titleLen)/2);
 	globalContainer->gfx->drawString(titlePos, area.y, globalContainer->littleFont, title.c_str());
 	globalContainer->littleFont->popStyle();
 }
@@ -701,8 +709,8 @@ void BuildingPicture::draw()
 	int dx = (56-miniSprite->getW(imgid))/2;
 	int dy = (46-miniSprite->getH(imgid))/2;
 	miniSprite->setBaseColor(selBuild->owner->color);
-	globalContainer->gfx->drawSprite(area.x+dx, area.y+dy, miniSprite, imgid);
-	globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 18);
+	globalContainer->gfx->drawSprite(area.x+dx+adjustX(), area.y+dy, miniSprite, imgid);
+	globalContainer->gfx->drawSprite(area.x+adjustX(), area.y, globalContainer->gamegui, 18);
 }
 
 
@@ -730,9 +738,9 @@ void TextLabel::draw()
 	int titleWidth = globalContainer->littleFont->getStringWidth(label.c_str());
 	int titleHeight = globalContainer->littleFont->getStringHeight(label.c_str());
 	if(centered)
-		globalContainer->gfx->drawString(area.x+(area.width-titleWidth)/2, area.y+(area.height-titleHeight)/2, globalContainer->littleFont, label.c_str());
+		globalContainer->gfx->drawString(area.x+adjustX()+(area.width-titleWidth)/2, area.y+(area.height-titleHeight)/2, globalContainer->littleFont, label.c_str());
 	else
-		globalContainer->gfx->drawString(area.x, area.y, globalContainer->littleFont, label.c_str());
+		globalContainer->gfx->drawString(area.x+adjustX(), area.y, globalContainer->littleFont, label.c_str());
 }
 
 
@@ -756,7 +764,7 @@ void NumberCycler::draw()
 {
 	std::stringstream s;
 	s<<currentNumber;
-	globalContainer->gfx->drawString(area.x, area.y, globalContainer->standardFont, s.str().c_str());
+	globalContainer->gfx->drawString(area.x+adjustX(), area.y, globalContainer->standardFont, s.str().c_str());
 }
 
 
@@ -789,17 +797,17 @@ Checkbox::Checkbox(MapEdit& me, const widgetRectangle& area, const std::string& 
 
 void Checkbox::draw()
 {
-	globalContainer->gfx->drawRect(area.x, area.y, 16, 16, Color::white);
+	globalContainer->gfx->drawRect(area.x+adjustX(), area.y, 16, 16, Color::white);
 	if(isActivated)
 	{
-		globalContainer->gfx->drawLine(area.x+4, area.y+4, area.x+12, area.y+12, Color::white);
-		globalContainer->gfx->drawLine(area.x+12, area.y+4, area.x+4, area.y+12, Color::white);
+		globalContainer->gfx->drawLine(area.x+4+adjustX(), area.y+4, area.x+adjustX()+12, area.y+12, Color::white);
+		globalContainer->gfx->drawLine(area.x+12+adjustX(), area.y+4, area.x+adjustX()+4, area.y+12, Color::white);
 	}
 	
 	std::string translatedText;
 	translatedText=Toolkit::getStringTable()->getString(text.c_str());
 	
-	globalContainer->gfx->drawString(area.x+20, area.y, globalContainer->littleFont, translatedText); 
+	globalContainer->gfx->drawString(area.x+20+adjustX(), area.y, globalContainer->littleFont, translatedText); 
 }
 
 
@@ -1241,6 +1249,12 @@ int MapEdit::run(void)
 		while (el->poll(&event))
 		{
  			processEvent(event);
+		}
+
+		GraphicContext *gfx = GraphicContext::instance();
+		if (gfx->resChanged()) {
+			SDL_Rect r = gfx->getRes();
+			gfx->setRes(r.w, r.h);
 		}
 
 		// While processing events the user could've tried to load a map that failed.
@@ -3197,7 +3211,8 @@ bool MapEdit::findAction(int x, int y)
 		MapEditorWidget* mi=*i;
 		if(mi->is_in(x, y) && mi->enabled)
 		{
-			mi->handleClick(mouseX-mi->area.x, mouseY-mi->area.y);
+			int adjustX = globalContainer->gfx->getW() - mi->area.initialWindowWidth;
+			mi->handleClick(mouseX-(mi->area.x+adjustX), mouseY-mi->area.y);
 			return true;
 		}
 	}

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1116,6 +1116,7 @@ MapEdit::MapEdit()
 
 MapEdit::~MapEdit()
 {
+	EventListener::instance()->removePainter("MapEdit");
 	Toolkit::releaseSprite("data/gui/editor");
 	for(std::vector<MapEditorWidget*>::iterator i=mew.begin(); i!=mew.end(); ++i)
 	{
@@ -1257,6 +1258,7 @@ int MapEdit::run(int sizeX, int sizeY, TerrainType terrainType)
 {
 	game.map.setSize(sizeX, sizeY, terrainType);
 	game.map.setGame(&game);
+	EventListener::instance()->addPainter("MapEdit", std::bind(&MapEdit::draw, this));
 	return run();
 }
 

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1210,6 +1210,8 @@ bool MapEdit::save(const std::string filename, const std::string name)
 
 void MapEdit::draw(void)
 {
+	std::unique_lock<std::recursive_mutex> lock(EventListener::renderMutex);
+	EventListener::ensureContext();
 	drawMap(0, 0, globalContainer->gfx->getW() - 0, globalContainer->gfx->getH(), true, true);
 
 	drawMenu();

--- a/src/MapEdit.h
+++ b/src/MapEdit.h
@@ -401,6 +401,8 @@ public:
 	///Saves the game to a particular file name
 	bool save(const std::string filename, const std::string name);
 
+	void draw(void);
+
 	///Updates the editor after map generation
 	void update();
 
@@ -778,6 +780,7 @@ private:
 	///Handles a click or drag of the no ressource growth area placement tool
 	void handleNoRessourceGrowthClick(int mx, int my);
 
+	Uint32 startTick, endTick, deltaTick;
 };
 
 

--- a/src/MapEdit.h
+++ b/src/MapEdit.h
@@ -38,14 +38,18 @@
 ///A generic rectangle structure used for a variety of purposes, but mainly for the convience of the widget system
 struct widgetRectangle
 {
-	widgetRectangle(int x, int y, int width, int height) : x(x), y(y), width(width), height(height) {}
-	widgetRectangle() : x(0), y(0), width(0), height(0) {}
-	bool is_in(int posx, int posy) { return posx>x && posx<(x+width) && posy>y && posy<(y+height); }
+	widgetRectangle(int x, int y, int width, int height) : x(x), y(y), width(width), height(height), initialWindowWidth(globalContainer->gfx->getW()) {}
+	widgetRectangle() : x(0), y(0), width(0), height(0), initialWindowWidth(0) {}
+	bool is_in(int posx, int posy) { return posx>(x+globalContainer->gfx->getW()-initialWindowWidth) &&
+											posx<(x+globalContainer->gfx->getW()-initialWindowWidth+width) &&
+											posy>y && 
+											posy<(y+height); }
 
 	int x;
 	int y;
 	int width;
 	int height;
+	int initialWindowWidth;
 };
 
 class MapEdit;
@@ -78,6 +82,7 @@ public:
 	///This function must be implemented by all derived classes. This is where the widget draws itself. It should use area.x
 	///and area.y to get the cordinates.
 	virtual void draw()=0;
+	int adjustX();
 	friend class MapEdit;
 protected:
 	MapEdit& me;

--- a/src/Minimap.cpp
+++ b/src/Minimap.cpp
@@ -71,6 +71,9 @@ void Minimap::draw(int localteam, int viewportX, int viewportY, int viewportW, i
 {
 	if (noX) return;
 
+	// Keep the minimap in the right place even if window is resized.
+	gameWidth = globalContainer->gfx->getW();
+
   // Compute the position of the minimap if it needs to be scaled & centered
 	computeMinimapPositioning();
 

--- a/src/ScriptEditorScreen.cpp
+++ b/src/ScriptEditorScreen.cpp
@@ -28,6 +28,7 @@
 #include <StringTable.h>
 #include <SupportFunctions.h>
 #include <Stream.h>
+#include <EventListener.h>
 using namespace GAGCore;
 #include <GUIText.h>
 #include <GUITextArea.h>
@@ -569,7 +570,8 @@ void ScriptEditorScreen::loadSave(bool isLoad, const char *dir, const char *ext)
 	while(loadSaveScreen->endValue<0)
 	{
 		int time = SDL_GetTicks();
-		while (SDL_PollEvent(&event))
+		EventListener *el = EventListener::instance();
+		while (el->poll(&event))
 		{
 			loadSaveScreen->translateAndProcessEvent(&event);
 		}

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include "StringTable.h"
 #include "Toolkit.h"
+#include "EventListener.h"
 
 using namespace GAGCore;
 using namespace GAGGUI;
@@ -62,7 +63,8 @@ void YOGClientGameConnectionDialog::execute()
 	while(endValue<0)
 	{
 		Sint32 time = SDL_GetTicks();
-		while (SDL_PollEvent(&event))
+		EventListener *el = EventListener::instance();
+		while (el->poll(&event))
 		{
 			if (event.type==SDL_QUIT)
 				break;


### PR DESCRIPTION
The resizing is a little buggy but it mostly works. One bug I noticed was that the buttons on title screen get mangled during resizing or the button disappears and only the text of the button shows. Another bug is the game sometimes flashes red when resizing, not sure why.

The way this works is the main thread spawns a secondary thread and then opens the window, listens for events and adds to an events queue until told to stop. The second thread handles events, logic and rendering. When exiting the game, the second thread tells main thread to quit the event loop. Then the main thread joins the secondary thread, closes the window, and exits.

SDL_PollEvent will block the thread calling it during resize on Windows, so that's why I had to start another thread to handle everything else. I changed SDL_PollEvent to `el->poll` so that the resize doesn't block the event loop.

Just tested this in a Linux VM and it crashes in SDL_GL_SwapWindow. It works on Windows 10 though.

TODO:
- [x] Refactor the drawing code in `MapEdit::run` into a separate draw method.
- [x] Implement support for painting MapEdit and Screen objects in EventListener.
- [x] Fix textures turning white when resizing
  - [x] Fix globules flickering
  - [x] Fix cursor flickering
  - [x] Fix tutorial message flickering
- [ ] Fix bottom of window not being drawn sometimes after resizing
- [ ] Fix blank frame sometimes being drawn on title screen and in tutorial
- [ ] Cursor and clouds animations are too fast when resizing the window.
- [ ] Optimize drawing routines