### PR TITLE
Use singular they for generic units and players

### DIFF
--- a/data/texts.en.txt
+++ b/data/texts.en.txt
@@ -1189,7 +1189,7 @@ The provided passwords don't match. Please retype them.
 [YESTS_UNABLE_TO_CONNECT]
 Unable to connect. Apparently, the YOG metaserver is down.
 [yog block command help]
-/block <playername>    Blocks a player; you will no longer see his text.
+/block <playername>    Blocks a player; you will no longer see their text.
 [yog block command player %0 already blocked]
 Player %0 already blocked
 [yog block command player %0 blocked]

--- a/scripts/tutorial_part3.sgsl
+++ b/scripts/tutorial_part3.sgsl
@@ -63,7 +63,7 @@ hide
 hilightUnits(Warrior)
 wait(Warrior(0) > 0)
 
-show("Whoa! Those warrior globs certainly look beefy and mighty. They would certainly do well to defend our colony. You probably noticed that he's wasting no time and going right to work, that is, training. Let's wait for another one to come.")
+show("Whoa! Those warrior globs certainly look beefy and mighty. They would certainly do well to defend our colony. You probably noticed that they're wasting no time and going right to work, that is, training. Let's wait for another one to come.")
 show("Wow ! Cette guerrière a l'air musclée et puissante, elle conviendra certainement à la défense de notre colonie. Vous pourriez remarquer qu'elle ne perd pas de temps et se met tout de suite au travail. Attendons qu'une deuxième soit prête.", fr)
 show("Whoah! Diese Krieger sehen muskulös und gewaltig aus. Sie werden deine Kolonie sicher gut verteidigen. Dir wird aufgefallen sein, dass er keine Zeit verschwendet und gleich zum Training geht. Lass uns warten bis ein weiterer fertig ist.",de)
 show("Esos glóbulos guerreros se ven tan grandes y poderosos!!, defenderán bien nuestra colonia.  Te habrás dado cuenta que no desperdician su tiempo y van de una vez a trabajar, entrenando.  Esperemos a que salga el siguiente.",es)

--- a/scripts/tutorial_part4.sgsl
+++ b/scripts/tutorial_part4.sgsl
@@ -32,7 +32,7 @@ show("Ха-ха-ха! У нас есть всё о чём хорошая кол�
 show("ﻫﺎﻫﺎﻫﺎ! ﺃﺻﺒﺢ ﻟﺪﻳﻨﺎ ﻛﻞ ﻣﺎ ﺗﺤﺘﺎﺟﻪ ﺍﻟﻤﺴﺘﻌﻤﺮﺍﺕ ﺍﻟﺠﻴﺪﺓ! ﻟﺪﻳﻨﺎ ﺍﻟﺤﻤﺎﻳﺔ، ﻭﺍﻟﻤﺒﺎﻧﻲ ﺍﻟﻤﺘﻄﻮﺭﺓ، ﻭﺍﻟﻤﺪﺍﺭﺱ، ﻭﻣﺴﺘﺸﻔﻰ، ﻭﺑﻌﺾ ﺍﻟﻤﻨﺎﺯﻝ، ﻭﻣﻴﺪﺍﻥ ﻟﻠﺴﺒﺎﻕ، ﻭﺑﺮﻛﺔ ﻟﻠﺴﺒﺎﺣﺔ، ﻓﻤﺎ ﺍﻟﺬﻱ ﻗﺪ ﻳﺘﻤﻨﺎﻩ ﺍﻟﻤﺮء ﺑﻌﺪ ﻛﻞ ﻫﺬﺍ؟ ﻓﻲ ﺍﻟﻮﺍﻗﻊ ﻻ ﻳﺒﺪﻭ ﺃﻧﻪ ﻗﺪ ﺗﺒﻘﻰ ﺃﻣﺎﻣﻨﺎ ﺍﻟﻜﺜﻴﺮ. ﺑﺈﻣﻜﺎﻧﻚ ﺍﻻﺳﺘﻤﺮﺍﺭ ﻓﻲ ﺗﺮﻗﻴﺔ ﺍﻟﻤﺒﺎﻧﻲ ﺇﻥ ﺭﻏﺒﺖ. ﻓﻔﻲ ﺍﻟﻮﺍﻗﻊ ﻣﺎ ﻳﺰﺍﻝ ﻫﻨﺎﻙ ﻣﺴﺘﻮﻯ ﺃﻋﻠﻰ ﻣﻦ ﻣﺴﺘﻮﻯ ﻣﺒﺎﻧﻴﻚ ﺍﻟﺤﺎﻟﻴﺔ. ﺇﻧﻪ ﺍﻟﻤﺴﺘﻮﻯ ٣ ﺍﻟﺨﺎﺭﻕ! ﻳﺠﺐ ﺃﻥ ﺗﺠﻌﻞ ﺍﻟﻮﺻﻮﻝ ﺇﻟﻰ ﺍﻟﻤﺴﺘﻮﻯ ﺍﻟﺜﺎﻟﺚ ﻣﻦ ﺃﻫﺪﺍﻓﻚ ﻓﻲ ﺍﻟﻠﻌﺐ، ﻓﻬﻮ ﻳﻌﻄﻴﻚ ﺃﻓﻀﻠﻴﺔ ﻛﺒﻴﺮﺓ ﻋﻠﻰ ﻋﺪﻭﻙ.",ar)
 space
 
-show("Talking about enemies, have you managed to spot yours? I think he is hiding north-west from our base. You can scroll there now.")
+show("Talking about enemies, have you managed to spot yours? I think they're hiding north-west from our base. You can scroll there now.")
 show("En parlant d'ennemis, avez-vous pensé à rechercher les vôtres ? Je pense qu'ils se cachent au Nord-Ouest de notre base. Vous pouvez aller regarder dès maintenant.", fr)
 show("Wo wir gerade über Feinde reden: Hast du es geschafft deinen zu finden? Ich denke er versteckt sich im Nordwesten deiner Basis. Du kannst nun dorthin scrollen.",de)
 show("Hablando de enemigos  ¿Haz logrado ver dónde están los tuyos?  Creo que se esconde al noroeste de nuestra base, puedes dar un vistazo.",es)


### PR DESCRIPTION
Switches three English strings that refer to a non-gendered unit or player from "he/his" to the singular "they":

- `scripts/tutorial_part3.sgsl` — a warrior glob ("he's wasting no time" → "they're wasting no time")
- `scripts/tutorial_part4.sgsl` — an enemy player ("I think he is hiding" → "I think they're hiding")
- `data/texts.en.txt` — the `/block` command help ("you will no longer see his text" → "their text")

None of these refer to a gendered individual, so the singular "they" is simply more accurate.

Only the English strings change. The French, German, and Spanish versions of these lines are left as-is: French and German bind the pronoun to the grammatical gender of the noun (there is no neutral singular equivalent), and the Spanish lines already avoid a gendered pronoun.