### PR TITLE
Fix Enter key not opening chat text input box.

### DIFF
--- a/libgag/src/KeyPress.cpp
+++ b/libgag/src/KeyPress.cpp
@@ -22,6 +22,8 @@
 #include "GUIBase.h"
 #include "FormatableString.h"
 
+#include <algorithm>
+
 using namespace GAGCore;
 using namespace GAGGUI;
 
@@ -45,16 +47,18 @@ KeyPress::KeyPress(SDL_Keysym nkey, bool pressed)
 	else
 		alt = false;
 
-	std::string key_s = std::string("[") + SDL_GetKeyName(nkey.sym) + std::string("]");
+	std::string name = SDL_GetKeyName(nkey.sym);
+	std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+	std::string key_s = std::string("[") + name + std::string("]");
 	Uint16 c=0;
 	//This is to get over a bug where ctrl-d ctrl-a etc... would cause nkey.unicode to be mangled,
 	//whereas nkey.sym is still fine
 	if(nkey.sym < 128)
 		c = nkey.sym;
 	
-	if(Toolkit::getStringTable()->doesStringExist(key_s.c_str()))
+	if(Toolkit::getStringTable()->doesStringExist(key_s))
 	{
-		key = SDL_GetKeyName(nkey.sym);
+		key = name;
 	}
 	else if (c)
 	{
@@ -65,7 +69,7 @@ KeyPress::KeyPress(SDL_Keysym nkey, bool pressed)
 	}
 	else
 	{
-		key = SDL_GetKeyName(nkey.sym);
+		key = name;
 	}
 }
 


### PR DESCRIPTION
SDL_GetKeyName gives "Return" for the Enter key.

The string "Return" wasn't found in the string table because doesStringExist
does a case-sensitive search for the string and it starts with an uppercase
character, but the string in the string table is all lowercase. Since it
was not found, KeyPress defaults to using the char value of the keysym,
which is '\r'. There isn't an '\r' in the KeyboardManager's list of
shortcuts, so getAction returns DoNothing and the chat box never appears.

This commit also fixes Escape key not opening menu and the Pause button
doing nothing.