### PR TITLE
Fix editor viewport racing northwest on entry

### DIFF
--- a/src/MapEdit.cpp
+++ b/src/MapEdit.cpp
@@ -825,8 +825,9 @@ MapEdit::MapEdit()
 	viewportY=0;
 	xSpeed=0;
 	ySpeed=0;
-	mouseX=0;
-	mouseY=0;
+	// screen center, not (0,0) -- see handleMapScroll()
+	mouseX=globalContainer->gfx->getW()/2;
+	mouseY=globalContainer->gfx->getH()/2;
 	relMouseX=0;
 	relMouseY=0;
 	wasMinimapRendered=false;


### PR DESCRIPTION
Bugfix ported from PR #132 (fix/fullscreen-scaling), split out to shrink #132/#129's diff against master per Leo's request.

`handleMapScroll()` treats mouseX/mouseY within scrollAreaWidth (10px) of a screen edge as an edge-scroll trigger. Both were constructor-initialized to (0,0) and only got their real value from the first SDL_MOUSEMOTION/button event, so on entering the editor (new map or load map) the viewport scrolled northwest every frame until the mouse first moved. Seeds them to the screen center instead.

Original commit: 521612d0477064302eb526d639554c6731de7ab7