### PR TITLE
drawChoice: fix tutorial-hilight arrow Y using horizontal centering offset

### DIFF
--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -2733,7 +2733,7 @@ void GameGUI::drawChoice(int pos, std::vector<std::string> &types, std::vector<b
 			globalContainer->gfx->setClipRect();
 			if(hilights.find(HilightBuildingOnPanel+IntBuildingType::shortNumberFromType(type)) != hilights.end())
 			{
-				arrowPositions.push_back(HilightArrowPosition(x+decX-36, y-6+decX, 38));
+				arrowPositions.push_back(HilightArrowPosition(x+decX-36, y-6+decY, 38));
 			}
 		}
 	}


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

The arrow position queued for a hilighted right-panel building/flag passed decX (the horizontal sprite-centering offset) as the Y nudge, producing a vertical misalignment that grew with the sprite's width.

Original commit: 44865b4b9e3198b62621f9651b673450f8ff8de9 by Kyle