### PR TITLE
WIP: Fix campaign editor

### DIFF
--- a/src/CampaignEditor.cpp
+++ b/src/CampaignEditor.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "CampaignEditor.h"
+#include "MapEdit.h"
 #include "Toolkit.h"
 #include "StringTable.h"
 #include "ChooseMapScreen.h"
@@ -173,6 +174,7 @@ CampaignMapEntryEditor::CampaignMapEntryEditor(Campaign& campaign, CampaignMapEn
 	descriptionEditor = new TextArea(420, 195, 180, 225, ALIGN_SCREEN_CENTERED, ALIGN_SCREEN_CENTERED, "standard", false, entry.getDescription().c_str());
 	ok = new TextButton(260, 430, 180, 40, ALIGN_SCREEN_CENTERED, ALIGN_SCREEN_CENTERED, "menu", table.getString("[ok]"), OK);
 	cancel = new TextButton(450, 430, 180, 40, ALIGN_SCREEN_CENTERED, ALIGN_SCREEN_CENTERED, "menu", table.getString("[Cancel]"), CANCEL);
+	editMap = new TextButton(10, 430, 150, 40, ALIGN_SCREEN_CENTERED, ALIGN_SCREEN_CENTERED, "menu", table.getString("[edit map]"), EDITMAP);
 
 	std::set<std::string> unlockedBy;
 	for(unsigned n=0; n<entry.getUnlockedByMaps().size(); ++n)
@@ -204,6 +206,7 @@ CampaignMapEntryEditor::CampaignMapEntryEditor(Campaign& campaign, CampaignMapEn
 	addWidget(descriptionEditor);
 	addWidget(ok);
 	addWidget(cancel);
+	addWidget(editMap);
 }
 
 
@@ -243,6 +246,13 @@ void CampaignMapEntryEditor::onAction(Widget *source, Action action, int par1, i
 		else if (source == cancel)
 		{
 			endExecute(CANCEL);
+		}
+		else if (source == editMap)
+		{
+			MapEdit mapEdit;
+			mapEdit.load(entry.getMapFileName());
+			if (mapEdit.run() == -1)
+				endExecute(-1);
 		}
 	}
 	else if(action == TEXT_ACTIVATED)

--- a/src/CampaignEditor.h
+++ b/src/CampaignEditor.h
@@ -77,6 +77,7 @@ public:
 		OK,
 		CANCEL,
 		ISLOCKED,
+		EDITMAP
 	};
 private:
 	CampaignMapEntry& entry;
@@ -87,6 +88,8 @@ private:
 	Button *ok;
 	/// The cancel button
 	Button *cancel;
+	/// Actually edit the map for real
+	Button* editMap;
 	/// List of maps that unlock the map thats being edited
 	CheckList* mapsUnlockedBy;
 	/// The label for mapsUnlockedBy


### PR DESCRIPTION
The campaign editor has been broken since at least April 30th.

When attempting to edit one of the four maps in the tutorial campaign, clicking Edit Map allows you to edit the translation key, name, and which maps it is unlocked by. Clicking Ok on the "Campaign Editor" screen (level select) goes from that menu back to the screen which just says "Editor", strangely enough. Clicking Edit Map goes to the **CampaignMapEntryEditor** class. It's `onAction` method would probably be the place to add another edit button that launches **MapEdit**.

TODO:
- [ ] Campaign maps are saved in wrong folder when saving. I should add some code to check if the map saved successfully, and if so, backup *campaigns/tutorial-N.map* and then overwrite it with *maps/tutorial-N.map*