### PR TITLE
Fix the 49 days overflow problem.

### DIFF
--- a/libgag/include/SDLCompat.h
+++ b/libgag/include/SDLCompat.h
@@ -1,0 +1,11 @@
+#include <SDL_version.h>
+// Compatibility shim for SDL before version 2.0.18
+#if SDL_VERSION_ATLEAST(2,0,18)
+// nothing
+#else // older than 2.0.18
+#ifdef MSC_VER
+#define SDL_GetTicks64 SDL_GetTicks
+#else // not MSC_VER
+#define SDL_GetTicks64() SDL_GetTicks()
+#endif // MSC_VER
+#endif // SDL_VERSION_ATLEAST

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -31,18 +31,8 @@
 #include <set>
 #include <boost/tuple/tuple.hpp>
 
-#include <SDL_timer.h>
+#include <SDLCompat.h>
 
-// Compatibility shim for SDL before version 2.0.18
-#if SDL_VERSION_ATLEAST(2,0,18)
-// nothing
-#else // older than 2.0.18
-#ifdef MSC_VER
-#define SDL_GetTicks64 SDL_GetTicks
-#else // not MSC_VER
-#define SDL_GetTicks64() SDL_GetTicks()
-#endif // MSC_VER
-#endif // SDL_VERSION_ATLEAST
 
 namespace GAGCore
 {

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -31,6 +31,19 @@
 #include <set>
 #include <boost/tuple/tuple.hpp>
 
+#include <SDL_timer.h>
+
+// Compatibility shim for SDL before version 2.0.18
+//#if SDL_COMPILED_VERSION < 2018
+#if SDL_VERSION_ATLEAST(2,0,18)
+// nothing
+#else // older than 2.0.18
+#ifdef MSC_VER
+#define SDL_GetTicks64 SDL_GetTicks;
+#else // not MSC_VER
+#define SDL_GetTicks64() SDL_GetTicks();
+#endif // MSC_VER
+#endif // SDL_VERSION_ATLEAST
 
 namespace GAGCore
 {

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -34,14 +34,13 @@
 #include <SDL_timer.h>
 
 // Compatibility shim for SDL before version 2.0.18
-//#if SDL_COMPILED_VERSION < 2018
 #if SDL_VERSION_ATLEAST(2,0,18)
 // nothing
 #else // older than 2.0.18
 #ifdef MSC_VER
-#define SDL_GetTicks64 SDL_GetTicks;
+#define SDL_GetTicks64 SDL_GetTicks
 #else // not MSC_VER
-#define SDL_GetTicks64() SDL_GetTicks();
+#define SDL_GetTicks64() SDL_GetTicks()
 #endif // MSC_VER
 #endif // SDL_VERSION_ATLEAST
 

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -422,8 +422,8 @@ namespace GAGGUI
 	
 	int Screen::execute(DrawableSurface *gfx, int stepLength)
 	{
-		Uint32 frameStartTime;
-		Sint32 frameWaitTime;
+		Uint64 frameStartTime;
+		Sint64 frameWaitTime;
 		
 		this->gfx = gfx;
 	
@@ -440,7 +440,7 @@ namespace GAGGUI
 		while (run)
 		{
 			// get first timer
-			frameStartTime=SDL_GetTicks();
+			frameStartTime=SDL_GetTicks64();
 			
 			// send timer
 			dispatchTimer(frameStartTime);
@@ -522,7 +522,7 @@ namespace GAGGUI
 			dispatchPaint();
 	
 			// wait timer
-			frameWaitTime=SDL_GetTicks()-frameStartTime;
+			frameWaitTime=SDL_GetTicks64()-frameStartTime;
 			frameWaitTime=stepLength-frameWaitTime;
 			if (frameWaitTime>0)
 				SDL_Delay(frameWaitTime);

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -523,7 +523,7 @@ namespace GAGGUI
 			dispatchPaint();
 	
 			// wait timer
-			frameWaitTime=SDL_GetTicks64()-frameStartTime;
+			frameWaitTime=static_cast<Sint64>(SDL_GetTicks64())-static_cast<Sint64>(frameStartTime);
 			frameWaitTime=stepLength-frameWaitTime;
 			if (frameWaitTime>0)
 				SDL_Delay(frameWaitTime);

--- a/libgag/src/GUIBase.cpp
+++ b/libgag/src/GUIBase.cpp
@@ -21,6 +21,7 @@
 #include <GUIStyle.h>
 #include <assert.h>
 #include <GraphicContext.h>
+#include <SDLCompat.h>
 #include <cmath>
 
 #include <Toolkit.h>

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -138,7 +138,7 @@ namespace GAGGUI
 			parentCtx->drawSurface(mbs->decX, mbs->decY, mbs->getSurface());
 			parentCtx->nextFrame();
 			Sint64 newTime = SDL_GetTicks64();
-			SDL_Delay(std::max(40 - newTime + time, 0ll));
+			SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
 		}
 	
 		int retVal;

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -110,7 +110,7 @@ namespace GAGGUI
 		SDL_Event event;
 		while(mbs->endValue<0)
 		{
-			Sint64 time = SDL_GetTicks64();
+			Uint64 time = SDL_GetTicks64();
 			while (SDL_PollEvent(&event))
 			{
 				if (event.type==SDL_QUIT)
@@ -138,8 +138,8 @@ namespace GAGGUI
 			parentCtx->drawSurface((int)0, (int)0, background);
 			parentCtx->drawSurface(mbs->decX, mbs->decY, mbs->getSurface());
 			parentCtx->nextFrame();
-			Sint64 newTime = SDL_GetTicks64();
-			SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
+			Uint64 newTime = SDL_GetTicks64();
+			SDL_Delay(std::max<Sint64>(40ll - static_cast<Sint64>(newTime) + static_cast<Sint64>(time), 0));
 		}
 	
 		int retVal;

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -109,7 +109,7 @@ namespace GAGGUI
 		SDL_Event event;
 		while(mbs->endValue<0)
 		{
-			Sint32 time = SDL_GetTicks();
+			Sint64 time = SDL_GetTicks64();
 			while (SDL_PollEvent(&event))
 			{
 				if (event.type==SDL_QUIT)
@@ -137,8 +137,8 @@ namespace GAGGUI
 			parentCtx->drawSurface((int)0, (int)0, background);
 			parentCtx->drawSurface(mbs->decX, mbs->decY, mbs->getSurface());
 			parentCtx->nextFrame();
-			Sint32 newTime = SDL_GetTicks();
-			SDL_Delay(std::max(40 - newTime + time, 0));
+			Sint64 newTime = SDL_GetTicks64();
+			SDL_Delay(std::max(40 - newTime + time, 0ll));
 		}
 	
 		int retVal;

--- a/libgag/src/GUIMessageBox.cpp
+++ b/libgag/src/GUIMessageBox.cpp
@@ -23,6 +23,7 @@
 #include <GUIButton.h>
 #include <Toolkit.h>
 #include <GraphicContext.h>
+#include <SDLCompat.h>
 #include <algorithm>
 
 using namespace GAGCore;

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -578,7 +578,7 @@ void EndGameScreen::saveReplay(const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
 		Uint64 ntime = SDL_GetTicks64();
-		SDL_Delay(std::max<Uint64>(0, 40 - ntime + time));
+		SDL_Delay(std::max<Sint64>(0, 40ll - static_cast<Sint64>(ntime) + static_cast<Sint64>(time)));
 	}
 
 	if (loadSaveScreen->endValue==0)

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -35,6 +35,7 @@
 #include "GameGUILoadSave.h"
 #include "StreamBackend.h"
 #include "ReplayWriter.h"
+#include "SDLCompat.h"
 
 EndGameStat::EndGameStat(int x, int y, int w, int h, Uint32 hAlign, Uint32 vAlign, Game *game)
 {

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -577,7 +577,7 @@ void EndGameScreen::saveReplay(const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
 		Uint64 ntime = SDL_GetTicks64();
-		SDL_Delay(std::max(0, 40 - ntime + time));
+		SDL_Delay(std::max<Uint64>(0, 40 - ntime + time));
 	}
 
 	if (loadSaveScreen->endValue==0)

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -566,7 +566,7 @@ void EndGameScreen::saveReplay(const char *dir, const char *ext)
 	SDL_Event event;
 	while(loadSaveScreen->endValue<0)
 	{
-		int time = SDL_GetTicks();
+		Uint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			loadSaveScreen->translateAndProcessEvent(&event);
@@ -576,7 +576,7 @@ void EndGameScreen::saveReplay(const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(0, 0, background);
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
-		int ntime = SDL_GetTicks();
+		Uint64 ntime = SDL_GetTicks64();
 		SDL_Delay(std::max(0, 40 - ntime + time));
 	}
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -260,7 +260,7 @@ int Engine::run(void)
 	{
 		assert(globalContainer->mix==NULL);
 		printf("nox::game started\n");
-		automaticGameStartTick = SDL_GetTicks();
+		automaticGameStartTick = SDL_GetTicks64();
 	}
 	else
 	{
@@ -309,8 +309,8 @@ int Engine::run(void)
 		
 		cpuStats.reset(speed);
 		
-		Sint32 needToBeTime = 0;
-		Sint32 startTime = SDL_GetTicks();
+		Sint64 needToBeTime = 0;
+		Sint64 startTime = SDL_GetTicks64();
 		unsigned frameNumber = 0;
 		bool sendBumpUp=false;
 
@@ -345,25 +345,25 @@ int Engine::run(void)
 				{
 					printf("nox::gui.localTeam is dead\n");
 					gui.isRunning = false;
-					automaticGameEndTick = SDL_GetTicks();
+					automaticGameEndTick = SDL_GetTicks64();
 				}
 				else if (gui.getLocalTeam()->hasWon && !globalContainer->automaticGameGlobalEndConditions)
 				{
 					printf("nox::gui.localTeam has won\n");
 					gui.isRunning = false;
-					automaticGameEndTick = SDL_GetTicks();
+					automaticGameEndTick = SDL_GetTicks64();
 				}
 				else if (gui.game.totalPrestigeReached)
 				{
 					printf("nox::gui.game.totalPrestigeReached\n");
 					gui.isRunning = false;
-					automaticGameEndTick = SDL_GetTicks();
+					automaticGameEndTick = SDL_GetTicks64();
 				}
 				else if (gui.game.isGameEnded)
 				{
 					printf("nox::gui.game.isGameEnded\n");
 					gui.isRunning = false;
-					automaticGameEndTick = SDL_GetTicks();
+					automaticGameEndTick = SDL_GetTicks64();
 				}
 			}
 			if(!globalContainer->runNoX && nextGuiStep == 0)
@@ -498,7 +498,7 @@ int Engine::run(void)
 				if ((int)gui.game.stepCounter == globalContainer->automaticEndingSteps)
 				{
 					gui.isRunning = false;
-					automaticGameEndTick = SDL_GetTicks();
+					automaticGameEndTick = SDL_GetTicks64();
 					printf("nox::gui.game.checkSum() = %08x\n", gui.game.checkSum());
 				}
 			}
@@ -523,7 +523,7 @@ int Engine::run(void)
 	
 				// we compute timing
 				needToBeTime += speed;
-				Sint32 currentTime = SDL_GetTicks() - startTime;
+				Sint64 currentTime = SDL_GetTicks64() - startTime;
 				//if we are more than 500 milliseconds behind where we should be,
 				//then truncate it. This is to avoid playing "catchup" for long
 				//periods of time if Glob2 recieved allmost no cpu time
@@ -531,7 +531,7 @@ int Engine::run(void)
 					needToBeTime = currentTime - 500;
 
 				//Any inconsistancies in the delays will be smoothed throughout the following frames,
-				Sint32 delay = std::max(0, needToBeTime - currentTime);
+				Sint64 delay = std::max(0, needToBeTime - currentTime);
 				SDL_Delay(delay);
 				
 				// we set CPU stats

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -41,6 +41,7 @@
 #include "GUIMessageBox.h"
 #include "ReplayReader.h"
 #include "ReplayWriter.h"
+#include "SDLCompat.h"
 
 #include <iostream>
 

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -311,7 +311,7 @@ int Engine::run(void)
 		cpuStats.reset(speed);
 		
 		Sint64 needToBeTime = 0;
-		Sint64 startTime = SDL_GetTicks64();
+		Uint64 startTime = SDL_GetTicks64();
 		unsigned frameNumber = 0;
 		bool sendBumpUp=false;
 
@@ -524,15 +524,15 @@ int Engine::run(void)
 	
 				// we compute timing
 				needToBeTime += speed;
-				Sint64 currentTime = SDL_GetTicks64() - startTime;
+				Sint64 currentTime = static_cast<Sint64>(SDL_GetTicks64()) - static_cast<Sint64>(startTime);
 				//if we are more than 500 milliseconds behind where we should be,
 				//then truncate it. This is to avoid playing "catchup" for long
 				//periods of time if Glob2 recieved allmost no cpu time
-				if(  (currentTime - needToBeTime) > 500)
+				if((currentTime - needToBeTime) > 500)
 					needToBeTime = currentTime - 500;
 
 				//Any inconsistancies in the delays will be smoothed throughout the following frames,
-				Sint64 delay = std::max<Sint64>(0, needToBeTime - currentTime);
+				Uint64 delay = std::max<Sint64>(0, needToBeTime - currentTime);
 				SDL_Delay(delay);
 				
 				// we set CPU stats

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -531,7 +531,7 @@ int Engine::run(void)
 					needToBeTime = currentTime - 500;
 
 				//Any inconsistancies in the delays will be smoothed throughout the following frames,
-				Sint64 delay = std::max(0, needToBeTime - currentTime);
+				Sint64 delay = std::max<Sint64>(0, needToBeTime - currentTime);
 				SDL_Delay(delay);
 				
 				// we set CPU stats

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -135,7 +135,7 @@ private:
 
 	CPUStatisticsManager cpuStats;
 
-	Sint64 automaticGameStartTick, automaticGameEndTick;
+	Uint64 automaticGameStartTick, automaticGameEndTick;
 
 	FILE *logFile;
 

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -135,7 +135,7 @@ private:
 
 	CPUStatisticsManager cpuStats;
 
-	Sint32 automaticGameStartTick, automaticGameEndTick;
+	Sint64 automaticGameStartTick, automaticGameEndTick;
 
 	FILE *logFile;
 

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -66,7 +66,7 @@ void FertilityCalculatorDialog::execute()
 	SDL_Event event;
 	while(endValue<0)
 	{
-		Sint64 time = SDL_GetTicks64();
+		Uint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type==SDL_QUIT)
@@ -95,8 +95,8 @@ void FertilityCalculatorDialog::execute()
 		parentCtx->drawSurface((int)0, (int)0, background);
 		parentCtx->drawSurface(decX, decY, getSurface());
 		parentCtx->nextFrame();
-		Sint64 newTime = SDL_GetTicks64();
-		SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
+		Uint64 newTime = SDL_GetTicks64();
+		SDL_Delay(std::max<Sint64>(40ll - static_cast<Sint64>(newTime) + static_cast<Sint64>(time), 0));
 	}
 	
 	delete background;

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -95,7 +95,7 @@ void FertilityCalculatorDialog::execute()
 		parentCtx->drawSurface(decX, decY, getSurface());
 		parentCtx->nextFrame();
 		Sint64 newTime = SDL_GetTicks64();
-		SDL_Delay(std::max(40 - newTime + time, 0));
+		SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
 	}
 	
 	delete background;

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include "StringTable.h"
 #include "Toolkit.h"
+#include "SDLCompat.h"
 
 using namespace GAGCore;
 using namespace GAGGUI;

--- a/src/FertilityCalculatorDialog.cpp
+++ b/src/FertilityCalculatorDialog.cpp
@@ -65,7 +65,7 @@ void FertilityCalculatorDialog::execute()
 	SDL_Event event;
 	while(endValue<0)
 	{
-		Sint32 time = SDL_GetTicks();
+		Sint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type==SDL_QUIT)
@@ -94,7 +94,7 @@ void FertilityCalculatorDialog::execute()
 		parentCtx->drawSurface((int)0, (int)0, background);
 		parentCtx->drawSurface(decX, decY, getSurface());
 		parentCtx->nextFrame();
-		Sint32 newTime = SDL_GetTicks();
+		Sint64 newTime = SDL_GetTicks64();
 		SDL_Delay(std::max(40 - newTime + time, 0));
 	}
 	

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1311,7 +1311,7 @@ void Game::syncStep(Sint32 localTeam)
 			globalContainer->replayWriter->advanceStep();
 		}
 
-		Sint64 startTick=SDL_GetTicks64();
+		Uint64 startTick=SDL_GetTicks64();
 
 		for (int i=0; i<mapHeader.getNumberOfTeams(); i++)
 			teams[i]->syncStep();
@@ -1349,8 +1349,8 @@ void Game::syncStep(Sint32 localTeam)
 			wonSyncStep();
 		}
 
-		Sint64 endTick=SDL_GetTicks64();
-		ticksGameSum[stepCounter&31]+=endTick-startTick;
+		Uint64 endTick=SDL_GetTicks64();
+		ticksGameSum[stepCounter&31]+=static_cast<Sint64>(endTick) - static_cast<Sint64>(startTick);
 		stepCounter++;
 		anyPlayerWaitedTimeFor+=1;
 	}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1310,7 +1310,7 @@ void Game::syncStep(Sint32 localTeam)
 			globalContainer->replayWriter->advanceStep();
 		}
 
