### PR TITLE
YOGServer: Allow client version 27

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -106,6 +106,8 @@
 //This must be updated when there are changes to YOG, MapHeader, GameHeader, BasePlayer, BaseTeam,
 //NetMessage, and the likes, in parrallel to change of the VERSION_MINOR above
 #define NET_PROTOCOL_VERSION 28
+//Clients with older versions than this will be rejected
+#define YOG_MIN_CLIENT_NET_PROTOCOL_VERSION 27
 // version 21 changed OrderModifyWarFlag to more generic OrderModifyMinLevelToFlag
 // version 22 added ConfigCheckSum to check if all use has the same file config.
 // version 23 updated to allow custom prestige settings

--- a/src/YOGServer.cpp
+++ b/src/YOGServer.cpp
@@ -181,7 +181,7 @@ YOGGamePolicy YOGServer::getGamePolicy() const
 
 YOGLoginState YOGServer::verifyLoginInformation(const std::string& username, const std::string& password, const std::string& ip, Uint16 version)
 {
-	if(version < NET_PROTOCOL_VERSION)
+	if(version < YOG_MIN_CLIENT_NET_PROTOCOL_VERSION)
 		return YOGClientVersionTooOld;
 	if(loginPolicy == YOGAnonymousLogin)
 		return YOGLoginSuccessful;
@@ -215,7 +215,7 @@ YOGLoginState YOGServer::verifyLoginInformation(const std::string& username, con
 
 YOGLoginState YOGServer::registerInformation(const std::string& username, const std::string& password, const std::string& ip, Uint16 version)
 {
-	if(version < NET_PROTOCOL_VERSION)
+	if(version < YOG_MIN_CLIENT_NET_PROTOCOL_VERSION)
 		return YOGClientVersionTooOld;
 	if(loginPolicy == YOGAnonymousLogin)
 		return YOGLoginSuccessful;


### PR DESCRIPTION
Differences between v27 and v28 should not affect the metaserver

Resolves #116