### PR TITLE
Check building footprints with wrap-around on load

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1050,12 +1050,12 @@ bool Game::integrity(void)
 						map.getCase(x, y).building = NOGBID; \
 					}
 
+				// Footprints may straddle the map edge (posX can be -1), so
+				// measure the cell's offset from the building with wrap-around.
 				const auto buildingEndX = building->posX + building->type->width;
-				healBuildingOutsideCoord(x >= building->posX || x < (buildingEndX & map.wMask), x, X);
-				healBuildingOutsideCoord(x < buildingEndX, x, X);
+				healBuildingOutsideCoord(((x - building->posX) & map.wMask) < building->type->width, x, X);
 				const auto buildingEndY = building->posY + building->type->height;
-				healBuildingOutsideCoord(y >= building->posY || y < (buildingEndY & map.hMask), y, Y);
-				healBuildingOutsideCoord(y < buildingEndY, y, Y);
+				healBuildingOutsideCoord(((y - building->posY) & map.hMask) < building->type->height, y, Y);
 			}
 			if (c.groundUnit != NOGUID)
 			{


### PR DESCRIPTION
Bugfix ported from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

Buildings may straddle the map edge (posX can be -1), so the cell at x = width-1 legitimately belongs to a building whose span reads [-1:5[. The two half-checks in `Game::integrity` treated that column as outside the footprint, logged "Invalid coordinate ... healing!" on every load, and cleared the cell's building id — un-registering the building's wrapped column. Measures the cell's offset from the building with the map mask instead, for X and Y alike.

Original commit: dce8436012dba97b408cdec51e52d9776dcc6fa6 (adapted here to this file's current `healBuildingOutsideCoord` macro, since PR #132 is built on the refactored file layout from #129).