### PR TITLE
Fix crash when highlighting a tool over a panel that doesn't own it

### DIFF
--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -2741,22 +2741,25 @@ void GameGUI::drawChoice(int pos, std::vector<std::string> &types, std::vector<b
 
 	globalContainer->gfx->setClipRect(globalContainer->gfx->getW()-RIGHT_MENU_WIDTH, 128, RIGHT_MENU_WIDTH, globalContainer->gfx->getH()-128);
 
-	// draw building selection if needed
-	if (selectionMode == TOOL_SELECTION)
+	// draw building selection if needed. selectionMode and the panel being
+	// painted are independent axes: the user can tab-cycle the displayed
+	// panel while a tool from a *different* panel stays selected, which
+	// leaves sel unset (-1) here -- a legitimate UI state, not an error, so
+	// there is simply nothing to highlight rather than something to assert on.
+	if (selectionMode == TOOL_SELECTION && sel>=0)
 	{
 		int sw;
 		if (numberPerLine == 2)
 			sw = globalContainer->gamegui->getW(8);
 		else
 			sw = globalContainer->gamegui->getW(23);
-			
-	  
-		assert(sel>=0);
+
+
 		int x=((sel  % numberPerLine)*width)+globalContainer->gfx->getW()-RIGHT_MENU_WIDTH;
 		int y=((sel / numberPerLine)*46)+YPOS_BASE_BUILDING;
-		
+
 		int decX = (width - sw) / 2;
-		
+
 		if (numberPerLine == 2)
 			globalContainer->gfx->drawSprite(x+decX, y+1, globalContainer->gamegui, 8);
 		else


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

drawChoice() asserted that, in TOOL_SELECTION mode, the active tool's building name is always present in the panel's types vector. That invariant is false: selectionMode and the displayed panel are independent axes. Selecting a tool couples it to a panel at pick time, but the player can then tab-cycle the display panel while the tool stays selected, leaving sel unset (-1). Draw the highlight only when the tool actually belongs to the panel being painted.

Original commit: 9bffb5fe37f35dab53c44282c5e75512468bcb83 by kylelutze