### PR TITLE
Connect the end-game chart segments end to end

### DIFF
--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -161,7 +161,7 @@ void EndGameStat::paint(void)
 				{
 					double value = getValue(double(px) / double(e_width-2), team, type);
 					int ny = e_height - int(double(e_height) * value / double(maxValue));
-					parent->getSurface()->drawLine(x + px + 1, y + previous_y, x + px, y + ny, color);
+					parent->getSurface()->drawLine(x + px, y + previous_y, x + px + 1, y + ny, color);
 					previous_y = ny;
 					int dist = (mouse_y-ny)*(mouse_y-ny) + (mouse_x-px-1)*(mouse_x-px-1);
 					if(dist < closest_position)


### PR DESCRIPTION
Cherry-picked bugfix from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

Each chart segment ran from (px+1, previous value) to (px, new value), so consecutive segments never shared an endpoint, producing a broken-looking chart.

Original commit: 1e82e81056cacee224af1eb7fb41e23e80034a58