### PR TITLE
Fix latent setBuilding(decLeft, decLeft) typo in tryToBuildingSiteRoom

### DIFF
--- a/src/building/Update.cpp
+++ b/src/building/Update.cpp
@@ -303,7 +303,7 @@ bool Building::tryToBuildingSiteRoom(void)
 
 		if (!type->isVirtual)
 		{
-			owner->map->setBuilding(posX, posY, type->decLeft, type->decLeft, NOGBID);
+			owner->map->setBuilding(posX, posY, type->width, type->height, NOGBID);
 			owner->map->setBuilding(newPosX, newPosY, newWidth, newHeight, gid);
 		}
 


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

Original commit: 89f4890610e4682114541ce45f5cb45693abbe569... (see 89f342e9 in #129)