-		Sint32 startTick=SDL_GetTicks();
+		Sint64 startTick=SDL_GetTicks64();
 
 		for (int i=0; i<mapHeader.getNumberOfTeams(); i++)
 			teams[i]->syncStep();
@@ -1348,7 +1348,7 @@ void Game::syncStep(Sint32 localTeam)
 			wonSyncStep();
 		}
 
-		Sint32 endTick=SDL_GetTicks();
+		Sint64 endTick=SDL_GetTicks64();
 		ticksGameSum[stepCounter&31]+=endTick-startTick;
 		stepCounter++;
 		anyPlayerWaitedTimeFor+=1;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -47,6 +47,7 @@
 #include "Integrity.h"
 #include "Utilities.h"
 #include "GameGUI.h"
+#include "SDLCompat.h"
 
 #include "MapEdit.h"
 

--- a/src/GameGUIMessageManager.cpp
+++ b/src/GameGUIMessageManager.cpp
@@ -19,6 +19,7 @@
 #include "GameGUIMessageManager.h"
 #include "GlobalContainer.h"
 #include "GUIList.h"
+#include "SDLCompat.h"
 
 InGameMessage::InGameMessage(const std::string& text, const GAGCore::Color& color, int time)
  : timeLeft(time), text(text), color(color)

