### PR TITLE
Remove leaked forbidden zone when a building dies awaiting upgrade room

### DIFF
--- a/src/building/Misc.cpp
+++ b/src/building/Misc.cpp
@@ -63,6 +63,12 @@ void Building::kill(void)
 	desiredMaxUnitWorking = 0;
 	updateCallLists();
 
+	// A building waiting for upgrade room has a forbidden zone stamped over
+	// its would-be footprint (addForbiddenZoneToUpgradeArea). The other exits
+	// from that state (tryToBuildingSiteRoom, cancelConstruction) remove it;
+	// dying must too, or the zone leaks and corrupts the team's pathfinding.
+	if (buildingState==WAITING_FOR_CONSTRUCTION_ROOM && constructionResultState==UPGRADE)
+		removeForbiddenZoneFromUpgradeArea();
 
 	if (!type->isVirtual)
 	{


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

Original commit: 7a61c2993e36efa6f98dbf7e912bd7ec4208cc86