### PR TITLE
Accept saves taken while a unit is entering a building

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1072,8 +1072,14 @@ bool Game::integrity(void)
 				checkInvariant(teams[tid]);
 				const auto unit = teams[tid]->myUnits[Unit::GIDtoID(c.airUnit)];
 				checkInvariant(unit);
-				checkInvariant(unit->posX == x);
-				checkInvariant(unit->posY == y);
+				// A unit on its final step into a building (DIS_ENTERING_BUILDING)
+				// already has the building's position but stays registered on the
+				// cell it came from until it is inside (see UnitDisplacement.cpp).
+				const bool entering = unit->displacement == Unit::DIS_ENTERING_BUILDING;
+				const int expectedX = entering ? ((unit->posX - unit->dx) & map.wMask) : unit->posX;
+				const int expectedY = entering ? ((unit->posY - unit->dy) & map.hMask) : unit->posY;
+				checkInvariant(expectedX == x);
+				checkInvariant(expectedY == y);
 			}
 		}
 	return true;


### PR DESCRIPTION
Cherry-picked bugfix from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

A unit on its final step into a building (displacement DIS_ENTERING_BUILDING) already carries the building's position, but the integrity check rejected the save as invalid, so games with a unit in that exact state failed to load.

Original commit: 9f4890610e4682114541ce45f5cb45693abbe569