### PR TITLE
Fix placeBuildingAt future-worker lookup for flags

### DIFF
--- a/src/GameGUIToolManager.cpp
+++ b/src/GameGUIToolManager.cpp
@@ -376,7 +376,7 @@ void GameGUIToolManager::placeBuildingAt(int mapX, int mapY, int localteam)
 			isRoom = false;
 		
 		int unitWorking = defaultAssign.getDefaultAssignedUnits(typeNum);
-		int unitWorkingFuture = defaultAssign.getDefaultAssignedUnits(typeNum+1);
+		int unitWorkingFuture = defaultAssign.getDefaultAssignedUnits(globalContainer->buildingsTypes.getTypeNum(building, 0, false));
 		
 		if (isRoom)
 		{


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

placeBuildingAt computed the finished-building default-assign row as `getDefaultAssignedUnits(typeNum+1)`. The +1 relies on the buildingsTypes table being laid out as consecutive [site, finished] pairs, which holds by accident for normal buildings but breaks for flags: flags have no site variant, so the placeable typeNum is already the finished entry and +1 walks into the next building's row (e.g. an exploration flag reads the war flag's default assign). Looks the finished type up by name instead, matching the other call sites in this file.

Original commit: 5993b37a287b06cb6e556fd7e0416902971da411 by kylelutze — adapted here to master's `getTypeNum(name, level, isBuildingSite)` API since the branch's `getFinishedTypeNum(name)` convenience helper doesn't exist yet on master (patch applied but referenced a symbol that doesn't compile on master; verified with a full `scons` build before and after the fix).