### PR TITLE
Map editor: only remove units and buildings the painted terrain no longer carries

### DIFF
--- a/src/Game.h
+++ b/src/Game.h
@@ -209,6 +209,8 @@ public:
 	//! This remove anything at case(x, y), and return a rect which include every removed things.
 	bool removeUnitAndBuildingAndFlags(int x, int y, unsigned flags=DEL_UNIT|DEL_BUILDING|DEL_FLAG);
 	bool removeUnitAndBuildingAndFlags(int x, int y, int size, unsigned flags=DEL_UNIT|DEL_BUILDING|DEL_FLAG);
+	//! Over the w*h tiles from (x, y), remove the buildings off grass and the ground units on water that cannot swim.
+	void removeUnallowedUnitsAndBuildings(int x, int y, int w, int h);
 	///A convenience function, returns a pointer to the unit with the guid, or NULL otherwise
 	Unit* getUnit(int guid);
 

--- a/src/Game_editor.cpp
+++ b/src/Game_editor.cpp
@@ -248,7 +248,7 @@ Building *Game::addBuilding(int x, int y, int typeNum, int teamNumber, Sint32 un
 bool Game::removeUnitAndBuildingAndFlags(int x, int y, unsigned flags)
 {
 	bool found=false;
-	if (flags & DEL_GROUND_UNIT)
+	if (flags & DEL_AIR_UNIT)
 	{
 		Uint16 gauid=map.getAirUnit(x, y);
 		if (gauid!=NOGUID)
@@ -261,7 +261,7 @@ bool Game::removeUnitAndBuildingAndFlags(int x, int y, unsigned flags)
 			found=true;
 		}
 	}
-	if (flags & DEL_AIR_UNIT)
+	if (flags & DEL_GROUND_UNIT)
 	{
 		Uint16 gguid=map.getGroundUnit(x, y);
 		if (gguid!=NOGUID)
@@ -317,6 +317,21 @@ bool Game::removeUnitAndBuildingAndFlags(int x, int y, int size, unsigned flags)
 				somethingInRect = true;
 
 	return somethingInRect;
+}
+
+void Game::removeUnallowedUnitsAndBuildings(int x, int y, int w, int h)
+{
+	for (int dx=x; dx<x+w; dx++)
+		for (int dy=y; dy<y+h; dy++)
+		{
+			int cx=dx&map.getMaskW();
+			int cy=dy&map.getMaskH();
+			if (!map.isGrass(cx, cy))
+				removeUnitAndBuildingAndFlags(cx, cy, 1, DEL_BUILDING);
+			Uint16 guid=map.getGroundUnit(cx, cy);
+			if (guid!=NOGUID && map.isWater(cx, cy) && !getUnit(guid)->performance[SWIM])
+				removeUnitAndBuildingAndFlags(cx, cy, 1, DEL_GROUND_UNIT);
+		}
 }
 
 bool Game::checkRoomForBuilding(int mousePosX, int mousePosY, const BuildingType *bt, int *buildingPosX, int *buildingPosY, int teamNumber, bool checkFow)

--- a/src/map/edit/MapEditClicks.cpp
+++ b/src/map/edit/MapEditClicks.cpp
@@ -186,32 +186,33 @@ void MapEdit::handleTerrainClick(int mx, int my)
 					switch(terrainType)
 					{
 					case TerrainSelector::Grass:
-						game.removeUnitAndBuildingAndFlags(x, y, 3, Game::DEL_BUILDING | Game::DEL_UNIT);
 						game.map.setUMatPos(x, y, GRASS, 1);
 						// a tile is drawn from the undermap corners at (x..x+1, y..y+1), so cells
 						// painted at (x-1..x+1) change the tiles from (x-2, y-2) on; only the
-						// resources those tiles no longer allow go
+						// resources, buildings and units those tiles no longer allow go
 						game.map.removeUnallowedResources(x-2, y-2, 4, 4);
+						game.removeUnallowedUnitsAndBuildings(x-2, y-2, 4, 4);
 						// grass is also the brush that clears: the tiles the cell touches go bare
+						game.removeUnitAndBuildingAndFlags(x, y, 2, Game::DEL_BUILDING | Game::DEL_UNIT);
 						for (int ty=y-1; ty<=y; ty++)
 							for (int tx=x-1; tx<=x; tx++)
 								game.map.getResource(tx, ty).clear();
 						break;
 					case TerrainSelector::Sand:
-						game.removeUnitAndBuildingAndFlags(x, y, 2, Game::DEL_BUILDING | Game::DEL_UNIT);
 						game.map.setUMatPos(x, y, SAND, 1);
 						// a tile is drawn from the undermap corners at (x..x+1, y..y+1), so cells
 						// painted at (x-1..x+1) change the tiles from (x-2, y-2) on; only the
-						// resources those tiles no longer allow go
+						// resources, buildings and units those tiles no longer allow go
 						game.map.removeUnallowedResources(x-2, y-2, 4, 4);
+						game.removeUnallowedUnitsAndBuildings(x-2, y-2, 4, 4);
 						break;
 					case TerrainSelector::Water:
-						game.removeUnitAndBuildingAndFlags(x, y, 5, Game::DEL_BUILDING | Game::DEL_UNIT);
 						game.map.setUMatPos(x, y, WATER, 1);
 						// a tile is drawn from the undermap corners at (x..x+1, y..y+1), so cells
 						// painted at (x-1..x+1) change the tiles from (x-2, y-2) on; only the
-						// resources those tiles no longer allow go
+						// resources, buildings and units those tiles no longer allow go
 						game.map.removeUnallowedResources(x-2, y-2, 4, 4);
+						game.removeUnallowedUnitsAndBuildings(x-2, y-2, 4, 4);
 						break;
 					case TerrainSelector::Wheat:
 						resToSet=CORN;

--- a/test/TerrainResourcesHarness.cpp
+++ b/test/TerrainResourcesHarness.cpp
@@ -2,6 +2,7 @@
 // Exercise real terrain regeneration and resource clearing without a window.
 #include "Building.h"
 #include "Game.h"
+#include "GameGUI.h"
 #include "GlobalContainer.h"
 #include "IntBuildingType.h"
 #include "Map.h"
@@ -19,6 +20,7 @@ int main()
 	GlobalContainer globals;
 	globalContainer = &globals;
 	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
 	const int positions[][2] = {{8, 8}, {0, 0}, {15, 0}, {0, 15}, {15, 15}};
 	int strokes = 0;
 	for (int type = 0; type < MAX_RESOURCES; ++type)
@@ -81,14 +83,19 @@ int main()
 	const int swarm = globals.buildingsTypes.getTypeNum("swarm", 0, false);
 	const int swarmW = globals.buildingsTypes.get(swarm)->width;
 	const int swarmH = globals.buildingsTypes.get(swarm)->height;
-	constexpr int swarmX = 8, swarmY = 8, workerX = 6, workerY = 9, explorerX = 11, explorerY = 9;
+	constexpr int swarmX = 8, swarmY = 8;
 
 	struct World
 	{
-		Game game{nullptr, nullptr};
+		GameGUI gui;
+		Game& game = gui.game;
 		int swarmW, swarmH;
+		int swarmX, swarmY, workerX, workerY, explorerX, explorerY;
 		Uint16 swarmGid, workerGid, explorerGid;
-		World(int swarm, int w, int h) : swarmW(w), swarmH(h)
+		World(int swarm, int w, int h, int offsetX = 0, int offsetY = 0) : swarmW(w), swarmH(h),
+            swarmX((8 + offsetX) & 15), swarmY((8 + offsetY) & 15),
+            workerX((6 + offsetX) & 15), workerY((9 + offsetY) & 15),
+            explorerX((11 + offsetX) & 15), explorerY((9 + offsetY) & 15)
 		{
 			game.map.setSize(4, 4, GRASS);
 			game.map.setGame(&game);
@@ -120,12 +127,13 @@ int main()
 		{
 			auto touched = [&](int x, int y)
 			{
-				return paint == GRASS && (x == px || x == px - 1) && (y == py || y == py - 1);
+				return paint == GRASS && (((x - px) & 15) == 0 || ((x - px) & 15) == 15)
+                    && (((y - py) & 15) == 0 || ((y - py) & 15) == 15);
 			};
 			bool swarmStands = true;
 			for (int y = swarmY; y < swarmY + swarmH; ++y)
 				for (int x = swarmX; x < swarmX + swarmW; ++x)
-					if (!game.map.isGrass(x, y) || touched(x, y))
+					if (!game.map.isGrass(x & 15, y & 15) || touched(x, y))
 						swarmStands = false;
 			const bool workerStands = !game.map.isWater(workerX, workerY) && !touched(workerX, workerY);
 			const bool explorerStands = !touched(explorerX, explorerY);
@@ -139,15 +147,19 @@ int main()
 	};
 
 	int entityStrokes = 0;
-	for (TerrainType paint : {GRASS, SAND, WATER})
-		for (int py = 4; py <= 13; ++py)
-			for (int px = 4; px <= 13; ++px)
-			{
-				World world(swarm, swarmW, swarmH);
-				world.stroke(px, py, paint);
-				world.check(px, py, paint);
-				++entityStrokes;
-			}
+    const int offsets[][2] = {{0, 0}, {-8, -8}, {7, -8}, {-8, 7}, {7, 7}};
+    for (const auto& offset : offsets)
+        for (TerrainType paint : {GRASS, SAND, WATER})
+            for (int py = 4; py <= 13; ++py)
+                for (int px = 4; px <= 13; ++px)
+                {
+                    World world(swarm, swarmW, swarmH, offset[0], offset[1]);
+                    const int x = (px + offset[0]) & 15;
+                    const int y = (py + offset[1]) & 15;
+                    world.stroke(x, y, paint);
+                    world.check(x, y, paint);
+                    ++entityStrokes;
+                }
 
 	// A cell touches the tiles c-1..c; the cell 2*swarmX+swarmW-c touches their mirror
 	// image across the swarm, the same distance east as c is west, and must agree.
@@ -160,17 +172,45 @@ int main()
 			assert(west.alive(west.swarmGid, true) == east.alive(east.swarmGid, true));
 		}
 
-	// Four water cells make the walker's tile open water: the walker goes, the explorer stays.
-	{
-		World world(swarm, swarmW, swarmH);
-		for (int y = workerY; y <= workerY + 1; ++y)
-			for (int x = workerX; x <= workerX + 1; ++x)
-				world.stroke(x, y, WATER);
-		assert(world.game.map.isWater(workerX, workerY));
-		assert(!world.alive(world.workerGid, false));
-		assert(world.game.map.getGroundUnit(workerX, workerY) == NOGUID);
-		assert(world.alive(world.explorerGid, false));
-		++entityStrokes;
-	}
-	std::printf("Terrain entity regressions passed: %d strokes, 3 terrains, %dx%d swarm, walker and explorer\n", entityStrokes, swarmW, swarmH);
+	// Co-located air units survive flooding, while only swimming ground units remain.
+    for (bool swimming : {false, true})
+        for (const auto& offset : offsets)
+        {
+            World world(swarm, swarmW, swarmH, offset[0], offset[1]);
+            Unit* worker = world.game.getUnit(world.workerGid);
+            worker->performance[SWIM] = swimming ? worker->race->getUnitType(WORKER, 1)->performance[SWIM] : 0;
+            Unit* explorer = world.game.getUnit(world.explorerGid);
+            world.game.map.setAirUnit(explorer->posX, explorer->posY, NOGUID);
+            explorer->posX = world.workerX;
+            explorer->posY = world.workerY;
+            world.game.map.setAirUnit(explorer->posX, explorer->posY, explorer->gid);
+            for (int y = world.workerY; y <= world.workerY + 1; ++y)
+                for (int x = world.workerX; x <= world.workerX + 1; ++x)
+                    world.stroke(x & 15, y & 15, WATER);
+            assert(world.game.map.isWater(world.workerX, world.workerY));
+            assert(world.alive(world.workerGid, false) == swimming);
+            assert(world.game.map.getGroundUnit(world.workerX, world.workerY) == (swimming ? world.workerGid : NOGUID));
+            assert(world.alive(world.explorerGid, false));
+            assert(world.game.map.getAirUnit(world.workerX, world.workerY) == world.explorerGid);
+            ++entityStrokes;
+        }
+
+    // A single deletion flag addresses exactly one occupancy layer.
+    for (unsigned flag : {unsigned(Game::DEL_GROUND_UNIT), unsigned(Game::DEL_AIR_UNIT)})
+    {
+        World world(swarm, swarmW, swarmH);
+        Unit* explorer = world.game.getUnit(world.explorerGid);
+        world.game.map.setAirUnit(explorer->posX, explorer->posY, NOGUID);
+        explorer->posX = world.workerX;
+        explorer->posY = world.workerY;
+        world.game.map.setAirUnit(explorer->posX, explorer->posY, explorer->gid);
+        world.game.removeUnitAndBuildingAndFlags(world.workerX, world.workerY, 1, flag);
+        assert(world.alive(world.workerGid, false) == (flag == Game::DEL_AIR_UNIT));
+        assert(world.alive(world.explorerGid, false) == (flag == Game::DEL_GROUND_UNIT));
+        assert(world.game.map.getGroundUnit(world.workerX, world.workerY) == (flag == Game::DEL_AIR_UNIT ? world.workerGid : NOGUID));
+        assert(world.game.map.getAirUnit(world.workerX, world.workerY) == (flag == Game::DEL_GROUND_UNIT ? world.explorerGid : NOGUID));
+        assert(world.alive(world.swarmGid, true));
+    }
+    std::printf("Terrain entity regressions passed: %d strokes, 3 terrains, interior and four wrapped corners, swimmers and separate occupancy layers\n", entityStrokes);
+    return 0;
 }

--- a/test/TerrainResourcesHarness.cpp
+++ b/test/TerrainResourcesHarness.cpp
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Exercise real terrain regeneration and resource clearing without a window.
+#include "Building.h"
+#include "Game.h"
 #include "GlobalContainer.h"
+#include "IntBuildingType.h"
 #include "Map.h"
+#include "Race.h"
+#include "Unit.h"
 
 #include <cassert>
 #include <cstdio>
@@ -65,4 +70,107 @@ int main()
 				}
 			}
 	std::printf("Terrain resource regressions passed: %d strokes, all 8 resources, 3 terrains, interior and four wrapped corners\n", strokes);