--- a/src/GameGUIMessageManager.cpp
+++ b/src/GameGUIMessageManager.cpp
@@ -41,7 +41,7 @@ void InGameMessage::draw(int x, int y)
 	Uint64 newTime = SDL_GetTicks64();
 	if(lastTime != 0)
 	{
-		timeLeft -=  (newTime - lastTime);
+		timeLeft -= std::max<Sint64>(static_cast<Sint64>(newTime) - static_cast<Sint64>(lastTime), 0);
 		timeLeft = std::max(0, timeLeft);
 	}
 	lastTime = newTime;

--- a/src/GameGUIMessageManager.cpp
+++ b/src/GameGUIMessageManager.cpp
@@ -37,7 +37,7 @@ std::string InGameMessage::getText() const
 
 void InGameMessage::draw(int x, int y)
 {
-	Uint32 newTime = SDL_GetTicks();
+	Uint64 newTime = SDL_GetTicks64();
 	if(lastTime != 0)
 	{
 		timeLeft -=  (newTime - lastTime);

--- a/src/GameGUIMessageManager.h
+++ b/src/GameGUIMessageManager.h
@@ -50,7 +50,7 @@ protected:
 	void draw(int x, int y);
 	int timeLeft;
 private:
-	Uint32 lastTime;
+	Uint64 lastTime;
 	std::string text;
 	GAGCore::Color color;
 };

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1321,7 +1321,7 @@ int MapEdit::run(void)
 		
 
 		endTick=SDL_GetTicks64();
-		deltaTick=endTick-startTick;
+		deltaTick=std::max<Sint64>(0, static_cast<Sint64>(endTick) - static_cast<Sint64>(startTick));
 		if (deltaTick<33)
 			SDL_Delay(33-deltaTick);
 		if (returnCode==-1)

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -1228,11 +1228,11 @@ int MapEdit::run(void)
 
 	bool isRunning=true;
 	int returnCode=0;
-	Uint32 startTick, endTick, deltaTick;
+	Uint64 startTick, endTick, deltaTick;
 	while (isRunning)
 	{
 		//SDL_Event event;
-		startTick=SDL_GetTicks();
+		startTick=SDL_GetTicks64();
 	
 		// we get all pending events but for mousemotion we only keep the last one
 		SDL_Event event;
@@ -1319,7 +1319,7 @@ int MapEdit::run(void)
 		globalContainer->gfx->nextFrame();
 		
 
-		endTick=SDL_GetTicks();
+		endTick=SDL_GetTicks64();
 		deltaTick=endTick-startTick;
 		if (deltaTick<33)
 			SDL_Delay(33-deltaTick);

--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -37,6 +37,7 @@
 #include "Utilities.h"
 #include "FertilityCalculatorDialog.h"
 #include "GUIMessageBox.h"
+#include "SDLCompat.h"
 
 
 #define RIGHT_MENU_WIDTH 160

--- a/src/NetBroadcastListener.cpp
+++ b/src/NetBroadcastListener.cpp
@@ -21,6 +21,7 @@
 #include "Stream.h"
 #include "BinaryStream.h"
 #include "StreamBackend.h"
+#include "SDLGraphicContext.h" // for SDL_GetTicks64 #define
 #include <iostream>
 #include <sstream>
 

--- a/src/NetBroadcastListener.cpp
+++ b/src/NetBroadcastListener.cpp
@@ -81,7 +81,7 @@ void NetBroadcastListener::update()
 			result = SDLNet_UDP_Recv(socket, packet);
 		}
 		
-		Uint64 time = SDL_GetTicks64() - lastTime;
+		Uint64 time = std::max<Sint64>(0, static_cast<Sint64>(SDL_GetTicks64()) - static_cast<Sint64>(lastTime));
 		for(unsigned int i=0; i<timeouts.size();)
 		{
 			timeouts[i] -= time;

--- a/src/NetBroadcastListener.cpp
+++ b/src/NetBroadcastListener.cpp
@@ -21,7 +21,7 @@
 #include "Stream.h"
 #include "BinaryStream.h"
 #include "StreamBackend.h"
-#include "SDLGraphicContext.h" // for SDL_GetTicks64 #define
+#include <SDLCompat.h>
 #include <iostream>
 #include <sstream>
 

--- a/src/NetBroadcastListener.cpp
+++ b/src/NetBroadcastListener.cpp
@@ -29,7 +29,7 @@ using namespace GAGCore;
 NetBroadcastListener::NetBroadcastListener()
 {
 	enableListening();
-	lastTime = SDL_GetTicks();
+	lastTime = SDL_GetTicks64();
 }
 
 
@@ -80,7 +80,7 @@ void NetBroadcastListener::update()
 			result = SDLNet_UDP_Recv(socket, packet);
 		}
 		
-		int time = SDL_GetTicks() - lastTime;
+		Uint64 time = SDL_GetTicks64() - lastTime;
 		for(unsigned int i=0; i<timeouts.size();)
 		{
 			timeouts[i] -= time;
@@ -95,7 +95,7 @@ void NetBroadcastListener::update()
 				++i;
 			}
 		}
