### PR TITLE
Fix libUSL crash due to a circular reference

### DIFF
--- a/libusl/src/code.cpp
+++ b/libusl/src/code.cpp
@@ -13,7 +13,7 @@ using std::string;
 
 ThunkPrototype* thisMember(Prototype* outer)
 {
-	ThunkPrototype* thunk = new ThunkPrototype(0, outer); // TODO: GC
+	ThunkPrototype* thunk = new ThunkPrototype(outer->heap, outer); // TODO: GC
 	thunk->body.push_back(new ThunkCode());
 	thunk->body.push_back(new ParentCode());
 	return thunk;
@@ -21,7 +21,7 @@ ThunkPrototype* thisMember(Prototype* outer)
 
 ThunkPrototype* methodMember(ScopePrototype* method)
 {
-	ThunkPrototype* thunk = new ThunkPrototype(0, method->outer);
+	ThunkPrototype* thunk = new ThunkPrototype(method->heap, method->outer);
 	thunk->body.push_back(new ThunkCode());
 	thunk->body.push_back(new ParentCode());
 	thunk->body.push_back(new CreateCode<Function>(method));

--- a/libusl/src/native.h
+++ b/libusl/src/native.h
@@ -29,12 +29,12 @@ template<typename This>
 struct NativeValuePrototype: Prototype
 {
 	NativeValuePrototype():
-		Prototype(static_cast<Heap*>(0))
+		Prototype(heap)
 	{
-		initialize();
 	}
 	
 private:
+	template<typename Thiss> friend struct NativeValue;
 	/// specialize this method to add members to a native value prototype
 	void initialize()
 	{}
@@ -56,7 +56,10 @@ struct NativeValue: Value
 	NativeValue(Heap* heap, const This& value):
 		Value(heap, &prototype),
 		value(value)
-	{}
+	{
+		prototype.heap = heap;
+		prototype.initialize();
+	}
 	
 	const This value;
 	

--- a/libusl/src/types.cpp
+++ b/libusl/src/types.cpp
@@ -25,15 +25,6 @@ Prototype::Prototype(Heap* heap):
 	Value(heap, 0)
 {}
 
-Prototype::~Prototype()
-{
-	for (auto const& pair : members) {
-		delete pair.second;
-	}
-	std::for_each(scopes.begin(), scopes.end(), [](ScopePrototype* p) { delete p; });
-}
-
-
 void Prototype::addMethod(NativeCode* native)
 {
 	ScopePrototype* scope = new ScopePrototype(static_cast<Heap*>(0), this); // TODO: GC
@@ -121,13 +112,6 @@ Scope::Scope(Heap* heap, ScopePrototype* prototype, Value* outer):
 	Thunk(heap, prototype, outer),
 	locals(prototype->locals.size(), 0)
 {}
-
-Scope::~Scope()
-{
-	for (auto& local : locals) {
-		delete local;
-	}
-}
 	
 /*
 NativeThunk::NativeThunk(Prototype* outer, const std::string& name):

--- a/libusl/src/types.cpp
+++ b/libusl/src/types.cpp
@@ -22,18 +22,20 @@ Value nil(0, &Nil);
 
 
 Prototype::Prototype(Heap* heap):
-	Value(heap, 0)
-{}
+	Value(heap, 0),
+	heap(heap)
+{
+}
 
 void Prototype::addMethod(NativeCode* native)
 {
-	ScopePrototype* scope = new ScopePrototype(static_cast<Heap*>(0), this); // TODO: GC
+	assert(heap);
+	ScopePrototype* scope = new ScopePrototype(heap, this); // TODO: GC
 	native->prologue(scope);
 	scope->body.push_back(native); // run the method
 	native->epilogue(scope);
 	
 	members[native->name] = methodMember(scope);
-	scopes.push_back(scope);
 }
 
 

--- a/libusl/src/types.h
+++ b/libusl/src/types.h
@@ -62,7 +62,6 @@ struct Prototype: Value
 	Scopes scopes;
 	
 	Prototype(Heap* heap);
-	~Prototype();
 	
 	void addMethod(NativeCode* native);
 	
@@ -148,7 +147,6 @@ struct Scope: Thunk
 	Locals locals;
 	
 	Scope(Heap* heap, ScopePrototype* prototype, Value* outer);
-	~Scope();
 	
 	virtual void dumpSpecific(std::ostream& stream) const
 	{

--- a/libusl/src/types.h
+++ b/libusl/src/types.h
@@ -59,7 +59,7 @@ struct Prototype: Value
 	typedef std::vector<ScopePrototype*> Scopes;
 	
 	Members members;
-	Scopes scopes;
+	Heap* heap;
 	
 	Prototype(Heap* heap);
 	

--- a/libusl/src/usl.cpp
+++ b/libusl/src/usl.cpp
@@ -112,9 +112,7 @@ Usl::Usl()
 
 	/*std::dynamic_pointer_cast<ScopePrototype>(rootPrototype).get()*/
 	root = std::make_unique<Scope>(&heap, dynamic_cast<ScopePrototype*>(prototype.get()), nullptr);
-}
 
-Usl::~Usl() {
 	// Remove prototype and root as they will be automatically deleted anyway.
 	for (auto it = heap.values.begin(); it != heap.values.end();)
 	{
@@ -123,7 +121,10 @@ Usl::~Usl() {
 		else
 			it++;
 	}
-	heap.collectGarbage();
+}
+
+Usl::~Usl() {
+	collectGarbage();
 }
 
 /*Usl::~Usl()
@@ -271,7 +272,7 @@ size_t Usl::run(size_t steps)
 	}
 	
 	// TODO: garbageCollect
-	
+	collectGarbage();
 	return total;
 }
 

--- a/libusl/src/usl.cpp
+++ b/libusl/src/usl.cpp
@@ -114,7 +114,17 @@ Usl::Usl()
 	root = std::make_unique<Scope>(&heap, dynamic_cast<ScopePrototype*>(prototype.get()), nullptr);
 }
 
-Usl::~Usl() {}
+Usl::~Usl() {
+	// Remove prototype and root as they will be automatically deleted anyway.
+	for (auto it = heap.values.begin(); it != heap.values.end();)
+	{
+		if (*it == prototype.get() || *it == root.get())
+			it = heap.values.erase(it);
+		else
+			it++;
+	}
+	heap.collectGarbage();
+}
 
 /*Usl::~Usl()
 {

--- a/libusl/src/usl.cpp
+++ b/libusl/src/usl.cpp
@@ -105,19 +105,34 @@ void print(Value* value)
 
 Usl::Usl()
 {
-	ScopePrototype* prototype = new ScopePrototype(&heap, 0);
+	prototype = std::make_unique<ScopePrototype>(&heap, nullptr);
 	prototype->addMethod(new Load());
 	prototype->addMethod(new Yield());
 	prototype->addMethod(new NativeFunction<void(Value*)>("print", print));
 
-	root = new Scope(&heap, prototype, 0);
+	/*std::dynamic_pointer_cast<ScopePrototype>(rootPrototype).get()*/
+	root = std::make_unique<Scope>(&heap, dynamic_cast<ScopePrototype*>(prototype.get()), nullptr);
 }
 
-Usl::~Usl()
+Usl::~Usl() {}
+
+/*Usl::~Usl()
 {
 	delete root->prototype;
 	delete root;
 }
+
+void swap(Usl& first, Usl& second)
+{
+	using std::swap;
+	swap(first.root, second.root);
+}
+
+Usl& Usl::operator=(Usl other)
+{
+	swap(*this, other);
+	return *this;
+}*/
 
 void Usl::markGarbage() const
 {
@@ -225,7 +240,7 @@ Scope* Usl::compile(const std::string& name, std::istream& stream)
 	ScopePrototype* prototype = new ScopePrototype(&heap, root->prototype);
 	block.generateMembers(prototype, &debug, &heap);
 	
-	Scope* scope = new Scope(&heap, prototype, root);
+	Scope* scope = new Scope(&heap, prototype, root.get());
 	return scope;
 }
 

--- a/libusl/src/usl.h
+++ b/libusl/src/usl.h
@@ -3,8 +3,10 @@
 
 #include "memory.h"
 #include "debug.h"
+#include "types.h"
 
 #include <istream>
+#include <memory>
 
 struct Thread;
 struct Scope;
@@ -27,7 +29,8 @@ struct Usl
 	
 	DebugInfo debug;
 	Heap heap;
-	Scope* root;
+	std::unique_ptr<Scope> root;
+	std::unique_ptr<Prototype> prototype;
 	Threads threads;
 	
 	/// Run one thread (round-robin over all threads) for a maximum of steps bytecodes executions

--- a/src/MapScriptUSL.cpp
+++ b/src/MapScriptUSL.cpp
@@ -167,7 +167,7 @@ void MapScriptUSL::decodeData(GAGCore::InputStream* stream, Uint32 versionMinor)
 bool MapScriptUSL::compileCode(const std::string& code)
 {
 	GameGUI* gui = dynamic_cast<NativeValue<GameGUI*>*>(usl.getConstant("gui"))->value;
-	usl = Usl();
+	new (&usl) Usl();
 	addGlob2Values(gui);
 	
 	const char* dirsToLoad[] = { "data/usl/Language/Runtime" , "data/usl/Glob2/Runtime", 0 };


### PR DESCRIPTION
Uses unique_ptrs for the root and root->prototype, but the rest is garbage collected.

The problem was that two Scopes had each other as a local, so deleting
    locals in the Scope destructor caused one of them to be deleted twice.