### PR TITLE
Fix using plain delete on a new[] array allocation.

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -364,12 +364,12 @@ void Game::executeOrder(boost::shared_ptr<Order> order, int localPlayer)
 						b->locked[i]=false;
 						if (b->globalGradient[i])
 						{
-							delete b->globalGradient[i];
+							delete[] b->globalGradient[i];
 							b->globalGradient[i]=NULL;
 						}
 						if (b->localRessources[i])
 						{
-							delete b->localRessources[i];
+							delete[] b->localRessources[i];
 							b->localRessources[i]=NULL;
 						}
 					}


### PR DESCRIPTION
Found a bug in beta4.5-574-g39980149. The game crashes when I go through tutorial 4 with `-fsanitize=address,leak` passed when compiling with g++ 7.5:
delete is called at Game.cpp:367 when delete[] should be called instead. An array is allocated at Map::buildingAvailable at line 4055 with new[] and then later deleted by plain delete.

_Map::buildingAvailable()_ (at [Map.cpp:4055](https://github.com/Globulation2/glob2/blob/f5f9bffb57ce70c1d0e98e93691da245e614e0a3/src/Map.cpp#L4055)) and _Map::updateLocalRessources()_ (at [Map.cpp:3754](https://github.com/Globulation2/glob2/blob/f5f9bffb57ce70c1d0e98e93691da245e614e0a3/src/Map.cpp#L4055)) both allocate with `new[]`, and the allocation is later deallocated in _Game::executeOrder_, but with the wrong type of `delete`.

I found this bug with AddressSanitizer while trying to fix the libUSL leak. To get an AddressSanitizer build going, I ran `scons CXXFLAGS='-g3 -Og -fsanitize=address,leak -fno-omit-frame-pointer' LINKFLAGS='-g3 -fsanitize=address,leak' -j6 --build=build_asan`

This bug is harmless on Linux where the allocation and deallocation functions work properly if you mix array and plain new/delete, but on some operating systems it can cause crashes if one mixes them, according to [Valgrind Memcheck manual](https://valgrind.org/docs/manual/mc-manual.html#mc-manual.rudefn).

<details>

<summary> First mismatch I found: </summary>

```
libpng warning: iCCP: known incorrect sRGB profile
libpng warning: iCCP: known incorrect sRGB profile
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate Y=45 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate X=52 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate X=53 for team 1 building 9 (racetrack) with X span [48:52[, healing!
Invalid coordinate Y=46 for team 1 building 9 (racetrack) with Y span [41:45[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate Y=83 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate X=115 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate X=116 for team 0 building 7 (swimmingpool) with X span [109:115[, healing!
Invalid coordinate Y=84 for team 0 building 7 (swimmingpool) with Y span [77:83[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate Y=104 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate X=102 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
Invalid coordinate X=103 for team 0 building 6 (racetrack) with X span [96:102[, healing!
Invalid coordinate Y=105 for team 0 building 6 (racetrack) with Y span [98:104[, healing!
music dir found: original
selecting music dir original
=================================================================
==28142==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x6290003d4200
    #0 0x7f2f0272bbb8 in operator delete(void*, unsigned long) (/usr/lib64/libasan.so.4+0xdebb8)
    #1 0x69f253 in Game::executeOrder(boost::shared_ptr<Order>, int) src/Game.cpp:367
    #2 0x72279a in GameGUI::executeOrder(boost::shared_ptr<Order>) src/GameGUI.cpp:4614
    #3 0x67225d in Engine::run() src/Engine.cpp:439
    #4 0x5f0b9f in CampaignMenuScreen::onAction(GAGGUI::Widget*, GAGGUI::Action, int, int) src/CampaignMenuScreen.cpp:70
    #5 0xf12240 in GAGGUI::Button::onSDLMouseButtonUp(SDL_Event*) libgag/src/GUIButton.cpp:84
    #6 0xf0af0f in GAGGUI::Screen::dispatchEvents(SDL_Event*) libgag/src/GUIBase.cpp:601
    #7 0xf0ee3c in GAGGUI::Screen::execute(GAGCore::DrawableSurface*, int) libgag/src/GUIBase.cpp:511
    #8 0x7eced8 in Glob2::run(int, char**) src/Glob2.cpp:310
    #9 0x7ee769 in main src/Glob2.cpp:441
    #10 0x7f2f01a3e24c in __libc_start_main (/lib64/libc.so.6+0x3524c)
    #11 0x411f89 in _start ../sysdeps/x86_64/start.S:120

0x6290003d4200 is located 0 bytes inside of 16384-byte region [0x6290003d4200,0x6290003d8200)
allocated by thread T0 here:
    #0 0x7f2f0272a9d0 in operator new[](unsigned long) (/usr/lib64/libasan.so.4+0xdd9d0)
    #1 0x8970dc in Map::buildingAvailable(Building*, bool, int, int, int*) src/Map.cpp:4055
    #2 0x57a122 in Building::subscribeForFlagingStep() src/Building.cpp:1843
    #3 0xc1dd56 in Team::updateAllBuildingTasks() src/Team.cpp:878
    #4 0xc1f9d2 in Team::syncStep() src/Team.cpp:1063
    #5 0x6a651f in Game::syncStep(int) src/Game.cpp:1316
    #6 0x67198e in Engine::run() src/Engine.cpp:492
    #7 0x5f0b9f in CampaignMenuScreen::onAction(GAGGUI::Widget*, GAGGUI::Action, int, int) src/CampaignMenuScreen.cpp:70
    #8 0xf12240 in GAGGUI::Button::onSDLMouseButtonUp(SDL_Event*) libgag/src/GUIButton.cpp:84
    #9 0xf0af0f in GAGGUI::Screen::dispatchEvents(SDL_Event*) libgag/src/GUIBase.cpp:601
    #10 0xf0ee3c in GAGGUI::Screen::execute(GAGCore::DrawableSurface*, int) libgag/src/GUIBase.cpp:511
    #11 0x7eced8 in Glob2::run(int, char**) src/Glob2.cpp:310
    #12 0x7ee769 in main src/Glob2.cpp:441
    #13 0x7f2f01a3e24c in __libc_start_main (/lib64/libc.so.6+0x3524c)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/usr/lib64/libasan.so.4+0xdebb8) in operator delete(void*, unsigned long)
==28142==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==28142==ABORTING
```

</details>

<details>

<summary> And again after I recompiled it and messed with the clearing flag in tutorial 4: </summary>

```
=================================================================
==31139==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x6190011d4180
    #0 0x7fc97d57dbb8 in operator delete(void*, unsigned long) (/usr/lib64/libasan.so.4+0xdebb8)
    #1 0x69f16c in Game::executeOrder(boost::shared_ptr<Order>, int) src/Game.cpp:372
    #2 0x722796 in GameGUI::executeOrder(boost::shared_ptr<Order>) src/GameGUI.cpp:4614
    #3 0x67225d in Engine::run() src/Engine.cpp:439
    #4 0x5f0b9f in CampaignMenuScreen::onAction(GAGGUI::Widget*, GAGGUI::Action, int, int) src/CampaignMenuScreen.cpp:70
    #5 0xf1223c in GAGGUI::Button::onSDLMouseButtonUp(SDL_Event*) libgag/src/GUIButton.cpp:84
    #6 0xf0af0b in GAGGUI::Screen::dispatchEvents(SDL_Event*) libgag/src/GUIBase.cpp:601
    #7 0xf0ee38 in GAGGUI::Screen::execute(GAGCore::DrawableSurface*, int) libgag/src/GUIBase.cpp:511
    #8 0x7eced4 in Glob2::run(int, char**) src/Glob2.cpp:310
    #9 0x7ee765 in main src/Glob2.cpp:441
    #10 0x7fc97c83e24c in __libc_start_main (/lib64/libc.so.6+0x3524c)
    #11 0x411f89 in _start ../sysdeps/x86_64/start.S:120

0x6190011d4180 is located 0 bytes inside of 1024-byte region [0x6190011d4180,0x6190011d4580)
allocated by thread T0 here:
    #0 0x7fc97d57c9d0 in operator new[](unsigned long) (/usr/lib64/libasan.so.4+0xdd9d0)
    #1 0x88ee1c in Map::updateLocalRessources(Building*, bool) src/Map.cpp:3754
    #2 0x5729d0 in Building::clearingFlagStep() src/Building.cpp:2347
    #3 0xc20249 in Team::syncStep() src/Team.cpp:1087
    #4 0x6a651b in Game::syncStep(int) src/Game.cpp:1316
    #5 0x67198e in Engine::run() src/Engine.cpp:492
    #6 0x5f0b9f in CampaignMenuScreen::onAction(GAGGUI::Widget*, GAGGUI::Action, int, int) src/CampaignMenuScreen.cpp:70
    #7 0xf1223c in GAGGUI::Button::onSDLMouseButtonUp(SDL_Event*) libgag/src/GUIButton.cpp:84
    #8 0xf0af0b in GAGGUI::Screen::dispatchEvents(SDL_Event*) libgag/src/GUIBase.cpp:601
    #9 0xf0ee38 in GAGGUI::Screen::execute(GAGCore::DrawableSurface*, int) libgag/src/GUIBase.cpp:511
    #10 0x7eced4 in Glob2::run(int, char**) src/Glob2.cpp:310
    #11 0x7ee765 in main src/Glob2.cpp:441
    #12 0x7fc97c83e24c in __libc_start_main (/lib64/libc.so.6+0x3524c)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/usr/lib64/libasan.so.4+0xdebb8) in operator delete(void*, unsigned long)
==31139==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==31139==ABORTING
```

</details>