### PR TITLE
Draw the editor team selector for MAX_COUNT teams only

### DIFF
--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -124,7 +124,7 @@ TeamColorSelector::TeamColorSelector(MapEdit& me, const widgetRectangle& area, c
 
 void TeamColorSelector::draw()
 {
-	for(int n=0; n<16; ++n)
+	for(int n=0; n<Team::MAX_COUNT; ++n)
 	{
 		const int xpos = area.x + (n%6)*16;
 		const int ypos = area.y + (n/6)*16;


### PR DESCRIPTION
Cherry-picked bugfix from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

Team::MAX_COUNT is 12, but TeamColorSelector::draw still looped to 16. Indexing teams[12..15] is undefined behavior.

Original commit: 3f6416b432441bf6327445b58d7d317e0b7eccb4