### PR TITLE
Fix LAN joining and shared map downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ jobs:
           scons -j$(nproc) release=1 server=0 terrain-test
           ./build/src/TerrainResourcesHarness
 
+      - name: Build and run the LAN session regression
+        run: |
+          scons -j$(nproc) release=1 server=0 lan-test
+          python3 test/run_lan_session_test.py build/src/LANSessionHarness
+
       - name: Build and run the tests
         working-directory: test
         run: |

--- a/src/Glob2Screen.h
+++ b/src/Glob2Screen.h
@@ -18,7 +18,7 @@ public:
 	
 private:
 	unsigned getNextTerrain(void);
-	int randomSeed;
+	Uint32 randomSeed; // Background LCG intentionally wraps modulo 2^32.
 };
 
 class Glob2TabScreen : public TabScreen
@@ -30,7 +30,7 @@ public:
 	
 private:
 	unsigned getNextTerrain(void);
-	int randomSeed;
+	Uint32 randomSeed; // Background LCG intentionally wraps modulo 2^32.
 };
 
 

--- a/src/LANFindScreen.cpp
+++ b/src/LANFindScreen.cpp
@@ -125,6 +125,7 @@ void LANFindScreen::onAction(Widget *source, Action action, int par1, int par2)
 			game->joinGame((*client->getGameListManager()->getGameList().begin()).getGameID());
 
 			Glob2TabScreen screen(true);
+			MultiplayerGameScreen lobby(&screen, game, client);
 			
 			listener.disableListening();
 			int rc = screen.execute(globalContainer->gfx, 40);

--- a/src/SConscript
+++ b/src/SConscript
@@ -484,6 +484,12 @@ if not env['server']:
     terrain_test = local.Program('TerrainResourcesHarness', terrain_sources)
     local.Alias('terrain-test', terrain_test)
 
+if not env['server']:
+    lan_sources = [source for source in source_files if source != 'Glob2.cpp']
+    lan_sources += local.Object('LANSessionHarness.o', '#test/LANSessionHarness.cpp')
+    lan_test = local.Program('LANSessionHarness', lan_sources)
+    local.Alias('lan-test', lan_test)
+
 #Add libgag, not as a library, but as an object
 server_source_files.append("../libgag/src/libgag_server.a")
 p2 = local.Program("glob2-server", server_source_files)

--- a/src/yog/YOGServerFileDistributor.cpp
+++ b/src/yog/YOGServerFileDistributor.cpp
@@ -86,8 +86,11 @@ void YOGServerFileDistributor::update()
 			std::get<0>(*i)->sendMessage(fileInfo);
 			std::get<2>(*i) = 1;
 		}
