### PR TITLE
Fix headless segfaults when loading corrupted save games

### DIFF
--- a/src/GameHeader.cpp
+++ b/src/GameHeader.cpp
@@ -54,6 +54,10 @@ bool GameHeader::load(GAGCore::InputStream *stream, Sint32 versionMinor)
 	gameLatency = stream->readSint32("gameLatency");
 	orderRate = stream->readUint8("orderRate");
 	numberOfPlayers = stream->readSint32("numberOfPlayers");
+	if (numberOfPlayers > Team::MAX_COUNT)
+	{
+		return false;
+	}
 	stream->readEnterSection("players");
 	for(int i=0; i<Team::MAX_COUNT; ++i)
 	{

--- a/src/GlobalContainer.cpp
+++ b/src/GlobalContainer.cpp
@@ -79,6 +79,8 @@ GlobalContainer::GlobalContainer(void)
 	fileManager->addWriteSubdir("videoshots");
 	logFileManager = new LogFileManager(fileManager);
 
+	title = nullptr;
+
 	// load user preference
 	settings.load();
 

--- a/src/MapHeader.cpp
+++ b/src/MapHeader.cpp
@@ -62,6 +62,12 @@ bool MapHeader::load(GAGCore::InputStream *stream)
 	numberOfTeams = stream->readSint32("numberOfTeams");
 	mapOffset = stream->readUint32("mapOffset");
 	isSavedGame = stream->readUint8("isSavedGame");
+
+	if(numberOfTeams > Team::MAX_COUNT)
+	{
+		return false;
+	}
+
 	if(versionMinor==67)
 		stream->readUint32("checksum");
 	


### PR DESCRIPTION
This PR fixes crashes found when fuzzing Globulation 2 [beta4.5-571-gd9e683c8](https://github.com/Globulation2/glob2/commit/d9e683c822e2a66b41968200129c1e9b0534bfa0) in headless mode with [AFL++ 4.07a](https://github.com/AFLplusplus/AFLplusplus) on an openSUSE 15.5 VirtualBox VM.

Fuzzed with `AFL_MAP_SIZE=2097152 afl-fuzz -i input -o output -f testcase.game -- build/src/glob2 -nox testcase.game 1 1` using an Auto_save.game file I happened to have lying around.

Each testcase can be checked with `gdb --ex run --args build/src/glob2 -nox <save file name> 1 1`. Note that, at least in Bash, the colons in the filename need to be escaped with backslashes.

[crashingsaves.zip](https://github.com/Globulation2/glob2/files/11717251/crashingsaves.zip)
[Auto_save.zip](https://github.com/Globulation2/glob2/files/11717261/Auto_save.zip)

