### PR TITLE
Remove uses of {bi,u}nary_function warned by GCC12.

### DIFF
--- a/libgag/src/GUIFileList.cpp
+++ b/libgag/src/GUIFileList.cpp
@@ -172,9 +172,9 @@ namespace GAGGUI
 		return fullName;
 	}
 	
-	struct strfilecmp_functor : public std::binary_function<std::string, std::string, bool>
+	struct strfilecmp_functor
 	{
-		bool operator()(std::string x, std::string y)
+		bool operator()(const std::string &x, const std::string &y)
 		{
 			bool xIsNotDir = (x[x.length()-1] != DIR_SEPARATOR);
 			bool yIsNotDir = (y[y.length()-1] != DIR_SEPARATOR);

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -320,7 +320,7 @@ void EndGameStat::onSDLMouseMotion(SDL_Event* event)
 
 
 //! This function is used to sort the player array
-struct MoreScore : public std::binary_function<const TeamEntry&, const TeamEntry&, bool>
+struct MoreScore
 {
 	EndOfGameStat::Type type;
 	bool operator()(const TeamEntry& t1, const TeamEntry& t2)

--- a/src/MapHeader.cpp
+++ b/src/MapHeader.cpp
@@ -286,7 +286,7 @@ std::string glob2FilenameToName(const std::string& filename)
 }
 
 template<typename It, typename T>
-class contains: std::unary_function<T, bool>
+class contains
 {
 public:
 	contains(const It from, const It to) : from(from), to(to) {}


### PR DESCRIPTION
These classes were deprecated in C++11 and removed in C++17.

Fixes #55.