### PR TITLE
More iterator fixes

### DIFF
--- a/src/AICastor.cpp
+++ b/src/AICastor.cpp
@@ -482,13 +482,15 @@ boost::shared_ptr<Order>AICastor::getOrder()
 	}*/
 		
 	//printf("getOrder(), %d projects\n", projects.size());
-	for (std::list<Project *>::iterator pi=projects.begin(); pi!=projects.end(); pi++)
+	for (std::list<Project *>::iterator pi=projects.begin(); pi!=projects.end();)
 		if ((*pi)->finished)
 		{
 			//printf("deleting project (%s)\n", (*pi)->debugName);
 			delete *pi;
 			pi=projects.erase(pi);
 		}
+		else
+			pi++;
 	bool blocking=false;
 	for (std::list<Project *>::iterator pi=projects.begin(); pi!=projects.end(); pi++)
 		if ((*pi)->blocking)

--- a/src/Sector.cpp
+++ b/src/Sector.cpp
@@ -114,12 +114,13 @@ void Sector::step(void)
 	assert(map);
 	assert(game);
 	
-	for (std::list<Bullet *>::iterator it=bullets.begin();it!=bullets.end();++it)
+	for (std::list<Bullet *>::iterator it=bullets.begin();it!=bullets.end();)
 	{
 		Bullet *bullet = (*it);
 		if ( bullet->ticksLeft > 0 )
 		{
 			bullet->step();
+			++it;
 		}
 		else
 		{
@@ -188,11 +189,12 @@ void Sector::step(void)
 	}
 	
 	// handle explosions timeout
-	for (std::list<BulletExplosion *>::iterator it=explosions.begin();it!=explosions.end();++it)
+	for (std::list<BulletExplosion *>::iterator it=explosions.begin();it!=explosions.end();)
 	{
 		if ( (*it)->ticksLeft > 0 )
 		{
 			(*it)->ticksLeft--;
+			++it;
 		}
 		else
 		{
@@ -202,11 +204,12 @@ void Sector::step(void)
 	}
 
 	// handle death animation
-	for (std::list<UnitDeathAnimation *>::iterator it=deathAnimations.begin();it!=deathAnimations.end();++it)
+	for (std::list<UnitDeathAnimation *>::iterator it=deathAnimations.begin();it!=deathAnimations.end();)
 	{
 		if ( (*it)->ticksLeft > 0 )
 		{
 			(*it)->ticksLeft--;
+			++it;
 		}
 		else
 		{

--- a/src/Team.cpp
+++ b/src/Team.cpp
@@ -991,7 +991,7 @@ void Team::syncStep(void)
 	}
 
 	bool isDirtyGlobalGradient=false;
-	for (std::list<Building *>::iterator it=buildingsWaitingForDestruction.begin(); it!=buildingsWaitingForDestruction.end(); ++it)
+	for (std::list<Building *>::iterator it=buildingsWaitingForDestruction.begin(); it!=buildingsWaitingForDestruction.end();)
 	{
 		Building *building=*it;
 		if (building->unitsInside.size()==0)
@@ -1012,6 +1012,8 @@ void Team::syncStep(void)
 			std::list<Building *>::iterator ittemp=it;
 			it=buildingsWaitingForDestruction.erase(ittemp);
 		}
+		else
+			++it;
 	}
 	if (isDirtyGlobalGradient)
 	{


### PR DESCRIPTION
Here's some more fixes for iterators. See issue #74 and PR #75 for an explanation. I think the assertion failure only happens in debug builds when building with Visual Studio's `cl.exe`, but it *might* be undefined behavior to attempt to increment an iterator that is pointing at the end, so it could cause problems in release builds too. I don't know for sure because I haven't read the C++ draft or bought a copy of C++ standard document. [Is it allowed to increment an end iterator?](https://stackoverflow.com/a/39820063/8890345) says it's undefined.