### PR TITLE
Fix --fwhole-program typo blocking release builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -303,7 +303,7 @@ def main():
 
     if env['release']:
         env.Append(CXXFLAGS=' -O3 -s')
-        env.Append(LINKFLAGS=' -O3 -s --fwhole-program')
+        env.Append(LINKFLAGS=' -O3 -s -fwhole-program')
     if env['profile']:
         env.Append(CXXFLAGS=' -pg')
         env.Append(LINKFLAGS='-pg')


### PR DESCRIPTION
`SConstruct` passed `--fwhole-program` (double dash) to g++ under `release=1`; g++ only accepts the single-dash GCC spelling `-fwhole-program` and rejects the double-dash form as unrecognized, so `scons release=1` failed at the final link step. One-character fix. Found while Leo was trying to build PR #134 off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
