### PR TITLE
Fix Team.cpp assertion fail under MSVC

### DIFF
--- a/src/Team.cpp
+++ b/src/Team.cpp
@@ -629,7 +629,7 @@ Building *Team::findNearestFood(Unit *unit)
 				if (ti == teamNumber)
 					continue;
 				Team *team = game->teams[ti];
-				if ((!team->sharedVisionFood & me) || (team->allies & me))
+				if (!(team->sharedVisionFood & me) || (team->allies & me))
 					continue;
 				for (std::list<Building *>::iterator bi = team->canFeedUnit.begin(); bi != team->canFeedUnit.end(); ++bi)
 				{
@@ -664,7 +664,7 @@ Building *Team::findNearestFood(Unit *unit)
 				if (ti == teamNumber)
 					continue;
 				Team *team = game->teams[ti];
-				if ((!team->sharedVisionFood & me) || (team->allies & me))
+				if (!(team->sharedVisionFood & me) || (team->allies & me))
 					continue;
 				for (std::list<Building *>::iterator bi = team->canFeedUnit.begin(); bi != team->canFeedUnit.end(); ++bi)
 				{

--- a/src/Team.cpp
+++ b/src/Team.cpp
@@ -1045,13 +1045,15 @@ void Team::syncStep(void)
 	if (buildingsToBeDestroyed.size())
 		buildingsToBeDestroyed.clear();
 
-	for (std::list<Building *>::iterator it=buildingsTryToBuildingSiteRoom.begin(); it!=buildingsTryToBuildingSiteRoom.end(); ++it)
+	for (std::list<Building *>::iterator it=buildingsTryToBuildingSiteRoom.begin(); it!=buildingsTryToBuildingSiteRoom.end();)
 	{
 		if ((*it)->tryToBuildingSiteRoom())
 		{
 			std::list<Building *>::iterator ittemp=it;
 			it=buildingsTryToBuildingSiteRoom.erase(ittemp);
 		}
+		else
+			++it;
 	}
 
 	updateAllBuildingTasks();


### PR DESCRIPTION
This pull request fixes an assertion failure under MSVC when upgrading the hospital at the start of tutorial 4. A for loop in Team::syncStep increments the iterator immediately after erasing an element. When the list only has one element, erasing that element and then incrementing causes an assertion failure which says "Cannot increment end list iterator". I spent a few hours yesterday trying to figure out why it crashes but didn't find the solution until I came across [this stackoverflow post](https://stackoverflow.com/questions/16269696/erasing-while-iterating-an-stdlist) today.

There is also a fix for a logic bug included in this PR.

Fixes #74.