-		lastTime = SDL_GetTicks();
+		lastTime = SDL_GetTicks64();
 	}
 }
 

--- a/src/NetBroadcastListener.h
+++ b/src/NetBroadcastListener.h
@@ -51,7 +51,7 @@ private:
 	std::vector<LANGameInformation> games;
 	std::vector<int> timeouts;
 	std::vector<IPaddress> addresses;
-	Uint32 lastTime;
+	Uint64 lastTime;
 };
 
 #endif

--- a/src/NetBroadcaster.cpp
+++ b/src/NetBroadcaster.cpp
@@ -21,7 +21,7 @@
 #include "Stream.h"
 #include "BinaryStream.h"
 #include "StreamBackend.h"
-#include "SDLGraphicContext.h" // for SDL_GetTicks64 fallback
+#include "SDLCompat.h" // for SDL_GetTicks64 fallback
 #include <iostream>
 #include "boost/lexical_cast.hpp"
 

--- a/src/NetBroadcaster.cpp
+++ b/src/NetBroadcaster.cpp
@@ -21,6 +21,7 @@
 #include "Stream.h"
 #include "BinaryStream.h"
 #include "StreamBackend.h"
+#include "SDLGraphicContext.h" // for SDL_GetTicks64 fallback
 #include <iostream>
 #include "boost/lexical_cast.hpp"
 

