### PR TITLE
Make the remember-unit setting remember the assigned counts

### DIFF
--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -175,6 +175,8 @@ GameGUI::~GameGUI()
 {
 	for (ParticleSet::iterator it = particles.begin(); it != particles.end(); ++it)
 		delete *it;
+	if (globalContainer->settings.rememberUnit)
+		globalContainer->settings.save();
 }
 
 void GameGUI::init()

--- a/src/GameGUIDefaultAssignManager.cpp
+++ b/src/GameGUIDefaultAssignManager.cpp
@@ -41,6 +41,12 @@ int GameGUIDefaultAssignManager::getDefaultAssignedUnits(int typenum)
 void GameGUIDefaultAssignManager::setDefaultAssignedUnits(int typenum, int value)
 {
 	unitCount[typenum] = value;
+	if (!globalContainer->settings.rememberUnit)
+		return;
+	// carry the choice over to the next game through the settings
+	const BuildingType* type = globalContainer->buildingsTypes.get(typenum);
+	if (type)
+		globalContainer->settings.defaultUnitsAssigned[type->shortTypeNum][type->level*2 + (type->isBuildingSite ? 0 : 1)] = value;
 }
 
 


### PR DESCRIPTION
Cherry-picked bugfix from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

The remember-unit checkbox has been saved and shown since 2007 but nothing read it, and the counts set in a game were never written back, so every game started with the default assignment regardless of the checkbox.

Original commit: 05ae83f7fbcffe13e758672b698c1db14436ff9b