+
+	// Buildings and units. After a stroke a building stands iff its whole footprint is
+	// still grass, a walker iff its tile is not water, an explorer always; the grass
+	// brush also clears the four tiles the cell touches. The oracle knows nothing about
+	// the stroke position, so it holds on every side of an entity alike.
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+	const int swarm = globals.buildingsTypes.getTypeNum("swarm", 0, false);
+	const int swarmW = globals.buildingsTypes.get(swarm)->width;
+	const int swarmH = globals.buildingsTypes.get(swarm)->height;
+	constexpr int swarmX = 8, swarmY = 8, workerX = 6, workerY = 9, explorerX = 11, explorerY = 9;
+
+	struct World
+	{
+		Game game{nullptr, nullptr};
+		int swarmW, swarmH;
+		Uint16 swarmGid, workerGid, explorerGid;
+		World(int swarm, int w, int h) : swarmW(w), swarmH(h)
+		{
+			game.map.setSize(4, 4, GRASS);
+			game.map.setGame(&game);
+			game.addTeam();
+			Building* building = game.addBuilding(swarmX, swarmY, swarm, 0);
+			Unit* worker = game.addUnit(workerX, workerY, 0, WORKER, 0, 0, 0, 0);
+			Unit* explorer = game.addUnit(explorerX, explorerY, 0, EXPLORER, 0, 0, 0, 0);
+			assert(building && worker && explorer && !worker->performance[SWIM]);
+			swarmGid = building->gid;
+			workerGid = worker->gid;
+			explorerGid = explorer->gid;
+		}
+		bool alive(Uint16 gid, bool building) const
+		{
+			if (building)
+				return game.teams[0]->myBuildings[Building::GIDtoID(gid)] != nullptr;
+			return game.teams[0]->myUnits[Unit::GIDtoID(gid)] != nullptr;
+		}
+		// The map operations used by MapEdit::handleTerrainClick.
+		void stroke(int x, int y, TerrainType paint)
+		{
+			game.map.setUMatPos(x, y, paint, 1);
+			game.map.removeUnallowedResources(x - 2, y - 2, 4, 4);
+			game.removeUnallowedUnitsAndBuildings(x - 2, y - 2, 4, 4);
+			if (paint == GRASS)
+				game.removeUnitAndBuildingAndFlags(x, y, 2, Game::DEL_BUILDING | Game::DEL_UNIT);
+		}
+		void check(int px, int py, TerrainType paint) const
+		{
+			auto touched = [&](int x, int y)
+			{
+				return paint == GRASS && (x == px || x == px - 1) && (y == py || y == py - 1);
+			};
+			bool swarmStands = true;
+			for (int y = swarmY; y < swarmY + swarmH; ++y)
+				for (int x = swarmX; x < swarmX + swarmW; ++x)
+					if (!game.map.isGrass(x, y) || touched(x, y))
+						swarmStands = false;
+			const bool workerStands = !game.map.isWater(workerX, workerY) && !touched(workerX, workerY);
+			const bool explorerStands = !touched(explorerX, explorerY);
+			assert(alive(swarmGid, true) == swarmStands);
+			assert((game.map.getBuilding(swarmX, swarmY) != NOGBID) == swarmStands);
+			assert(alive(workerGid, false) == workerStands);
+			assert((game.map.getGroundUnit(workerX, workerY) != NOGUID) == workerStands);
+			assert(alive(explorerGid, false) == explorerStands);
+			assert((game.map.getAirUnit(explorerX, explorerY) != NOGUID) == explorerStands);
+		}
+	};
+
+	int entityStrokes = 0;
+	for (TerrainType paint : {GRASS, SAND, WATER})
+		for (int py = 4; py <= 13; ++py)
+			for (int px = 4; px <= 13; ++px)
+			{
+				World world(swarm, swarmW, swarmH);
+				world.stroke(px, py, paint);
+				world.check(px, py, paint);
+				++entityStrokes;
+			}
+
+	// A cell touches the tiles c-1..c; the cell 2*swarmX+swarmW-c touches their mirror
+	// image across the swarm, the same distance east as c is west, and must agree.
+	for (TerrainType paint : {GRASS, SAND, WATER})
+		for (int c = 4; c <= swarmX; ++c)
+		{
+			World west(swarm, swarmW, swarmH), east(swarm, swarmW, swarmH);
+			west.stroke(c, swarmY, paint);
+			east.stroke(2 * swarmX + swarmW - c, swarmY, paint);
+			assert(west.alive(west.swarmGid, true) == east.alive(east.swarmGid, true));
+		}
+
+	// Four water cells make the walker's tile open water: the walker goes, the explorer stays.
+	{
+		World world(swarm, swarmW, swarmH);
+		for (int y = workerY; y <= workerY + 1; ++y)
+			for (int x = workerX; x <= workerX + 1; ++x)
+				world.stroke(x, y, WATER);
+		assert(world.game.map.isWater(workerX, workerY));
+		assert(!world.alive(world.workerGid, false));
+		assert(world.game.map.getGroundUnit(workerX, workerY) == NOGUID);
+		assert(world.alive(world.explorerGid, false));
+		++entityStrokes;
+	}
+	std::printf("Terrain entity regressions passed: %d strokes, 3 terrains, %dx%d swarm, walker and explorer\n", entityStrokes, swarmW, swarmH);
 }