--- a/src/NetBroadcaster.cpp
+++ b/src/NetBroadcaster.cpp
@@ -53,7 +53,7 @@ void NetBroadcaster::update()
 {
 	if(socket)
 	{
-		Uint32 time = SDL_GetTicks();
+		Uint64 time = SDL_GetTicks64();
 		if((time - lastTime) >= 500 )
 		{
 			MemoryStreamBackend* msb = new MemoryStreamBackend;
@@ -127,7 +127,7 @@ void NetBroadcaster::enableBroadcasting()
 	SDLNet_ResolveHost(&localaddress, "127.0.0.1", LAN_BROADCAST_PORT);
 	SDLNet_UDP_Bind(localsocket, 0, &localaddress);
 	
-	lastTime = SDL_GetTicks();
+	lastTime = SDL_GetTicks64();
 }
 
 

--- a/src/NetBroadcaster.cpp
+++ b/src/NetBroadcaster.cpp
@@ -55,7 +55,7 @@ void NetBroadcaster::update()
 	if(socket)
 	{
 		Uint64 time = SDL_GetTicks64();
-		if((time - lastTime) >= 500 )
+		if((static_cast<Sint64>(time) - static_cast<Sint64>(lastTime)) >= 500 )
 		{
 			MemoryStreamBackend* msb = new MemoryStreamBackend;
 			BinaryOutputStream* bos = new BinaryOutputStream(msb);

--- a/src/NetBroadcaster.h
+++ b/src/NetBroadcaster.h
@@ -46,7 +46,7 @@ private:
 	LANGameInformation info;
 	UDPsocket socket;
 	UDPsocket localsocket;
-	Uint32 lastTime;
+	Uint64 lastTime;
 	Uint32 timer;
 };
 

--- a/src/NetConnectionThread.cpp
+++ b/src/NetConnectionThread.cpp
@@ -20,6 +20,7 @@
 #include "StreamBackend.h"
 #include "BinaryStream.h"
 #include "NetMessage.h"
+#include "SDLCompat.h"
 #include "boost/lexical_cast.hpp"
 
 using namespace GAGCore;

--- a/src/ScriptEditorScreen.cpp
+++ b/src/ScriptEditorScreen.cpp
@@ -568,7 +568,7 @@ void ScriptEditorScreen::loadSave(bool isLoad, const char *dir, const char *ext)
 	SDL_Event event;
 	while(loadSaveScreen->endValue<0)
 	{
-		int time = SDL_GetTicks();
+		Uint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			loadSaveScreen->translateAndProcessEvent(&event);
@@ -578,7 +578,7 @@ void ScriptEditorScreen::loadSave(bool isLoad, const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(0, 0, background);
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
-		int ntime = SDL_GetTicks();
+		Uint64 ntime = SDL_GetTicks64();
 		SDL_Delay(std::max(0, 40 - ntime + time));
 	}
 

--- a/src/ScriptEditorScreen.cpp
+++ b/src/ScriptEditorScreen.cpp
@@ -581,7 +581,7 @@ void ScriptEditorScreen::loadSave(bool isLoad, const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
 		Uint64 ntime = SDL_GetTicks64();
-		SDL_Delay(std::max<Uint64>(0, 40 - ntime + time));
+		SDL_Delay(std::max<Sint64>(0, 40ll - static_cast<Sint64>(ntime) + static_cast<Sint64>(time)));
 	}
 
 	if (loadSaveScreen->endValue==0)

--- a/src/ScriptEditorScreen.cpp
+++ b/src/ScriptEditorScreen.cpp
@@ -35,6 +35,8 @@ using namespace GAGCore;
 #include <GUITextInput.h>
 using namespace GAGGUI;
 
+#include "SDLCompat.h"
+
 #include "MapScript.h"
 
 #include <algorithm>

--- a/src/ScriptEditorScreen.cpp
+++ b/src/ScriptEditorScreen.cpp
@@ -579,7 +579,7 @@ void ScriptEditorScreen::loadSave(bool isLoad, const char *dir, const char *ext)
 		globalContainer->gfx->drawSurface(loadSaveScreen->decX, loadSaveScreen->decY, loadSaveScreen->getSurface());
 		globalContainer->gfx->nextFrame();
 		Uint64 ntime = SDL_GetTicks64();
-		SDL_Delay(std::max(0, 40 - ntime + time));
+		SDL_Delay(std::max<Uint64>(0, 40 - ntime + time));
 	}
 
 	if (loadSaveScreen->endValue==0)

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include "StringTable.h"
 #include "Toolkit.h"
+#include "SDLCompat.h"
 
 using namespace GAGCore;
 using namespace GAGGUI;

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -61,7 +61,7 @@ void YOGClientGameConnectionDialog::execute()
 	SDL_Event event;
 	while(endValue<0)
 	{
-		Sint32 time = SDL_GetTicks();
+		Sint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type==SDL_QUIT)
@@ -94,7 +94,7 @@ void YOGClientGameConnectionDialog::execute()
 		parentCtx->drawSurface(decX, decY, getSurface());
 		parentCtx->nextFrame();
 		updateGame();
-		Sint32 newTime = SDL_GetTicks();
+		Sint64 newTime = SDL_GetTicks64();
 		SDL_Delay(std::max(40 - newTime + time, 0));
 	}
 	

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -62,7 +62,7 @@ void YOGClientGameConnectionDialog::execute()
 	SDL_Event event;
 	while(endValue<0)
 	{
-		Sint64 time = SDL_GetTicks64();
+		Uint64 time = SDL_GetTicks64();
 		while (SDL_PollEvent(&event))
 		{
 			if (event.type==SDL_QUIT)
@@ -95,8 +95,8 @@ void YOGClientGameConnectionDialog::execute()
 		parentCtx->drawSurface(decX, decY, getSurface());
 		parentCtx->nextFrame();
 		updateGame();
-		Sint64 newTime = SDL_GetTicks64();
-		SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
+		Uint64 newTime = SDL_GetTicks64();
+		SDL_Delay(std::max<Sint64>(40ll - static_cast<Sint64>(newTime) + static_cast<Sint64>(time), 0));
 	}
 	
 	delete background;

--- a/src/YOGClientGameConnectionDialog.cpp
+++ b/src/YOGClientGameConnectionDialog.cpp
@@ -95,7 +95,7 @@ void YOGClientGameConnectionDialog::execute()
 		parentCtx->nextFrame();
 		updateGame();
 		Sint64 newTime = SDL_GetTicks64();
-		SDL_Delay(std::max(40 - newTime + time, 0));
+		SDL_Delay(std::max<Sint64>(40 - newTime + time, 0));
 	}
 	
 	delete background;

--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -155,7 +155,7 @@ int YOGServer::run()
 		startTick = SDL_GetTicks64();
 		update();
 		endTick=SDL_GetTicks64();
-		int remaining = std::max(speed - endTick + startTick, 0);
+		int remaining = std::max<Uint64>(speed - endTick + startTick, 0);
 		SDL_Delay(remaining);
 	}
 	std::cout<<nl.isListening()<<std::endl;

--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -118,7 +118,7 @@ void YOGServer::update()
 	maps.update();
 	fileDistributionManager.update();
 	
-	int t = SDL_GetTicks();
+	Uint64 t = SDL_GetTicks64();
 	if(organizedGameTimeEnabled)
 	{
 		if(t > organizedGameBroadcastTime)
@@ -151,10 +151,10 @@ int YOGServer::run()
 	while(nl.isListening())
 	{
 		const int speed = 20;
-		int startTick, endTick;
-		startTick = SDL_GetTicks();
+		Uint64 startTick, endTick;
+		startTick = SDL_GetTicks64();
 		update();
-		endTick=SDL_GetTicks();
+		endTick=SDL_GetTicks64();
 		int remaining = std::max(speed - endTick + startTick, 0);
 		SDL_Delay(remaining);
 	}

--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -156,7 +156,7 @@ int YOGServer::run()
 		startTick = SDL_GetTicks64();
 		update();
 		endTick=SDL_GetTicks64();
-		int remaining = std::max<Uint64>(speed - endTick + startTick, 0);
+		int remaining = std::max<Sint64>(speed - static_cast<Sint64>(endTick) + static_cast<Sint64>(startTick), 0);
 		SDL_Delay(remaining);
 	}
 	std::cout<<nl.isListening()<<std::endl;

--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -27,6 +27,7 @@
 #include "YOGServer.h"
 #include "YOGServerPlayer.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
+#include "SDLCompat.h"
 
 YOGServer::YOGServer(YOGLoginPolicy loginPolicy, YOGGamePolicy gamePolicy)
 	: loginPolicy(loginPolicy), gamePolicy(gamePolicy), administrator(this), playerInfos(this), routerManager(*this), router("localhost"), maps(this), scoreCalculator(this)

--- a/src/YOGServer.h
+++ b/src/YOGServer.h
@@ -169,7 +169,7 @@ private:
 	void removeGameInfo(Uint16 gameID);
 
 	///This represents the next time when the message will be broad casted that a game is organized
-	int organizedGameBroadcastTime;
+	Uint64 organizedGameBroadcastTime;
 	static const bool organizedGameTimeEnabled = false;
 
 	NetListener nl;

--- a/src/YOGServerGame.cpp
+++ b/src/YOGServerGame.cpp
@@ -43,7 +43,7 @@ YOGServerGame::YOGServerGame(Uint16 gameID, Uint32 chatChannel, const std::strin
 
 void YOGServerGame::update()
 {
-	if((SDL_GetTicks64() - latencyUpdateTimer) > 4000)
+	if((static_cast<Sint64>(SDL_GetTicks64()) - static_cast<Sint64>(latencyUpdateTimer)) > 4000)
 	{
 		chooseLatencyMode();
 	}

--- a/src/YOGServerGame.cpp
+++ b/src/YOGServerGame.cpp
@@ -24,6 +24,7 @@
 #include "YOGServerFileDistributor.h"
 #include "YOGServerPlayer.h"
 #include "YOGAfterJoinGameInformation.h"
+#include "SDLCompat.h"
 
 YOGServerGame::YOGServerGame(Uint16 gameID, Uint32 chatChannel, const std::string& routerIP, YOGServer& server)
 	: playerManager(gameHeader), gameID(gameID), chatChannel(chatChannel), routerIP(routerIP), server(server)

--- a/src/YOGServerGame.cpp
+++ b/src/YOGServerGame.cpp
@@ -34,7 +34,7 @@ YOGServerGame::YOGServerGame(Uint16 gameID, Uint32 chatChannel, const std::strin
 	recievedMapHeader=false;
 	hasAddedHost=false;
 	latencyMode = 0;
-	latencyUpdateTimer = SDL_GetTicks();
+	latencyUpdateTimer = SDL_GetTicks64();
 	aiNum = 0;
 	mapFile = server.getFileDistributionManager().allocateFileDistributor();
 }
@@ -42,7 +42,7 @@ YOGServerGame::YOGServerGame(Uint16 gameID, Uint32 chatChannel, const std::strin
 
 void YOGServerGame::update()
 {
-	if((SDL_GetTicks() - latencyUpdateTimer) > 4000)
+	if((SDL_GetTicks64() - latencyUpdateTimer) > 4000)
 	{
 		chooseLatencyMode();
 	}
@@ -356,7 +356,7 @@ Uint16 YOGServerGame::getHostPlayerID() const
 
 void YOGServerGame::chooseLatencyMode()
 {
-	latencyUpdateTimer=SDL_GetTicks();
+	latencyUpdateTimer=SDL_GetTicks64();
 	
 	unsigned highest = 0;
 	unsigned second_highest = 0;

--- a/src/YOGServerGame.h
+++ b/src/YOGServerGame.h
@@ -130,7 +130,7 @@ private:
 	boost::shared_ptr<YOGServerPlayer> host;
 	GameHeader gameHeader;
 	int latencyMode;
-	int latencyUpdateTimer;
+	Uint64 latencyUpdateTimer;
 	Uint32 mapFile;
 	MapHeader mapHeader;
 	NetGamePlayerManager playerManager;

--- a/src/YOGServerPlayer.cpp
+++ b/src/YOGServerPlayer.cpp
@@ -34,7 +34,7 @@ YOGServerPlayer::YOGServerPlayer(shared_ptr<NetConnection> connection, Uint16 id
 	loginState = YOGLoginUnknown;
 	gameID=0;
 	netVersion=0;
-	pingCountdown=SDL_GetTicks();
+	pingCountdown=SDL_GetTicks64();
 	pingSendTime=0;
 	port = 0;
 }
@@ -47,11 +47,11 @@ void YOGServerPlayer::update()
 	updateConnectionSates();
 	updateGamePlayerLists();
 
-	if(SDL_GetTicks() - pingCountdown > 5000 && pingCountdown != 0)
+	if(SDL_GetTicks64() - pingCountdown > 5000 && pingCountdown != 0)
 	{
 		shared_ptr<NetPing> message(new NetPing);
 		connection->sendMessage(message);
-		pingSendTime = SDL_GetTicks();
+		pingSendTime = SDL_GetTicks64();
 		pingCountdown = 0;
 	}
 
@@ -256,11 +256,11 @@ void YOGServerPlayer::update()
 	else if(type==MNetPingReply)
 	{
 		shared_ptr<NetPingReply> info = static_pointer_cast<NetPingReply>(message);
-		pings.push_back(SDL_GetTicks() - pingSendTime);
+		pings.push_back(SDL_GetTicks64() - pingSendTime);
 		if(pings.size() > 16)
 			pings.erase(pings.begin());
 
-		pingCountdown = SDL_GetTicks();
+		pingCountdown = SDL_GetTicks64();
 	}
 	//This recieves a ping reply
 	else if(type==MNetSendGameResult)

--- a/src/YOGServerPlayer.cpp
+++ b/src/YOGServerPlayer.cpp
@@ -48,7 +48,7 @@ void YOGServerPlayer::update()
 	updateConnectionSates();
 	updateGamePlayerLists();
 
-	if(SDL_GetTicks64() - pingCountdown > 5000 && pingCountdown != 0)
+	if((static_cast<Sint64>(SDL_GetTicks64()) - static_cast<Sint64>(pingCountdown)) > 5000 && pingCountdown != 0)
 	{
 		shared_ptr<NetPing> message(new NetPing);
 		connection->sendMessage(message);
@@ -257,7 +257,7 @@ void YOGServerPlayer::update()
 	else if(type==MNetPingReply)
 	{
 		shared_ptr<NetPingReply> info = static_pointer_cast<NetPingReply>(message);
-		pings.push_back(SDL_GetTicks64() - pingSendTime);
+		pings.push_back(std::max<Sint64>(0, static_cast<Sint64>(SDL_GetTicks64()) - static_cast<Sint64>(pingSendTime)));
 		if(pings.size() > 16)
 			pings.erase(pings.begin());
 

--- a/src/YOGServerPlayer.cpp
+++ b/src/YOGServerPlayer.cpp
@@ -22,6 +22,7 @@
 #include "YOGServer.h"
 #include "YOGServerFileDistributor.h"
 #include "YOGServerPlayer.h"
+#include "SDLCompat.h"
 
 using boost::static_pointer_cast;
 

--- a/src/YOGServerPlayer.h
+++ b/src/YOGServerPlayer.h
@@ -160,7 +160,7 @@ private:
 	///Counts down between sending a ping
 	Uint64 pingCountdown;
 	///This says the time when the ping was sent, 0 means not waiting on ping reply
-	unsigned pingSendTime;
+	Uint64 pingSendTime;
 	///This holds the most recent 5 pings
 	std::list<Uint64> pings;
 	

--- a/src/YOGServerPlayer.h
+++ b/src/YOGServerPlayer.h
@@ -158,11 +158,11 @@ private:
 	weak_ptr<YOGServerGame> game;
 
 	///Counts down between sending a ping
-	Uint32 pingCountdown;
+	Uint64 pingCountdown;
 	///This says the time when the ping was sent, 0 means not waiting on ping reply
 	unsigned pingSendTime;
 	///This holds the most recent 5 pings
-	std::list<unsigned> pings;
+	std::list<Uint64> pings;
 	
 };
 

--- a/src/YOGServerRouter.cpp
+++ b/src/YOGServerRouter.cpp
@@ -132,10 +132,10 @@ int YOGServerRouter::run()
 	while(nl.isListening())
 	{
 		const int speed = 25;
-		int startTick, endTick;
-		startTick = SDL_GetTicks();
+		Uint64 startTick, endTick;
+		startTick = SDL_GetTicks64();
 		update();
-		endTick=SDL_GetTicks();
+		endTick=SDL_GetTicks64();
 		int remaining = std::max(speed - endTick + startTick, 0);
 		SDL_Delay(remaining);
 		

--- a/src/YOGServerRouter.cpp
+++ b/src/YOGServerRouter.cpp
@@ -26,6 +26,7 @@
 #include "YOGServerGameRouter.h"
 #include "YOGServerRouter.h"
 #include "YOGServerRouterPlayer.h"
+#include "SDLCompat.h"
 #include <sstream>
 
 using namespace GAGCore;

--- a/src/YOGServerRouter.cpp
+++ b/src/YOGServerRouter.cpp
@@ -137,7 +137,7 @@ int YOGServerRouter::run()
 		startTick = SDL_GetTicks64();
 		update();
 		endTick=SDL_GetTicks64();
-		int remaining = std::max<Uint64>(speed - endTick + startTick, 0);
+		int remaining = std::max<Sint64>(speed - static_cast<Sint64>(endTick) + static_cast<Sint64>(startTick), 0);
 		SDL_Delay(remaining);
 		
 		if(shutdownMode)

--- a/src/YOGServerRouter.cpp
+++ b/src/YOGServerRouter.cpp
@@ -136,7 +136,7 @@ int YOGServerRouter::run()
 		startTick = SDL_GetTicks64();
 		update();
 		endTick=SDL_GetTicks64();
-		int remaining = std::max(speed - endTick + startTick, 0);
+		int remaining = std::max<Uint64>(speed - endTick + startTick, 0);
 		SDL_Delay(remaining);
 		
 		if(shutdownMode)


### PR DESCRIPTION
As explained in #80, SDL_GetTicks will overflow to 0 after about 49 days, because it uses a 32-bit unsigned type to store milliseconds rather than a 64-bit type. This PR fixes that and also changes the assigned variables to be 64-bit.

Put compatibility shim in place for SDL < 2.0.18.

Fixes #80.