### PR TITLE
Fix swapped fruit/resource building-failure labels

### DIFF
--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -3552,9 +3552,9 @@ void GameGUI::drawBuildingInfos(void)
 					else if(j == Building::UnitCantAccessResource)
 						s = FormatableString(Toolkit::getStringTable()->getString("[%0 units can't access resource]")).arg(n);
 					else if(j == Building::UnitCantAccessFruit)
-						s = FormatableString(Toolkit::getStringTable()->getString("[%0 units too far from resource]")).arg(n);
-					else if(j == Building::UnitTooFarFromResource)
 						s = FormatableString(Toolkit::getStringTable()->getString("[%0 units can't access fruit]")).arg(n);
+					else if(j == Building::UnitTooFarFromResource)
+						s = FormatableString(Toolkit::getStringTable()->getString("[%0 units too far from resource]")).arg(n);
 					else if(j == Building::UnitTooFarFromFruit)
 						s = FormatableString(Toolkit::getStringTable()->getString("[%0 units too far from fruit]")).arg(n);
 					globalContainer->gfx->drawString(globalContainer->gfx->getW()-RIGHT_MENU_WIDTH+10, ypos, globalContainer->littleFont, s.c_str());


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

The if/else chain mapped UnitCantAccessFruit to "too far from resource" and UnitTooFarFromResource to "can't access fruit" — each pair displayed the other's label in the building inspector.

Original commit: 4fd4a565d0a22c71cc984ac8b070b9bc6b87997e by Kyle (minimal swap here; the branch also refactors this into an indexed table, left out to keep this PR to just the fix).