### PR DESCRIPTION
Follow-up to #140, which fixed only the resource half of this.

**Bug** (reported by Leo in the map editor, present on master since the 2006 editor rewrite): with a 1x1 grass brush, painting two tiles west of a swarm removes it, painting two tiles east of it does not.

**Mechanism.** A terrain stroke paints the undermap corner between tiles x-1 and x (the click is snapped to the nearest corner, and the cursor square straddles those two tiles). Grass and water also fringe the neighbouring corners, so a cell changes at most the tiles (x-2..x+1). The stroke then called `removeUnitAndBuildingAndFlags(x, y, 3)` for grass and `5` for water: a square *centred on the corner index*, which reaches one tile further east and south than west and north. Sand used `2`, the right window, but still removed walkers that can stand on sand.

**Fix.**
- `Game::removeUnallowedUnitsAndBuildings(x, y, w, h)` mirrors `Map::removeUnallowedResources`: over the tiles a stroke can change, drop buildings whose tile is no longer grass and ground units on open water that cannot swim. Air units stay.
- Grass keeps its eraser role from #140: it also clears the four tiles the cursor square covers, and nothing beyond them.
- `removeUnitAndBuildingAndFlags` had `DEL_GROUND_UNIT` reading the air layer and `DEL_AIR_UNIT` the ground layer; every caller passed both, so nothing noticed. Fixed. Note for future callers: passing a lone enumerator selects the `(x, y, size, flags)` overload with the default clear-everything flags, so pass the size explicitly.

**Verification.** `scons release=1 server=0 terrain-test && ./build/src/TerrainResourcesHarness` now also runs an entity oracle: a 4x4 swarm, a walker and an explorer, 300 single-cell strokes of each terrain around them, a west/east mirror check across the swarm, and a four-cell water stroke that drowns the walker and keeps the explorer. The oracle knows nothing about the stroke position, so it fails on any directional bias (it caught the overload trap above during development). `test/` suite: OK (153 tests).
