### PR TITLE
Avoid defining snprintf & friends on VS2015+.

### DIFF
--- a/libgag/include/GAGSys.h
+++ b/libgag/include/GAGSys.h
@@ -32,7 +32,7 @@
 
    #define S_IFDIR _S_IFDIR
 
-   #ifndef __MINGW32__
+   #if defined(_MSC_VER) && _MSC_VER < 1900
 	#define snprintf _snprintf
 	#define vsnprintf _vsnprintf
 	#pragma warning (disable : 4786)

--- a/libgag/src/TextStream.cpp
+++ b/libgag/src/TextStream.cpp
@@ -22,7 +22,7 @@
 #include <fstream>
 #include <iostream>
 #include <stack>
-#ifdef WIN32
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf
 #endif

--- a/src/IRC.h
+++ b/src/IRC.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <map>
 
-#ifdef WIN32
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf
 #define strcasecmp _stricmp

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -35,7 +35,7 @@ using ssize_t = SSIZE_T;
 #include "Utilities.h"
 #include "Game.h"
 
-#ifdef WIN32
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #define vsnprintf _vsnprintf
 #endif


### PR DESCRIPTION
Visual Studio 2015 conforms better to the C standard than previous versions and actually has snprintf without the underscore. snprintf [was added](https://stackoverflow.com/a/8712996/8890345) in Visual Studio 2015. A _MSC_VER macro with a value ≥ 1900 [indicates VS2015 or later](https://github.com/cpredef/predef/blob/master/Compilers.md#microsoft-visual-c).

> Beginning with the UCRT in Visual Studio 2015 and Windows 10, vsnprintf is no longer identical to _vsnprintf. The vsnprintf function conforms to the C99 standard; _vnsprintf is kept for backward compatibility with older Visual Studio code.
> – [`vsnprintf`, `_vsnprintf`, `_vsnprintf_l`, `_vsnwprintf`, `_vsnwprintf_l`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l?view=msvc-170)

> Short story: Microsoft has finally implemented snprintf in Visual Studio 2015. On earlier versions you can simulate it as below.
> – [snprintf and Visual Studio 2010](https://stackoverflow.com/a/8712996/8890345)