### PR TITLE
Draw the terrain selector highlight after flushing the tile batch

### DIFF
--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -320,14 +320,15 @@ void TerrainSelector::draw()
 		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 59);
 	if(terrainType==PruneTree)
 		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->ressources, 64);
-	if(me.terrainType==terrainType)
-		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 22);
 	if (terrainType == Grass || terrainType == Sand || terrainType == Water)
 		globalContainer->gfx->finishDrawingSprite(globalContainer->terrain, 255);
 	else
 		globalContainer->gfx->finishDrawingSprite(globalContainer->ressources, 255);
 	if (me.terrainType == terrainType)
+	{
+		globalContainer->gfx->drawSprite(area.x, area.y, globalContainer->gamegui, 22);
 		globalContainer->gfx->finishDrawingSprite(globalContainer->gamegui, 255);
+	}
 }
 
 


### PR DESCRIPTION
Cherry-picked bugfix from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

In GL mode the terrain and resource sheets are uniform-size atlases, so their sprites are queued until finishDrawingSprite. Drawing the highlight before the batch flushed put it behind (or ahead of, depending on batching order) the terrain sprites it should sit above.

Original commit: 4cbe0f63bb8631bca549952494e49a2f873ba123