-		else if(std::get<2>(*i) == 0) {
-			// WORKAROUND
+		else if(std::get<2>(*i) == 0)
+		{
+			// The header arrives through the next server update. Advance past
+			// this recipient so waiting for it cannot stall the message pump.
+			++i;
 			continue;
 		}
 		else if(std::get<2>(*i)-1 < (int)chunks.size() && std::get<1>(*i) < localtime)
@@ -172,6 +175,8 @@ void YOGServerFileDistributor::requestDataFromPlayer()
 {
 	if(!startedLoading)
 	{
+		// All recipients share this upload, including guests who rejoin.
+		startedLoading=true;
 		shared_ptr<NetRequestFile> message(new NetRequestFile(fileID));
 		player->sendMessage(message);
 	}

--- a/test/LANSessionHarness.cpp
+++ b/test/LANSessionHarness.cpp
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Exercise real LAN clients, lobby widgets, sockets, readiness and departures.
+#include "GlobalContainer.h"
+#include "Engine.h"
+#include "LANFindScreen.h"
+#include "MultiplayerGameScreen.h"
+#include "YOGClientBringup.h"
+#include "YOGServer.h"
+#include "FileManager.h"
+#include "GUITextInput.h"
+#include "Toolkit.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <set>
+#include <string>
+
+GlobalContainer* globalContainer = nullptr;
+using namespace GAGGUI;
+using namespace GAGCore;
+
+namespace
+{
+void click(int x, int y)
+{
+	SDL_Event event{};
+	event.type = SDL_MOUSEBUTTONDOWN;
+	event.button.button = SDL_BUTTON_LEFT;
+	event.button.state = SDL_PRESSED;
+	event.button.x = x;
+	event.button.y = y;
+	SDL_PushEvent(&event);
+	event.type = SDL_MOUSEBUTTONUP;
+	event.button.state = SDL_RELEASED;
+	SDL_PushEvent(&event);
+}
+
+Uint32 readyTimer(Uint32, void*) { click(610, 450); return 0; }
+Uint32 leaveTimer(Uint32, void*) { click(530, 525); return 0; }
+Uint32 timeoutTimer(Uint32, void*)
+{
+	SDL_Event event{};
+	event.type = SDL_QUIT;
+	SDL_PushEvent(&event);
+	return 0;
+}
+
+class JoinScreen : public LANFindScreen
+{
+public:
+	JoinScreen(const std::string& address, const std::string& capture) : capture(capture)
+	{
+		// Use the real form's public widget API; no networking is stubbed.
+		for (Widget* widget : widgets)
+			if (auto* input = dynamic_cast<TextInput*>(widget))
+				if (input->getText() == "localhost") input->setText(address);
+	}
+	void onTimer(Uint32 tick) override
+	{
+		LANFindScreen::onTimer(tick);
+		const Uint64 start = SDL_GetTicks64();
+		// SDL timers only enqueue input. Rendering and network state stay on
+		// the real screen's main thread, including the nested lobby loop.
+		SDL_TimerID ready = SDL_AddTimer(5000, readyTimer, nullptr);
+		SDL_TimerID leave = SDL_AddTimer(25000, leaveTimer, nullptr);
+		SDL_TimerID timeout = SDL_AddTimer(40000, timeoutTimer, nullptr);
+		LANFindScreen::onAction(nullptr, BUTTON_RELEASED, CONNECT, 0);
+		SDL_RemoveTimer(ready);
+		SDL_RemoveTimer(leave);
+		SDL_RemoveTimer(timeout);
+		SDL_SaveBMP(globalContainer->gfx->getSDLSurface(), capture.c_str());
+		bool ok = returnCode != QUIT_APPLICATION && SDL_GetTicks64() - start < 39000;
+		std::puts(ok ? "JOIN PASS: lobby returned through Leave Game" : "JOIN FAIL: lobby did not complete before the timeout");
+		endExecute(ok ? 0 : 1);
+	}
+private:
+	std::string capture;
+};
+
+class HostScreen : public Glob2TabScreen
+{
+public:
+	HostScreen(std::shared_ptr<MultiplayerGame> game, int cycles, std::string capture)
+		: Glob2TabScreen(true), game(game), cycles(cycles), capture(capture), start(SDL_GetTicks64()) {}
+	void onTimer(Uint32 tick) override
+	{
+		Glob2TabScreen::onTimer(tick);
+		if (!pendingCapture.empty())
+		{
+			SDL_SaveBMP(globalContainer->gfx->getSDLSurface(), pendingCapture.c_str());
+			pendingCapture.clear();
+		}
+		if (SDL_GetTicks64() - start > 180000)
+		{
+			std::puts("HOST FAIL: timed out waiting for ready/join/leave cycles");
+			endExecute(1);
+			return;
+		}
+		auto& header = game->getGameHeader();
+		int count = header.getNumberOfPlayers();
+		if (count != previousCount)
+		{
+			std::printf("HOST roster=%d state=%d\n", count, int(game->getGameJoinCreationState()));
+			for (int i = 0; i < count; ++i)
+			{
+				const BasePlayer& p = header.getBasePlayer(i);
+				std::printf("  slot=%d id=%u name=%s mask=%u\n", p.number, p.playerID, p.name.c_str(), p.numberMask);
+			}
+			previousCount = count;
+		}
+		std::set<Uint32> ids;
+		for (int i = 0; i < count; ++i)
+		{
+			const BasePlayer& p = header.getBasePlayer(i);
+			if (!ids.insert(p.playerID).second || p.number != i || p.numberMask != (Uint32(1) << i))
+			{
+				std::puts("HOST FAIL: duplicate identity or invalid slot mask");
+				endExecute(1);
+			}
+		}
+		if (count > 2)
+		{
+			std::puts("HOST FAIL: expected exactly one host and one guest");
+			endExecute(1);
+		}
+		if (count == 2 && game->isGameReadyToStart() && !readySeen)
+		{
+			readySeen = true;
+			std::printf("HOST guest ready, cycle=%d\n", completed + 1);
+			pendingCapture = capture + "-" + std::to_string(completed + 1) + ".bmp";
+		}
+		if (count == 1 && readySeen)
+		{
+			readySeen = false;
+			++completed;
+			std::printf("HOST departure verified, cycle=%d\n", completed);
+			if (completed == cycles)
+			{
+				std::puts("HOST PASS: all ready/join/leave cycles completed");
+				game->leaveGame();
+				endExecute(0);
+			}
+		}
+	}
+private:
+	std::shared_ptr<MultiplayerGame> game;
+	int cycles, completed = 0, previousCount = -1;
+	bool readySeen = false;
+	std::string capture, pendingCapture;
+	Uint64 start;
+};
+
+int host(int cycles, const std::string& capture)
+{
+	auto client = std::make_shared<YOGClient>();
+	auto server = std::make_shared<YOGServer>(YOGAnonymousLogin, YOGSingleGame);
+	if (!server->isListening()) { std::puts("HOST FAIL: port in use"); return 1; }
+	server->enableLANBroadcasting();
+	client->attachGameServer(server);
+	client->connect("127.0.0.1");
+	if (LANBringup::waitForConnectionState(*client, YOGClient::WaitingForLoginInformation) != LANBringup::Result::Reached) return 1;
+	client->attemptLogin("LAN host");
+	if (LANBringup::waitForConnectionState(*client, YOGClient::ClientOnStandby) != LANBringup::Result::Reached) return 1;
+	auto game = std::make_shared<MultiplayerGame>(client);
+	client->setMultiplayerGame(game);
+	game->createNewGame("LAN regression");
+	// A private map name forces a real transfer without touching user maps.
+	MapHeader map = Engine::loadMapHeader("maps/FourSquares1.map");
+	map.setMapName("LAN regression transfer");
+	std::filesystem::copy_file("maps/FourSquares1.map",
+		Toolkit::getFileManager()->getDir(0) + "/" + map.getFileName(),
+		std::filesystem::copy_options::overwrite_existing);
+	game->setMapHeader(map);
+	HostScreen screen(game, cycles, capture);
+	MultiplayerGameScreen lobby(&screen, game, client);
+	int rc = screen.execute(globalContainer->gfx, 20);
+	client->setMultiplayerGame({});
+	return rc;
+}
+}
+
+int main(int argc, char** argv)
+{
+	if (argc != 5)
+	{
+		std::fprintf(stderr, "Usage: %s host|join address cycles capture-prefix\n", argv[0]);
+		return 2;
+	}
+	std::setvbuf(stdout, nullptr, _IONBF, 0);
+	SDL_setenv("SDL_AUDIODRIVER", "dummy", 0);
+	GlobalContainer globals;
+	globalContainer = &globals;
+	// Keep the harness's map downloads and anonymous server data separate
+	// from the user's normal game profile.
+	Toolkit::close();
+	Toolkit::init((std::string("glob2-lan-test-") + argv[1]).c_str());
+	globals.fileManager = Toolkit::getFileManager();
+	for (const char* dir : {"maps", "games", "campaigns", "replays", "thumbnails", "beta4", "beta4/gamelog", "logs", "scripts", "videoshots"})
+		globals.fileManager->addWriteSubdir(dir);
+	globals.settings.screenWidth = 640;
+	globals.settings.screenHeight = 600;
+	globals.settings.screenFlags = 0;
+	globals.settings.optionFlags |= GlobalContainer::OPTION_LOW_SPEED_GFX;
+	globals.settings.mute = true;
+	globals.settings.language = "en";
+	globals.settings.setUsername(std::string(argv[1]) == "host" ? "LAN host" : "LAN guest");
+	globals.load();
+	if (SDLNet_Init() < 0) return 1;
+	int rc = 0;
+	if (std::string(argv[1]) == "host") rc = host(std::stoi(argv[3]), argv[4]);
+	else for (int cycle = 0; cycle < std::stoi(argv[3]) && !rc; ++cycle)
+	{
+		const auto downloaded = std::filesystem::path(globals.fileManager->getDir(0)) / "maps/LAN_regression_transfer.map";
+		// Force a second request too: rejoining must reuse the server's upload
+		// rather than append another copy of its chunks to the cached transfer.
+		std::filesystem::remove(downloaded);
+		JoinScreen screen(argv[2], std::string(argv[4]) + "-" + std::to_string(cycle + 1) + ".bmp");
+		rc = screen.execute(globals.gfx, 20);
+		std::ifstream original("maps/FourSquares1.map", std::ios::binary);
+		std::ifstream received(downloaded, std::ios::binary);
+		std::string expected((std::istreambuf_iterator<char>(original)), {});
+		std::string actual((std::istreambuf_iterator<char>(received)), {});
+		if (!original || !received || actual != expected)
+		{
+			std::puts("JOIN FAIL: downloaded map differs from source");
+			rc = 1;
+		}
+		else std::printf("JOIN map verified: %zu bytes, cycle=%d\n", actual.size(), cycle + 1);
+		SDL_Delay(1000);
+	}
+	SDLNet_Quit();
+	return rc;
+}

--- a/test/README.md
+++ b/test/README.md
@@ -85,3 +85,36 @@ To poke `cases[i].terrain` directly (`regenerateMap` is protected): grass < 16, 
 - Testing other Map behaviors (`doesUnitTouch*`, `doesPosTouch*`, `setClearingArea*`, `markImmobileUnit`, etc.).
 - Adding regression tests around any Map state mutator before refactoring it.
 - **Don't use** for behaviors that genuinely need real `Game` / `Team` / `Unit` / `Building` wiring (e.g. `doesUnitTouchEnemy` reaches into `game->teams[]->myBuildings[]`) — those need either a different stub set or a refactor to decouple first.
+
+## Real LAN session regression
+
+From the repository root:
+
+```sh
+scons -j2 release=1 server=0 lan-test
+python3 test/run_lan_session_test.py build/src/LANSessionHarness
+```
+
+This runs separate host and joining client processes with real SDL lobby widgets,
+YOG anonymous LAN server, game router, and TCP connections. The joiner uses the
+actual `LANFindScreen` Connect path. It clicks Ready and Leave Game, then rejoins.
+Both cycles force a map download and compare all 616018 bytes against the fixture
+source (`maps/FourSquares1.map`). The host verifies readiness, roster size, unique
+player IDs, slot masks, and both departures. The map's current size is not hardcoded
+in the test. Linux CI runs this automatically with SDL's dummy video/audio drivers.
+
+For two physical machines, run these from each machine's repository root, using
+absolute capture prefixes whose parent directories already exist:
+
+```sh
+SDL_VIDEODRIVER=dummy ./build/src/LANSessionHarness host 127.0.0.1 2 /tmp/lan-host
+SDL_VIDEODRIVER=dummy ./build/src/LANSessionHarness join HOST_IP 2 /tmp/lan-guest
+```
+
+Start the joiner after the host prints `HOST roster=1`. TCP ports 7489 and 7491
+must be reachable; this does not connect to the public YOG service. Omit
+`SDL_VIDEODRIVER=dummy` to show the real window. Normal game profiles are preserved;
+the harness uses `.glob2-lan-test-host` and `.glob2-lan-test-join` profiles containing
+only test data. Fixed input timers allow map transfer before leaving; the runner
+bounds startup, execution, and child cleanup. Logs and captures are written under
+`output/lan-session-test` by default (`--output` overrides it).

--- a/test/run_lan_session_test.py
+++ b/test/run_lan_session_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Run real host/join/ready/leave/rejoin clients on loopback (no public YOG)."""
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("output/lan-session-test"))
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.setdefault("SDL_VIDEODRIVER", "dummy")
+    env.setdefault("SDL_AUDIODRIVER", "dummy")
+    host_log = output / "host.log"
+    join_log = output / "join.log"
+    with host_log.open("w") as host_out, join_log.open("w") as join_out:
+        host = subprocess.Popen(
+            [str(binary), "host", "127.0.0.1", "2", str(output / "host")],
+            stdout=host_out, stderr=subprocess.STDOUT, env=env,
+        )
+        try:
+            deadline = time.monotonic() + 20
+            while "HOST roster=1" not in host_log.read_text():
+                if host.poll() is not None or time.monotonic() >= deadline:
+                    raise RuntimeError("Host did not publish a lobby")
+                time.sleep(0.1)
+            joined = subprocess.run(
+                [str(binary), "join", "127.0.0.1", "2", str(output / "join")],
+                stdout=join_out, stderr=subprocess.STDOUT, env=env, timeout=100,
+            )
+            if joined.returncode != 0:
+                raise RuntimeError(f"Join/transfer/leave test exited {joined.returncode}")
+            if host.wait(timeout=15) != 0:
+                raise RuntimeError("Host roster/readiness verification failed")
+        except (RuntimeError, subprocess.TimeoutExpired) as error:
+            print(f"LAN session regression FAIL: {error}")
+            print(host_log.read_text())
+            print(join_log.read_text())
+            return 1
+        finally:
+            if host.poll() is None:
+                host.terminate()
+                try:
+                    host.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    host.kill()
+                    host.wait()
+    print(host_log.read_text())
+    print(join_log.read_text())
+    print("LAN session regression PASS: two ready/join/leave cycles and exact map downloads")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Joining a LAN game currently opens an empty tab container, so the guest never sees the multiplayer lobby or pumps its game updates. Restore the multiplayer screen for the lifetime of the join session.

Real client testing also exposed two map-transfer failures after joining: the server loops forever over a recipient waiting for the file header, and a second download request restarts the same upload and appends duplicate chunks. Advance the pending recipient and mark the shared upload as started when requesting it.

Add an integration harness that uses real SDL lobby widgets, anonymous LAN server, router, and TCP connections. It enters through `LANFindScreen`, clicks Ready and Leave Game, rejoins, and forces a private map download each time. Both downloads must match the source byte for byte; the host checks readiness, roster size, unique player IDs, slot masks, and departures. A bounded Python runner runs it in Ubuntu CI using SDL's dummy video/audio drivers.

The rendered test also exposed signed overflow in the background terrain generator. Use unsigned 32-bit wraparound without changing the generated tile pattern.

Validation:
- Real network sessions passed on `pharaoh-dev-1` (host) → `pharaoh-dev-2` (guest), `pharaoh-dev-3` → `therig`, and `pharaoh-dev-1` → macOS (visible SDL window). Every pair completed two ready/leave/rejoin cycles and two exact 616,018-byte map downloads; both processes exited zero.
- macOS optimized and AddressSanitizer/UndefinedBehaviorSanitizer loopback sessions passed; sanitizer run used `UBSAN_OPTIONS=halt_on_error=1`, with no suppressions. Linux optimized loopback passed too.
- macOS release client and YOG server builds passed. All four physical Linux hosts ran the same SHA-256-verified Ubuntu 26.04/GCC 15.2 binary built from the final changed source.
- Negative controls: the original empty-lobby path fails the UI test; restoring the old server behavior fails the download regression.

These tests cover the LAN lobby, readiness, departures, and map transfer. They do not start a match or validate gameplay synchronization. Final CI results are recorded in the verification comment before merging.

Fixes #90.
