### PR TITLE
Pull in two safe Debian packaging patches

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -249,6 +249,9 @@ def main():
     # tools like ar fall back to /tmp, which sandboxed environments may block.
     if 'TMPDIR' in os.environ:
         env['ENV']['TMPDIR'] = os.environ['TMPDIR']
+    # Likewise for SOURCE_DATE_EPOCH, needed by build tools for reproducible builds.
+    if 'SOURCE_DATE_EPOCH' in os.environ:
+        env['ENV']['SOURCE_DATE_EPOCH'] = os.environ['SOURCE_DATE_EPOCH']
     env["VERSION"] = "0.9.5.0"
     establish_options(env)
 

--- a/data/glob2.desktop
+++ b/data/glob2.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Version=1.0
-Encoding=UTF-8
 Name=Globulation 2
 GenericName=Real Time Strategy Game
 GenericName[de]=Echtzeit-Strategiespiel
@@ -11,3 +10,4 @@ Terminal=false
 X-MultipleArgs=false
 Type=Application
 Categories=Game;StrategyGame;
+Keywords=Globulation;Game;Strategy;


### PR DESCRIPTION
Debian carries these in debian/patches for glob2 0.9.4.4-11 and they were never forwarded upstream (see https://tracker.debian.org/pkg/glob2 -> "debian patches"):

- `sconstruct-explicitly-add-source_date_ep.patch`: SConstruct passes `SOURCE_DATE_EPOCH` through to the build environment when set, for reproducible builds. Guarded on presence so normal (non-Debian) builds are unaffected.
- `desktop.patch`: `data/glob2.desktop` drops the deprecated `Encoding=` key and adds `Keywords=` per the freedesktop.org desktop entry spec.

The other 9 patches Debian carries are either already fixed upstream, target code that no longer exists, or need a maintainer call (filed separately if wanted).