### PR TITLE
Fix swapped hilight arrows for warrior/explorer top-bar counters

### DIFF
--- a/src/GameGUI.cpp
+++ b/src/GameGUI.cpp
@@ -4030,17 +4030,19 @@ void GameGUI::drawTopScreenBar(void)
 		globalContainer->gfx->drawString(dec+22, 0, globalContainer->littleFont, FormatableString("%0 / %1").arg(free).arg(tot).c_str());
 		globalContainer->littleFont->popStyle();
 		
-		if(i==WORKER && hilights.find(HilightWorkersWorkingFreeStat) != hilights.end())
-		{
-			arrowPositions.push_back(HilightArrowPosition(dec+22, 32, 39));
-		}
-		
-		else if(i==WARRIOR && hilights.find(HilightExplorersWorkingFreeStat) != hilights.end())
-		{
-			arrowPositions.push_back(HilightArrowPosition(dec+22, 32, 39));
-		}
-		
-		else if(i==EXPLORER && hilights.find(HilightWarriorsWorkingFreeStat) != hilights.end())
+		// Tutorial hilight arrow for this counter. The sprite, the free/total
+		// counter, and the arrow position above all key off the unit-type index
+		// i (WORKER=0, EXPLORER=1, WARRIOR=2 from UnitConsts.h); the matching
+		// hilight id must too. This table keeps that pairing in one place so it
+		// cannot be silently swapped. Indices follow the UnitConsts ordering,
+		// NOT the Hilight* enum's numeric order (which lists explorer/warrior
+		// the other way around), so the mapping is spelled out explicitly.
+		static const int hilightForUnitType[3] = {
+			HilightWorkersWorkingFreeStat,   // i == WORKER
+			HilightExplorersWorkingFreeStat, // i == EXPLORER
+			HilightWarriorsWorkingFreeStat,  // i == WARRIOR
+		};
+		if(hilights.find(hilightForUnitType[i]) != hilights.end())
 		{
 			arrowPositions.push_back(HilightArrowPosition(dec+22, 32, 39));
 		}


### PR DESCRIPTION
Bugfix ported from PR #129 (feat/ai-trainer-support), split out to shrink #129's diff against master per Leo's request.

drawTopScreenBar's three-branch chain paired the warrior counter with the explorers hilight and the explorer counter with the warriors hilight — a copy-paste swap. A script requesting the explorers stat drew its arrow over the warrior counter and vice versa. Replaced with a table indexed by the same unit-type index used everywhere else in the loop, so the pairing can't be silently swapped again.

Original commit: d8e69de86b067b78c605411a48877ddc8979de4b by kylelutze