### PR TITLE
Reject truncated map data and preserve autosaves on write failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,10 +120,10 @@ jobs:
       - name: Build glob2
         run: scons -j$(nproc) release=1 mingw=1
 
-      - name: Build the YOG server
-        run: scons -j$(nproc) release=1 mingw=1 server=1 --build=build-server
-
       - name: Test savegame loading and atomic autosaves
         run: |
           scons -j$(nproc) release=1 mingw=1 server=0 savegame-safety-test
           python3 test/run-savegame-safety-tests.py build/src/SavegameSafetyHarness.exe
+
+      - name: Build the YOG server
+        run: scons -j$(nproc) release=1 mingw=1 server=1 --build=build-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
           scons -j$(nproc) release=1 server=0 selection-test
           ./build/src/GameGUISelectionHarness
 
+      - name: Test savegame loading and atomic autosaves
+        run: |
+          scons -j$(nproc) release=1 server=0 savegame-safety-test
+          python3 test/run-savegame-safety-tests.py build/src/SavegameSafetyHarness
+
       - name: Build the YOG server
         run: scons -j$(nproc) release=1 server=1 --build=build-server
 
@@ -117,3 +122,8 @@ jobs:
 
       - name: Build the YOG server
         run: scons -j$(nproc) release=1 mingw=1 server=1 --build=build-server
+
+      - name: Test savegame loading and atomic autosaves
+        run: |
+          scons -j$(nproc) release=1 mingw=1 server=0 savegame-safety-test
+          python3 test/run-savegame-safety-tests.py build/src/SavegameSafetyHarness.exe

--- a/libgag/include/BinaryStream.h
+++ b/libgag/include/BinaryStream.h
@@ -61,12 +61,27 @@ namespace GAGCore
 	{
 	private:
 		StreamBackend *backend;
+		bool checkedReads = false;
 		
 	public:
 		BinaryInputStream(StreamBackend *backend) { this->backend = backend; }
 		virtual ~BinaryInputStream() { delete backend; }
 	
-		virtual void read(void *data, size_t size, const std::string name) { backend->read(data, size); }
+		class CheckedReads
+		{
+			BinaryInputStream *stream;
+			bool previous;
+		public:
+			explicit CheckedReads(InputStream *input) : stream(dynamic_cast<BinaryInputStream *>(input)), previous(stream && stream->checkedReads)
+			{
+				if (stream) stream->checkedReads = true;
+			}
+			~CheckedReads() { if (stream) stream->checkedReads = previous; }
+			CheckedReads(const CheckedReads&) = delete;
+			CheckedReads& operator=(const CheckedReads&) = delete;
+		};
+
+		virtual void read(void *data, size_t size, const std::string name);
 	
 		virtual void readEndianIndependent(void *v, size_t size, const std::string name);
 	

--- a/libgag/include/FileManager.h
+++ b/libgag/include/FileManager.h
@@ -46,6 +46,7 @@ namespace GAGCore
 		int fileListIndex;
 	
 	private:
+		static bool isAbsolutePath(const std::string& path);
 		//! clear the list of file for directory listing
 		void clearFileList(void);
 		//! internal function that does the real listing job

--- a/libgag/include/FileManager.h
+++ b/libgag/include/FileManager.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <fstream>
 #include <string>
+#include <functional>
 
 //! this is the host filesystem directory separator
 #ifndef DIR_SEPARATOR
@@ -19,6 +20,7 @@
 namespace GAGCore
 {
 	class StreamBackend;
+	class OutputStream;
 	
 	//! File Manager (filesystem abstraction)
 	class FileManager
@@ -85,6 +87,9 @@ namespace GAGCore
 		//! Open an output stream backend, use it to construct specific output streams
 		StreamBackend *openOutputStreamBackend(const std::string filename);
 		
+		//! Replace a file only after the writer, flush, and close all succeed.
+		bool writeAtomically(const std::string& filename, const std::function<void(OutputStream&)>& writer);
+
 		//! Open an input stream backend, use it to construct specific input streams
 		StreamBackend *openInputStreamBackend(const std::string filename);
 		

--- a/libgag/include/StreamBackend.h
+++ b/libgag/include/StreamBackend.h
@@ -27,6 +27,12 @@ namespace GAGCore
 		virtual void write(const void *data, const size_t size) = 0;
 		virtual void flush(void) = 0;
 		virtual void read(void *data, size_t size) = 0;
+		virtual bool readExact(void *data, size_t size)
+		{
+			const size_t before = getPosition();
+			read(data, size);
+			return getPosition() - before == size;
+		}
 		virtual void putc(int c) = 0;
 		virtual int getChar(void) = 0;
 		virtual void seekFromStart(int displacement) = 0;
@@ -40,7 +46,7 @@ namespace GAGCore
 	//! The FILE* implementation of stream backend
 	class FileStreamBackend : public StreamBackend
 	{
-	private:
+	protected:
 		FILE *fp;
 		
 	public:
@@ -51,6 +57,7 @@ namespace GAGCore
 		virtual void write(const void *data, const size_t size) { assert(fp); fwrite(data, size, 1 ,fp); }
 		virtual void flush(void) { assert(fp); fflush(fp); }
 		virtual void read(void *data, size_t size) { assert(fp); fread(data, size, 1, fp); }
+		virtual bool readExact(void *data, size_t size) { return fp && fread(data, 1, size, fp) == size; }
 		virtual void putc(int c) { assert(fp); fputc(c, fp); }
 		virtual int getChar(void) { assert(fp); return fgetc(fp); }
 		virtual void seekFromStart(int displacement) { assert(fp); fseek(fp, displacement, SEEK_SET); }

--- a/libgag/src/BinaryStream.cpp
+++ b/libgag/src/BinaryStream.cpp
@@ -63,9 +63,21 @@ namespace GAGCore
 		SHA1Final(sha1, &sha1Context);
 	}
 	
+	void BinaryInputStream::read(void *data, size_t size, const std::string name)
+	{
+		if (size == 0) return;
+		if (checkedReads)
+		{
+			if (!backend->readExact(data, size))
+				throw std::ios_base::failure("Incomplete binary field: " + name);
+		}
+		else
+			backend->read(data, size);
+	}
+
 	void BinaryInputStream::readEndianIndependent(void *v, size_t size, const std::string name)
 	{
-		backend->read(v, size);
+		read(v, size, name);
 		if (size==2)
 		{
 			*(Uint16 *)v = ntohs(*(Uint16 *)v);
@@ -91,9 +103,6 @@ namespace GAGCore
 	std::string BinaryInputStream::readText(const std::string name)
 	{
 		size_t len = readUint32("");
-		std::valarray<char> buffer(len+1);
-		read(&buffer[0], len, "");
-		buffer[len] = 0;
 
 		// We don't use strings longer than MAX_BINARY_STRING_LENGTH, so beyond that the bits don't represent a string.
 		if (len > MAX_BINARY_STRING_LENGTH)
@@ -104,6 +113,10 @@ namespace GAGCore
 			//  - MapEdit.cpp : 1135
 			throw std::ios_base::failure("String "+name+" length > "+std::to_string(MAX_BINARY_STRING_LENGTH));
 		}
+
+		std::valarray<char> buffer(len+1);
+		read(&buffer[0], len, "");
+		buffer[len] = 0;
 
 		return std::string(&buffer[0]);
 	}

--- a/libgag/src/FileManager.cpp
+++ b/libgag/src/FileManager.cpp
@@ -9,10 +9,6 @@
 #include <SDL_endian.h>
 #include <iostream>
 #include <valarray>
-#include <atomic>
-#ifndef WIN32
-#include <unistd.h>
-#endif
 #include <zlib.h>
 #include "BinaryStream.h"
 #include "TextStream.h"
@@ -56,7 +52,7 @@ namespace GAGCore
 	// passing absolute paths (e.g. --save-game-as /tmp/foo.game) need direct
 	// access. POSIX absolutes start with '/'; Windows absolutes can also be
 	// drive-letter ("C:\..." / "C:/...") or UNC ("\\server\share").
-	static bool isAbsolutePath(const std::string& path)
+	bool FileManager::isAbsolutePath(const std::string& path)
 	{
 		if (path.empty()) return false;
 		if (path[0] == '/') return true;
@@ -235,98 +231,6 @@ namespace GAGCore
 		return new FileStreamBackend(NULL);
 	}
 	
-	namespace
-	{
-		class CheckedFileBackend : public FileStreamBackend
-		{
-		public:
-			explicit CheckedFileBackend(FILE *file) : FileStreamBackend(file) {}
-			void write(const void *data, size_t size) override
-			{
-				if (fwrite(data, 1, size, fp) != size)
-					throw std::ios_base::failure("File write failed");
-			}
-			void flush() override
-			{
-				if (fflush(fp) != 0 || ferror(fp))
-					throw std::ios_base::failure("File flush failed");
-			}
-			void seekFromStart(int offset) override { seek(offset, SEEK_SET); }
-			void seekFromEnd(int offset) override { seek(offset, SEEK_END); }
-			void seekRelative(int offset) override { seek(offset, SEEK_CUR); }
-			size_t getPosition() override
-			{
-				const long position = ftell(fp);
-				if (position < 0) throw std::ios_base::failure("File position failed");
-				return static_cast<size_t>(position);
-			}
-			void close()
-			{
-				FILE *file = fp;
-				fp = NULL;
-				if (fclose(file) != 0)
-					throw std::ios_base::failure("File close failed");
-			}
-		private:
-			void seek(int offset, int origin)
-			{
-				if (fseek(fp, offset, origin) != 0)
-					throw std::ios_base::failure("File seek failed");
-			}
-		};
-	}
-
-	bool FileManager::writeAtomically(const std::string& filename, const std::function<void(OutputStream&)>& writer)
-	{
-		std::vector<std::string> paths;
-		if (isAbsolutePath(filename)) paths.push_back(filename);
-		else for (const auto& directory : dirList)
-			paths.push_back(directory + DIR_SEPARATOR + filename);
-
-		static std::atomic<unsigned long> sequence{0};
-#ifdef WIN32
-		const auto process = GetCurrentProcessId();
-#else
-		const auto process = getpid();
-#endif
-		for (const auto& path : paths)
-		{
-			FILE *file = NULL;
-			std::string temporary;
-			for (int attempt = 0; attempt < 100; ++attempt)
-			{
-				temporary = path + ".tmp-" + std::to_string(process) + "-" + std::to_string(sequence++);
-				file = fopen(temporary.c_str(), "wbx");
-				if (file || errno != EEXIST) break;
-			}
-			if (!file) continue;
-
-			try
-			{
-				auto *backend = new CheckedFileBackend(file);
-				BinaryOutputStream stream(backend);
-				writer(stream);
-				stream.flush();
-				backend->close();
-#ifdef WIN32
-				if (!MoveFileExA(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING))
-#else
-				if (std::rename(temporary.c_str(), path.c_str()) != 0)
-#endif
-					throw std::ios_base::failure("File replacement failed");
-				return true;
-			}
-			catch (const std::exception& error)
-			{
-				std::remove(temporary.c_str());
-				std::cerr << "FileManager::writeAtomically: " << path << ": " << error.what() << std::endl;
-				return false;
-			}
-		}
-		std::cerr << "FileManager::writeAtomically: cannot create temporary file for " << filename << std::endl;
-		return false;
-	}
-
 	StreamBackend *FileManager::openInputStreamBackend(const std::string filename)
 	{
 		if (isAbsolutePath(filename))

--- a/libgag/src/FileManager.cpp
+++ b/libgag/src/FileManager.cpp
@@ -9,6 +9,10 @@
 #include <SDL_endian.h>
 #include <iostream>
 #include <valarray>
+#include <atomic>
+#ifndef WIN32
+#include <unistd.h>
+#endif
 #include <zlib.h>
 #include "BinaryStream.h"
 #include "TextStream.h"
@@ -231,6 +235,98 @@ namespace GAGCore
 		return new FileStreamBackend(NULL);
 	}
 	
+	namespace
+	{
+		class CheckedFileBackend : public FileStreamBackend
+		{
+		public:
+			explicit CheckedFileBackend(FILE *file) : FileStreamBackend(file) {}
+			void write(const void *data, size_t size) override
+			{
+				if (fwrite(data, 1, size, fp) != size)
+					throw std::ios_base::failure("File write failed");
+			}
+			void flush() override
+			{
+				if (fflush(fp) != 0 || ferror(fp))
+					throw std::ios_base::failure("File flush failed");
+			}
+			void seekFromStart(int offset) override { seek(offset, SEEK_SET); }
+			void seekFromEnd(int offset) override { seek(offset, SEEK_END); }
+			void seekRelative(int offset) override { seek(offset, SEEK_CUR); }
+			size_t getPosition() override
+			{
+				const long position = ftell(fp);
+				if (position < 0) throw std::ios_base::failure("File position failed");
+				return static_cast<size_t>(position);
+			}
+			void close()
+			{
+				FILE *file = fp;
+				fp = NULL;
+				if (fclose(file) != 0)
+					throw std::ios_base::failure("File close failed");
+			}
+		private:
+			void seek(int offset, int origin)
+			{
+				if (fseek(fp, offset, origin) != 0)
+					throw std::ios_base::failure("File seek failed");
+			}
+		};
+	}
+
+	bool FileManager::writeAtomically(const std::string& filename, const std::function<void(OutputStream&)>& writer)
+	{
+		std::vector<std::string> paths;
+		if (isAbsolutePath(filename)) paths.push_back(filename);
+		else for (const auto& directory : dirList)
+			paths.push_back(directory + DIR_SEPARATOR + filename);
+
+		static std::atomic<unsigned long> sequence{0};
+#ifdef WIN32
+		const auto process = GetCurrentProcessId();
+#else
+		const auto process = getpid();
+#endif
+		for (const auto& path : paths)
+		{
+			FILE *file = NULL;
+			std::string temporary;
+			for (int attempt = 0; attempt < 100; ++attempt)
+			{
+				temporary = path + ".tmp-" + std::to_string(process) + "-" + std::to_string(sequence++);
+				file = fopen(temporary.c_str(), "wbx");
+				if (file || errno != EEXIST) break;
+			}
+			if (!file) continue;
+
+			try
+			{
+				auto *backend = new CheckedFileBackend(file);
+				BinaryOutputStream stream(backend);
+				writer(stream);
+				stream.flush();
+				backend->close();
+#ifdef WIN32
+				if (!MoveFileExA(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING))
+#else
+				if (std::rename(temporary.c_str(), path.c_str()) != 0)
+#endif
+					throw std::ios_base::failure("File replacement failed");
+				return true;
+			}
+			catch (const std::exception& error)
+			{
+				std::remove(temporary.c_str());
+				std::cerr << "FileManager::writeAtomically: " << path << ": " << error.what() << std::endl;
+				return false;
+			}
+		}
+		std::cerr << "FileManager::writeAtomically: cannot create temporary file for " << filename << std::endl;
+		return false;
+	}
+
 	StreamBackend *FileManager::openInputStreamBackend(const std::string filename)
 	{
 		if (isAbsolutePath(filename))

--- a/libgag/src/FileManagerAtomic.cpp
+++ b/libgag/src/FileManagerAtomic.cpp
@@ -6,6 +6,9 @@
 #include <memory>
 #ifdef WIN32
 #include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
 #else
 #include <unistd.h>
 #endif
@@ -14,6 +17,26 @@ namespace GAGCore
 {
 	namespace
 	{
+		FILE *openExclusive(const std::string& path)
+		{
+#ifdef WIN32
+			const int fd = _open(path.c_str(), _O_WRONLY | _O_CREAT | _O_EXCL | _O_BINARY,
+				_S_IREAD | _S_IWRITE);
+			if (fd < 0) return NULL;
+			FILE *file = _fdopen(fd, "wb");
+			if (!file)
+			{
+				const int error = errno;
+				_close(fd);
+				std::remove(path.c_str());
+				errno = error;
+			}
+			return file;
+#else
+			return fopen(path.c_str(), "wbx");
+#endif
+		}
+
 		class CheckedFileBackend : public FileStreamBackend
 		{
 		public:
@@ -73,7 +96,7 @@ namespace GAGCore
 			for (int attempt = 0; attempt < 100; ++attempt)
 			{
 				temporary = path + ".tmp-" + std::to_string(process) + "-" + std::to_string(sequence++);
-				file = fopen(temporary.c_str(), "wbx");
+				file = openExclusive(temporary);
 				if (file || errno != EEXIST) break;
 			}
 			if (!file) continue;

--- a/libgag/src/FileManagerAtomic.cpp
+++ b/libgag/src/FileManagerAtomic.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <FileManager.h>
+#include <BinaryStream.h>
+#include <atomic>
+#include <cerrno>
+#include <memory>
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace GAGCore
+{
+	namespace
+	{
+		class CheckedFileBackend : public FileStreamBackend
+		{
+		public:
+			explicit CheckedFileBackend(FILE *file) : FileStreamBackend(file) {}
+			void write(const void *data, size_t size) override
+			{
+				if (fwrite(data, 1, size, fp) != size)
+					throw std::ios_base::failure("File write failed");
+			}
+			void flush() override
+			{
+				if (fflush(fp) != 0 || ferror(fp))
+					throw std::ios_base::failure("File flush failed");
+			}
+			void seekFromStart(int offset) override { seek(offset, SEEK_SET); }
+			void seekFromEnd(int offset) override { seek(offset, SEEK_END); }
+			void seekRelative(int offset) override { seek(offset, SEEK_CUR); }
+			size_t getPosition() override
+			{
+				const long position = ftell(fp);
+				if (position < 0) throw std::ios_base::failure("File position failed");
+				return static_cast<size_t>(position);
+			}
+			void close()
+			{
+				FILE *file = fp;
+				fp = NULL;
+				if (fclose(file) != 0)
+					throw std::ios_base::failure("File close failed");
+			}
+		private:
+			void seek(int offset, int origin)
+			{
+				if (fseek(fp, offset, origin) != 0)
+					throw std::ios_base::failure("File seek failed");
+			}
+		};
+	}
+
+	bool FileManager::writeAtomically(const std::string& filename, const std::function<void(OutputStream&)>& writer)
+	{
+		std::vector<std::string> paths;
+		if (isAbsolutePath(filename)) paths.push_back(filename);
+		else for (const auto& directory : dirList)
+			paths.push_back(directory + DIR_SEPARATOR + filename);
+
+		static std::atomic<unsigned long> sequence{0};
+#ifdef WIN32
+		const auto process = GetCurrentProcessId();
+#else
+		const auto process = getpid();
+#endif
+		for (const auto& path : paths)
+		{
+			FILE *file = NULL;
+			std::string temporary;
+			for (int attempt = 0; attempt < 100; ++attempt)
+			{
+				temporary = path + ".tmp-" + std::to_string(process) + "-" + std::to_string(sequence++);
+				file = fopen(temporary.c_str(), "wbx");
+				if (file || errno != EEXIST) break;
+			}
+			if (!file) continue;
+
+			try
+			{
+				std::unique_ptr<FILE, decltype(&std::fclose)> owner(file, &std::fclose);
+				auto *backend = new CheckedFileBackend(file);
+				owner.release();
+				BinaryOutputStream stream(backend);
+				writer(stream);
+				stream.flush();
+				backend->close();
+#ifdef WIN32
+				if (!MoveFileExA(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING))
+#else
+				if (std::rename(temporary.c_str(), path.c_str()) != 0)
+#endif
+					throw std::ios_base::failure("File replacement failed");
+				return true;
+			}
+			catch (const std::exception& error)
+			{
+				std::remove(temporary.c_str());
+				std::cerr << "FileManager::writeAtomically: " << path << ": " << error.what() << std::endl;
+				return false;
+			}
+		}
+		std::cerr << "FileManager::writeAtomically: cannot create temporary file for " << filename << std::endl;
+		return false;
+	}
+
+}

--- a/libgag/src/SConscript
+++ b/libgag/src/SConscript
@@ -1,5 +1,5 @@
 libgag_sources = Split("""
-BinaryStream.cpp    CursorManager.cpp     FileManager.cpp   FormatableString.cpp
+BinaryStream.cpp    CursorManager.cpp     FileManager.cpp FileManagerAtomic.cpp   FormatableString.cpp
 GraphicContext.cpp GraphicContextDraw.cpp GraphicContextCompound.cpp
 DrawableSurface.cpp DrawableSurfaceDraw.cpp DrawableSurfaceCompound.cpp
 GUIAnimation.cpp    GUIBase.cpp           GUIButton.cpp
@@ -15,7 +15,7 @@ GUITabScreen.cpp    GUITabScreenWindow.cpp  TextSort.cpp    GUICheckList.cpp
 
 libgag_just_server = Split("""
 
-BinaryStream.cpp     Stream.cpp     FileManager.cpp   FormatableString.cpp
+BinaryStream.cpp     Stream.cpp     FileManager.cpp FileManagerAtomic.cpp   FormatableString.cpp
 TextStream.cpp      StreamFilter.cpp   StreamBackend.cpp StringTable.cpp  Toolkit.cpp
 """)
 

--- a/libusl/src/lexer.cpp
+++ b/libusl/src/lexer.cpp
@@ -40,7 +40,7 @@ const Token Tokenizer::next()
 
 const Token::Type Lexer::tokenTypes[] =
 {
-	Token::Type(SPACE,   "a space",                 "[[:blank:]]+"),
+	Token::Type(SPACE,   "a space",                 "[ \t]+"),
 	Token::Type(VAL,     "'val'",                   "val"),
 	Token::Type(DEF,     "'def'",                   "def"),
 	Token::Type(FUN,     "'fun'",                   "fun"),

--- a/src/SConscript
+++ b/src/SConscript
@@ -496,6 +496,12 @@ if not env['server']:
     speed_test = local.Program('game-speed-tests', speed_sources)
     local.Alias('speed-tests', speed_test)
 
+if not env['server']:
+    savegame_sources = [source for source in source_files if source != 'Glob2.cpp']
+    savegame_sources += local.Object('SavegameSafetyHarness.o', '#test/SavegameSafetyHarness.cpp')
+    savegame_test = local.Program('SavegameSafetyHarness', savegame_sources)
+    local.Alias('savegame-safety-test', savegame_test)
+
 #Add libgag, not as a library, but as an object
 server_source_files.append("../libgag/src/libgag_server.a")
 p2 = local.Program("glob2-server", server_source_files)

--- a/src/SConscript
+++ b/src/SConscript
@@ -499,7 +499,11 @@ if not env['server']:
 if not env['server']:
     savegame_sources = [source for source in source_files if source != 'Glob2.cpp']
     savegame_sources += local.Object('SavegameSafetyHarness.o', '#test/SavegameSafetyHarness.cpp')
-    savegame_test = local.Program('SavegameSafetyHarness', savegame_sources)
+    savegame_env = local.Clone()
+    # Headless tests use a console entry point so failures reach the CI log.
+    savegame_env['LINKFLAGS'] = [flag for flag in local['LINKFLAGS'] if flag != '-mwindows']
+    savegame_env['LIBS'] = [lib for lib in local['LIBS'] if lib != 'SDL2main']
+    savegame_test = savegame_env.Program('SavegameSafetyHarness', savegame_sources)
     local.Alias('savegame-safety-test', savegame_test)
 
 #Add libgag, not as a library, but as an object

--- a/src/SConscript
+++ b/src/SConscript
@@ -501,7 +501,7 @@ if not env['server']:
     savegame_sources += local.Object('SavegameSafetyHarness.o', '#test/SavegameSafetyHarness.cpp')
     savegame_env = local.Clone()
     # Headless tests use a console entry point so failures reach the CI log.
-    savegame_env['LINKFLAGS'] = [flag for flag in local['LINKFLAGS'] if flag != '-mwindows']
+    savegame_env['LINKFLAGS'] = [flag for flag in local.Split(local['LINKFLAGS']) if flag != '-mwindows']
     savegame_env['LIBS'] = [lib for lib in local['LIBS'] if lib != 'SDL2main']
     savegame_test = savegame_env.Program('SavegameSafetyHarness', savegame_sources)
     local.Alias('savegame-safety-test', savegame_test)

--- a/src/gui/GameGUIStep.cpp
+++ b/src/gui/GameGUIStep.cpp
@@ -323,16 +323,8 @@ void GameGUI::syncStep(void)
 	{
 		const std::string name = Toolkit::getStringTable()->getString("[auto save]");
 		std::string fileName = glob2NameToFilename("games", name, "game");
-		OutputStream *stream = new BinaryOutputStream(Toolkit::getFileManager()->openOutputStreamBackend(fileName));
-		if (stream->isEndOfStream())
-		{
-			std::cerr << "GameGUI::syncStep : can't open autosave file " << name << " for writing" << std::endl;
-		}
-		else
-		{
-			save(stream, name);
-		}
-		delete stream;
+		if (!Toolkit::getFileManager()->writeAtomically(fileName, [&](OutputStream& stream) { save(&stream, name); }))
+			std::cerr << "GameGUI::syncStep: autosave failed; previous save retained" << std::endl;
 	}
 }
 

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -111,110 +111,44 @@ Map::~Map(void)
 
 void Map::clear()
 {
-	if (arraysBuilt)
+	// A failed load can own only a subset of these arrays.
+	for (int t=0; t<Team::MAX_COUNT; ++t)
 	{
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			if (resourcesGradient[t][0][0])
-				for (int r=0; r<MAX_RESOURCES; r++)
-					for (int s=0; s<2; s++)
-					{
-						assert(resourcesGradient[t][r][s]);
-						delete[] resourcesGradient[t][r][s];
-						resourcesGradient[t][r][s] = NULL;
-					}
-		
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			if (forbiddenGradient[t][0])
-				for (int s=0; s<2; s++)
-				{
-					assert(forbiddenGradient[t][s]);
-					delete[] forbiddenGradient[t][s];
-					forbiddenGradient[t][s] = NULL;
-					assert(guardAreasGradient[t][s]);
-					delete[] guardAreasGradient[t][s];
-					guardAreasGradient[t][s] = NULL;
-					assert(clearAreasGradient[t][s]);
-					delete[] clearAreasGradient[t][s];
-					clearAreasGradient[t][s] = NULL;
-					
-					guardGradientUpdated[t][s] = false;
-					clearGradientUpdated[t][s] = false;
-				}
-		
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			if (exploredArea[t])
+		for (int r=0; r<MAX_RESOURCES; ++r)
+			for (int swim=0; swim<2; ++swim)
 			{
-				assert(exploredArea[t]);
-				delete[] exploredArea[t];
-				exploredArea[t] = NULL;
+				delete[] resourcesGradient[t][r][swim];
+				resourcesGradient[t][r][swim] = NULL;
+				gradientUpdated[t][r][swim] = false;
 			}
-		
-		assert(undermap);
-		delete[] undermap;
-		undermap=NULL;
-		
-		assert(sectors);
-		delete[] sectors;
-		sectors=NULL;
-
-		assert(listedAddr);
-		delete[] listedAddr;
-		listedAddr=NULL;
-		
-		assert(aStarPoints);
-		delete[] aStarPoints;
-		aStarPoints=NULL;
-
-		for (int t=0; t<Team::MAX_COUNT; t++)
+		for (int swim=0; swim<2; ++swim)
 		{
-			if (clearingAreaClaims[t])
-			{
-				assert(clearingAreaClaims[t]);
-				delete[] clearingAreaClaims[t];
-				clearingAreaClaims[t]=NULL;
-			}
+			delete[] forbiddenGradient[t][swim];
+			forbiddenGradient[t][swim] = NULL;
+			delete[] guardAreasGradient[t][swim];
+			guardAreasGradient[t][swim] = NULL;
+			delete[] clearAreasGradient[t][swim];
+			clearAreasGradient[t][swim] = NULL;
+			guardGradientUpdated[t][swim] = false;
+			clearGradientUpdated[t][swim] = false;
 		}
-		
-		assert(immobileUnits);
-		delete[] immobileUnits;
-		immobileUnits=NULL;
-
-		arraysBuilt=false;
+		delete[] exploredArea[t];
+		exploredArea[t] = NULL;
+		delete[] clearingAreaClaims[t];
+		clearingAreaClaims[t] = NULL;
 	}
-	else
-	{
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			for (int r=0; r<MAX_RESOURCES; r++)
-				for (int s=0; s<2; s++)
-					assert(resourcesGradient[t][r][s]==NULL);
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			for (int s=0; s<2; s++)
-			{
-				assert(forbiddenGradient[t][s] == NULL);
-				assert(guardAreasGradient[t][s] == NULL);
-				assert(clearAreasGradient[t][s] == NULL);
-			}
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			assert(exploredArea[t] == NULL);
-		for (int t=0; t<Team::MAX_COUNT; t++)
-			assert(clearingAreaClaims[t] == NULL);
-		
-		assert(undermap==NULL);
-		assert(sectors==NULL);
-		assert(listedAddr==NULL);
+	delete[] undermap;
+	undermap = NULL;
+	delete[] sectors;
+	sectors = NULL;
+	delete[] listedAddr;
+	listedAddr = NULL;
+	delete[] aStarPoints;
+	aStarPoints = NULL;
+	delete[] immobileUnits;
+	immobileUnits = NULL;
+	arraysBuilt = false;
 
-		assert(w==0);
-		assert(h==0);
-		assert(size==0);
-		assert(wMask==0);
-		assert(hMask==0);
-		assert(wDec==0);
-		assert(hDec==0);
-		assert(wSector==0);
-		assert(hSector==0);
-		assert(sizeSector==0);
-	}
-	
 	w=h=0;
 	size=0;
 	wMask=hMask=0;

--- a/src/map/io/MapIO.cpp
+++ b/src/map/io/MapIO.cpp
@@ -13,16 +13,20 @@
 
 #include <algorithm>
 #include <Stream.h>
+#include <BinaryStream.h>
+#include <limits>
 
 
 bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
+try
 {
+	GAGCore::BinaryInputStream::CheckedReads checked(stream);
 	assert(header.getVersionMinor()>=16);
 
 	Sint32 versionMinor = header.getVersionMinor();
 
 	clear();
-	
+
 	stream->readEnterSection("Map");
 
 	char signature[4];
@@ -36,6 +40,9 @@ bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
 	// We load and compute size:
 	wDec = stream->readSint32("wDec");
 	hDec = stream->readSint32("hDec");
+	if (wDec < 0 || hDec < 0 || wDec >= std::numeric_limits<int>::digits ||
+		hDec >= std::numeric_limits<int>::digits || wDec + hDec >= std::numeric_limits<int>::digits)
+		return false;
 	w = 1<<wDec;
 	h = 1<<hDec;
 	wMask = w-1;
@@ -67,6 +74,8 @@ bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
 
 		cases[i].terrain = stream->readUint16("terrain");
 		cases[i].building = stream->readUint16("building");
+		if (cases[i].building != NOGBID && cases[i].building >= Building::MAX_COUNT * header.getNumberOfTeams())
+			return false;
 
 		stream->read(&(cases[i].resource), 4, "ressource");
 		cases[i].groundUnit = stream->readUint16("groundUnit");
@@ -96,7 +105,50 @@ bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
 	const bool restoreExploredArea = header.getIsSavedGame() && versionMinor >= EXPLORED_AREA_SAVED_VERSION_MINOR;
 	if (restoreExploredArea)
 		loadExploredArea(stream, header.getNumberOfTeams(), game != NULL);
-	
+
+	this->game = game;
+
+	// We load sectors:
+	wSector = stream->readSint32("wSector");
+	hSector = stream->readSint32("hSector");
+	if (wSector < 0 || hSector < 0 || wSector > w || hSector > h)
+		return false;
+	sizeSector = wSector*hSector;
+	assert(sectors == NULL);
+	sectors = new Sector[sizeSector];
+
+#ifndef YOG_SERVER_ONLY
+	// Map::setGame is bypassed on the loaded-game path (Game::load uses
+	// Map::load directly and the game pointer is set inline above), so
+	// the per-sector render buckets must be sized here too.
+	if (game)
+		game->animations->resize(sizeSector);
+#endif  // !YOG_SERVER_ONLY
+
+	arraysBuilt = true;
+
+	stream->readEnterSection("sectors");
+	for (int i=0; i<sizeSector; i++)
+	{
+		stream->readEnterSection(i);
+		if (!sectors[i].load(stream, this->game, versionMinor))
+		{
+			stream->readLeaveSection(3);
+			return false;
+		}
+		stream->readLeaveSection();
+	}
+	stream->readLeaveSection();
+
+	stream->read(signature, 4, "signatureEnd");
+	stream->readLeaveSection();
+
+	if (memcmp(signature, "MapE", 4)!=0)
+	{
+		fprintf(stderr, "Map:: Failed to find signature at the end of Map.\n");
+		return false;
+	}
+
 	if (game)
 	{
                 /* Must set game field before following action as they
@@ -124,15 +176,15 @@ bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
 				assert(forbiddenGradient[t][s] == NULL);
 				forbiddenGradient[t][s] = new Uint8[size];
 				updateForbiddenGradient(t, s);
-				
+
 				assert(guardAreasGradient[t][s] == NULL);
 				guardAreasGradient[t][s] = new Uint8[size];
 				updateGuardAreasGradient(t, s);
-			
+
 				assert(clearAreasGradient[t][s] == NULL);
 				clearAreasGradient[t][s] = new Uint8[size];
 				updateClearAreasGradient(t, s);
-				
+
 				guardGradientUpdated[t][s] = false;
 				clearGradientUpdated[t][s] = false;
 			}
@@ -146,53 +198,21 @@ bool Map::load(GAGCore::InputStream *stream, MapHeader& header, Game *game)
 				makeDiscoveredAreasExplored(t);
 			}
 			assert(exploredArea[t]);
-			
+
 			clearingAreaClaims[t] = new Uint16[size];
 			memset(clearingAreaClaims[t], NOGUID, size*sizeof(Uint16));
 		}
 	}
 
-	// We load sectors:
-	wSector = stream->readSint32("wSector");
-	hSector = stream->readSint32("hSector");
-	sizeSector = wSector*hSector;
-	assert(sectors == NULL);
-	sectors = new Sector[sizeSector];
-
-#ifndef YOG_SERVER_ONLY
-	// Map::setGame is bypassed on the loaded-game path (Game::load uses
-	// Map::load directly and the game pointer is set inline above), so
-	// the per-sector render buckets must be sized here too.
-	if (game)
-		game->animations->resize(sizeSector);
-#endif  // !YOG_SERVER_ONLY
-
-	arraysBuilt = true;
-	
-	stream->readEnterSection("sectors");
-	for (int i=0; i<sizeSector; i++)
-	{
-		stream->readEnterSection(i);
-		if (!sectors[i].load(stream, this->game, versionMinor))
-		{
-			stream->readLeaveSection(3);
-			return false;
-		}
-		stream->readLeaveSection();
-	}
-	stream->readLeaveSection();
-
-	stream->read(signature, 4, "signatureEnd");
-	stream->readLeaveSection();
-	
-	if (memcmp(signature, "MapE", 4)!=0)
-	{
-		fprintf(stderr, "Map:: Failed to find signature at the end of Map.\n");
-		return false;
-	}
-	
 	return true;
 }
+catch (const std::ios_base::failure& error)
+{
+	std::cerr << "Map::load: " << error.what() << std::endl;
+	clear();
+	return false;
+}
+
 
 void Map::save(GAGCore::OutputStream *stream)
 {

--- a/test/MapExploredAreaSaveLoadTest.cpp
+++ b/test/MapExploredAreaSaveLoadTest.cpp
@@ -39,8 +39,8 @@ constexpr int kMapDec = 3;   // 8x8
 constexpr int kTeams = 3;
 constexpr Uint32 kSentinel = 0xC0FFEE42u;
 
-// Sized Map with no Sector array; see test/README.md. exploredArea is owned
-// here because Map::clear() only frees it on the arraysBuilt path.
+// Sized Map with no Sector array; see test/README.md. The fixture releases
+// its explored-area buffers before base cleanup.
 struct TeamMap : Map
 {
 	TeamMap()

--- a/test/MapQueryTest.cpp
+++ b/test/MapQueryTest.cpp
@@ -19,10 +19,7 @@ namespace
 	// The isFreeFor*/isHardSpaceFor* predicates only need: a sized cases[] vector,
 	// and w/h/wMask/hMask/wDec/hDec for coordToIndex(). We set those directly.
 	//
-	// The destructor resets size fields before Map::~Map() runs, because Map's
-	// clear() else-branch (the path taken when arraysBuilt==false) asserts
-	// w==0 / h==0 / etc. — that's a real assert in production, but it expects
-	// to see a constructed-then-clear()'d Map, not a manually-poked one.
+	// The fixture resets its dimension metadata before base cleanup.
 	struct GrassMap : Map
 	{
 		GrassMap()
@@ -42,7 +39,6 @@ namespace
 			wMask = hMask = 0;
 			wDec = hDec = 0;
 			size = 0;
-			// Map::~Map() will call clear() which asserts these are 0.
 		}
 
 		void putBuilding(int x, int y, Uint16 gbid = 0)

--- a/test/README.md
+++ b/test/README.md
@@ -56,10 +56,10 @@ struct GrassMap : Map {
         wMask = 7; hMask = 7;
         size = 64;
         cases.assign(64, Case{});           // default: terrain=0 (grass), no bldg/unit
-        // arraysBuilt stays false, so clear() takes the else-branch
+        // No Sector or auxiliary arrays are allocated.
     }
     ~GrassMap() {
-        // Map::clear()'s else-branch asserts these are 0 before letting Map::~Map() proceed
+        // Reset fixture dimensions before base cleanup.
         w = h = wMask = hMask = wDec = hDec = 0;
         size = 0;
     }

--- a/test/README.md
+++ b/test/README.md
@@ -140,3 +140,18 @@ software OpenGL (`LIBGL_ALWAYS_SOFTWARE=1`). Xvfb and xauth must be installed.
 The GL run requires an OpenGL-enabled build. On macOS, the Homebrew SDL workaround
 described above also applies. To run with sanitizers, use the flags in the selection
 regression instructions with the `aspect-test` target instead.
+
+### Savegame safety
+
+Build `scons release=1 server=0 savegame-safety-test`, then run
+`python3 test/run-savegame-safety-tests.py build/src/SavegameSafetyHarness`
+(use `.exe` on Windows). No display is required. The runner uses a disposable
+profile and working directory; an optional final argument supplies a truncated
+save that must be rejected.
+
+The harness checks the production autosave path, byte equivalence with direct
+serialization, successful reload, truncated map data from file and memory
+streams, recovery after failed loads, and oversized map-area strings. Atomic
+replacement tests cover callback/open/rename failures and temporary-file cleanup.
+On POSIX, child processes impose file-size limits to exercise short writes and
+buffered flush errors while checking that the previous save survives unchanged.

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -44,7 +44,7 @@ if sys.platform == "darwin" or sys.platform.startswith("linux"):
 gag_server = gag_env.StaticLibrary('gagserver', [
   gag_env.Object('gagserver-' + name + '.o', '../libgag/src/' + name + '.cpp')
   for name in Split("""
-    BinaryStream FileManager FormatableString Stream StreamBackend
+    BinaryStream FileManager FileManagerAtomic FormatableString Stream StreamBackend
     StreamFilter StringTable TextStream Toolkit
   """)])
 

--- a/test/SavegameSafetyHarness.cpp
+++ b/test/SavegameSafetyHarness.cpp
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "GlobalContainer.h"
+#include "Engine.h"
+#include <BinaryStream.h>
+#include <FileManager.h>
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#ifndef WIN32
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <csignal>
+#endif
+
+GlobalContainer *globalContainer = nullptr;
+using namespace GAGCore;
+namespace fs = std::filesystem;
+
+static std::string contents(const fs::path& path)
+{
+	std::ifstream file(path, std::ios::binary);
+	assert(file);
+	return std::string(std::istreambuf_iterator<char>(file), {});
+}
+
+static void checkAtomicWrites(FileManager& files, const fs::path& directory)
+{
+	const std::string path = (directory / "atomic.game").string();
+	const auto write = [](OutputStream& stream) { stream.write("complete", 8, "data"); };
+	assert(files.writeAtomically(path, write));
+	assert(contents(path) == "complete");
+	assert(!files.writeAtomically(path, [](OutputStream& stream) {
+		stream.write("partial", 7, "data");
+		throw std::runtime_error("injected serialization failure");
+	}));
+	assert(contents(path) == "complete");
+	assert(files.writeAtomically(path, [](OutputStream& stream) {
+		stream.write("placeholder", 11, "data");
+		stream.seekFromStart(0);
+		stream.write("replacement", 11, "data");
+	}));
+	assert(contents(path) == "replacement");
+	const auto blocked = directory / "directory.game";
+	fs::create_directory(blocked);
+	assert(!files.writeAtomically(blocked.string(), write));
+	assert(fs::is_directory(blocked));
+	assert(!files.writeAtomically((directory / "missing" / "save.game").string(), write));
+#ifndef WIN32
+	for (rlim_t limit : {rlim_t(0), rlim_t(1024)})
+	{
+		const pid_t child = fork();
+		assert(child >= 0);
+		if (child == 0)
+		{
+			std::signal(SIGXFSZ, SIG_IGN);
+			struct rlimit budget = {limit, limit};
+			if (setrlimit(RLIMIT_FSIZE, &budget) != 0) _exit(2);
+			const bool saved = files.writeAtomically(path, [limit](OutputStream& stream) {
+				const std::string data(limit ? 16384 : 8, 'x');
+				stream.write(data.data(), data.size(), "data");
+			});
+			_exit(saved ? 3 : 0);
+		}
+		int status = 0;
+		assert(waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+		assert(contents(path) == "replacement");
+	}
+#endif
+	for (const auto& entry : fs::directory_iterator(directory))
+		assert(entry.path().filename().string().find(".tmp-") == std::string::npos);
+	std::cout << "PASS atomic creation/replacement, seek, serialization/open/rename failure, temporary cleanup" << std::endl;
+#ifndef WIN32
+	std::cout << "PASS injected short write and buffered flush failure preserve previous bytes" << std::endl;
+#endif
+}
+
+static std::unique_ptr<BinaryInputStream> input(const std::string& bytes, bool file)
+{
+	if (file)
+	{
+		FILE *fp = tmpfile();
+		assert(fp && fwrite(bytes.data(), 1, bytes.size(), fp) == bytes.size());
+		rewind(fp);
+		return std::make_unique<BinaryInputStream>(new FileStreamBackend(fp));
+	}
+	auto *backend = new MemoryStreamBackend(bytes.data(), bytes.size());
+	backend->seekFromStart(0);
+	return std::make_unique<BinaryInputStream>(backend);
+}
+
+int main(int argc, char **argv)
+{
+	assert(argc == 2 || argc == 3);
+	assert(std::string(argv[1]).find("glob2-save-test-") == 0);
+	GlobalContainer globals(argv[1]);
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.load();
+	const fs::path directory = fs::absolute(globals.fileManager->getDir(0));
+	checkAtomicWrites(*globals.fileManager, directory);
+	{
+		GameGUI gui;
+		auto map = Engine::loadMapHeader("maps/balanced.map");
+		GameHeader header;
+		header.setNumberOfPlayers(1);
+		header.setRandomSeed(123456);
+		header.getBasePlayer(0) = BasePlayer(0, "Test", 0, BasePlayer::P_LOCAL);
+		assert(gui.loadFromHeaders(map, header, true, true));
+		gui.localPlayer = gui.localTeamNo = 0;
+		gui.adjustLocalTeam();
+		gui.game.stepCounter = 79;
+		// The engine's initial replay save sets the serialized map offset.
+		{
+			BinaryOutputStream initial(new MemoryStreamBackend());
+			gui.save(&initial, "Auto save");
+		}
+		gui.syncStep();
+		const fs::path save = directory / "games" / "Auto_save.game";
+		const auto bytes = contents(save);
+		{
+			auto *backend = new MemoryStreamBackend();
+			BinaryOutputStream reference(backend);
+			gui.save(&reference, "Auto save");
+			const std::string expected(backend->getBuffer(), backend->getPosition());
+			assert(bytes == expected);
+		}
+		std::cout << "PASS atomic autosave bytes match direct serialization" << std::endl;
+
+		{
+			GameGUI restored;
+			auto stream = input(bytes, true);
+			assert(restored.load(stream.get()));
+			std::vector<Uint32> before, after;
+			gui.game.checkSum(&before, nullptr, nullptr);
+			restored.game.checkSum(&after, nullptr, nullptr);
+			assert(before.size() == after.size());
+			// Component zero includes the map format version, upgraded on save.
+			assert(std::equal(before.begin() + 1, before.end(), after.begin() + 1));
+			assert(restored.game.stepCounter == gui.game.stepCounter);
+		}
+		std::cout << "PASS production autosave reloads with unchanged simulation checksum components" << std::endl;
+#ifndef WIN32
+		const pid_t child = fork();
+		assert(child >= 0);
+		if (child == 0)
+		{
+			std::signal(SIGXFSZ, SIG_IGN);
+			struct rlimit budget = {0, 0};
+			if (setrlimit(RLIMIT_FSIZE, &budget) != 0) _exit(2);
+			gui.game.stepCounter = 335;
+			gui.syncStep();
+			_exit(0);
+		}
+		int status = 0;
+		assert(waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0);
+		assert(contents(save) == bytes);
+		std::cout << "PASS failed production autosave preserves the previous complete game" << std::endl;
+#endif
+		auto stream = input(bytes, false);
+		MapHeader savedHeader;
+		assert(savedHeader.load(stream.get()));
+		const size_t offset = savedHeader.getMapOffset();
+		assert(bytes.substr(offset, 4) == "MapB");
+		const auto mapBytes = bytes.substr(offset);
+		const size_t cells = size_t(gui.game.map.getW()) * gui.game.map.getH();
+		const size_t cellsStart = 12 + cells;
+		const size_t cellsEnd = cellsStart + cells * 33;
+		const size_t mapEnd = mapBytes.find("MapE");
+		assert(mapEnd != std::string::npos && cellsEnd < mapEnd);
+		const size_t cuts[] = {0, 1, 3, 4, 7, 11, 12, cellsStart - 1, cellsStart,
+			cellsStart + 6, cellsStart + 7, cellsStart + 32, cellsEnd - 2171,
+			cellsEnd - 1, cellsEnd, cellsEnd + 1, mapEnd, mapEnd + 3};
+		int count = 0;
+		for (bool file : {false, true})
+			for (size_t cut : cuts)
+			{
+				Map loaded;
+				auto truncated = input(mapBytes.substr(0, cut), file);
+				assert(!loaded.load(truncated.get(), savedHeader, &gui.game));
+				auto complete = input(mapBytes, file);
+				assert(loaded.load(complete.get(), savedHeader, &gui.game));
+				++count;
+			}
+		std::cout << "PASS " << count << " truncated map loads rejected, followed by successful reuse" << std::endl;
+		for (bool file : {false, true})
+		{
+			std::string malformed = mapBytes;
+			malformed.replace(cellsEnd, 4, 4, char(0xFF));
+			auto oversized = input(malformed, file);
+			Map loaded;
+			assert(!loaded.load(oversized.get(), savedHeader, &gui.game));
+		}
+		std::cout << "PASS oversized map-area string rejected before allocation" << std::endl;
+
+		if (argc == 3)
+		{
+			GameGUI broken;
+			BinaryInputStream attachment(globals.fileManager->openInputStreamBackend(argv[2]));
+			assert(!broken.load(&attachment));
+			std::cout << "PASS issue #130 attachment rejected without abort" << std::endl;
+		}
+	}
+}

--- a/test/SavegameSafetyHarness.cpp
+++ b/test/SavegameSafetyHarness.cpp
@@ -1,4 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+#define SDL_MAIN_HANDLED
+#ifdef main
+#undef main
+#endif
 #include "GlobalContainer.h"
 #include "Engine.h"
 #include <BinaryStream.h>
@@ -94,6 +98,9 @@ static std::unique_ptr<BinaryInputStream> input(const std::string& bytes, bool f
 
 int main(int argc, char **argv)
 {
+	SDL_SetMainReady();
+	std::setvbuf(stdout, nullptr, _IONBF, 0);
+	std::cout << "Starting headless savegame safety checks" << std::endl;
 	assert(argc == 2 || argc == 3);
 	assert(std::string(argv[1]).find("glob2-save-test-") == 0);
 	GlobalContainer globals(argv[1]);
@@ -204,4 +211,5 @@ int main(int argc, char **argv)
 			std::cout << "PASS issue #130 attachment rejected without abort" << std::endl;
 		}
 	}
+	return 0;
 }

--- a/test/SavegameSafetyHarness.cpp
+++ b/test/SavegameSafetyHarness.cpp
@@ -13,7 +13,9 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
-#ifndef WIN32
+#ifdef WIN32
+#include <process.h>
+#else
 #include <sys/resource.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -34,8 +36,17 @@ static std::string contents(const fs::path& path)
 static void checkAtomicWrites(FileManager& files, const fs::path& directory)
 {
 	const std::string path = (directory / "atomic.game").string();
+#ifdef WIN32
+	const auto process = _getpid();
+#else
+	const auto process = getpid();
+#endif
+	const std::string collision = path + ".tmp-" + std::to_string(process) + "-0";
+	{ std::ofstream existing(collision); existing << "keep"; }
 	const auto write = [](OutputStream& stream) { stream.write("complete", 8, "data"); };
 	assert(files.writeAtomically(path, write));
+	assert(contents(collision) == "keep");
+	fs::remove(collision);
 	assert(contents(path) == "complete");
 	assert(!files.writeAtomically(path, [](OutputStream& stream) {
 		stream.write("partial", 7, "data");
@@ -76,7 +87,7 @@ static void checkAtomicWrites(FileManager& files, const fs::path& directory)
 #endif
 	for (const auto& entry : fs::directory_iterator(directory))
 		assert(entry.path().filename().string().find(".tmp-") == std::string::npos);
-	std::cout << "PASS atomic creation/replacement, seek, serialization/open/rename failure, temporary cleanup" << std::endl;
+	std::cout << "PASS atomic creation/replacement, temporary-name collision, seek, serialization/open/rename failure, temporary cleanup" << std::endl;
 #ifndef WIN32
 	std::cout << "PASS injected short write and buffered flush failure preserve previous bytes" << std::endl;
 #endif

--- a/test/run-savegame-safety-tests.py
+++ b/test/run-savegame-safety-tests.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Run savegame-safety-test without a display, in a disposable profile."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+
+binary = Path(sys.argv[1]).resolve()
+extra = [str(Path(arg).resolve()) for arg in sys.argv[2:]]
+profile = 'glob2-save-test-' + uuid.uuid4().hex
+try:
+    with tempfile.TemporaryDirectory(prefix=profile) as work:
+        subprocess.run([str(binary), profile, *extra], cwd=work, check=True, timeout=90)
+finally:
+    if os.name != 'nt':
+        shutil.rmtree(Path.home() / ('.' + profile), ignore_errors=True)


### PR DESCRIPTION
The autosave attached to #130 ends partway through its map-cell array. Loading it currently continues with incomplete cells and aborts in `BuildingUtils::GIDtoTeam`. Autosave also opens the destination for truncation before serialization has succeeded, so a failed write can destroy the previous save.

This change enables exact binary reads while loading maps, rejects incomplete fields and invalid map bounds before gradient generation, and makes partially loaded maps safe to clear and reuse. Binary string lengths are checked before allocating their buffers. Autosave writes to an exclusively created temporary file in the destination directory, checks write/seek/flush/close errors, then replaces the destination only on success (rename on POSIX, replace-existing move on Windows).

Validation on an optimized Apple Silicon Mac build:

- The actual #130 attachment returns a load failure without aborting.
- 36 truncated map cases across file and memory backends fail cleanly, followed by successful loads into the same Map object.
- Production autosave bytes match direct serialization; reloading preserves simulation checksum components (the saved format version is upgraded).
- Injected callback, open, rename, short-write, and buffered-flush failures preserve previous bytes. A file-size-limited child also verifies the production `GameGUI::syncStep` autosave path.
- Oversized area-name strings are rejected before allocation, and handled failures remove temporary files.

The headless regression runs in disposable profiles on Linux and Windows CI. It uses a console entry point so startup failures reach the CI log. Windows temporary files use `_open` with `_O_EXCL`, including collision coverage, because MSVCRT does not support `fopen`'s C11 `x` mode. The scripting lexer uses explicit spaces/tabs because the Windows regex runtime rejects its `blank` character class during static initialization.

The Mac ASan+UBSan suite passes without suppressions, as do 153 CppUnit tests and 19 standalone programs. Independent builds pass on devlaptop (Ubuntu 24.04/GCC 13.3) and pharaoh-dev-1 (Ubuntu 26.04/GCC 15.2); the verified Ubuntu 26.04 binary also passes the savegame suite on therig and pharaoh-dev-2/3. AI-bearing 250-tick replay checks at 1×, 4×, and Maximum remain byte-identical to the pre-change baseline. Final CI passes Ubuntu 22.04, Ubuntu 24.04, and Windows MinGW, including client/server builds and the new headless savegame regression. The verification comment records the exact tested head and detailed checks.

Fixes #130.
