### PR TITLE
Fix spurious scons "Two different environments" warnings

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -497,7 +497,12 @@ if not env['server']:
     local.Alias('speed-tests', speed_test)
 
 if not env['server']:
-    savegame_sources = [source for source in source_files if source != 'Glob2.cpp']
+    # Compile through `local` (the same environment every other target here
+    # uses) so these objects aren't rebuilt under a second Environment
+    # instance further down, which just makes scons warn about duplicate
+    # environments on targets that already exist.
+    savegame_sources = local.Object([source for source in source_files if source != 'Glob2.cpp' and source.endswith('.cpp')])
+    savegame_sources += [source for source in source_files if not source.endswith('.cpp')]
     savegame_sources += local.Object('SavegameSafetyHarness.o', '#test/SavegameSafetyHarness.cpp')
     savegame_env = local.Clone()
     # Headless tests use a console entry point so failures reach the CI log.

--- a/src/SConscript
+++ b/src/SConscript
@@ -497,10 +497,7 @@ if not env['server']:
     local.Alias('speed-tests', speed_test)
 
 if not env['server']:
-    # Compile through `local` (the same environment every other target here
-    # uses) so these objects aren't rebuilt under a second Environment
-    # instance further down, which just makes scons warn about duplicate
-    # environments on targets that already exist.
+    # Compile with local, not savegame_env, to avoid rebuilding shared objects under a second environment.
     savegame_sources = local.Object([source for source in source_files if source != 'Glob2.cpp' and source.endswith('.cpp')])
     savegame_sources += [source for source in source_files if not source.endswith('.cpp')]
     savegame_sources += local.Object('SavegameSafetyHarness.o', '#test/SavegameSafetyHarness.cpp')


### PR DESCRIPTION
`savegame_env` (a `.Clone()` of `local` with tweaked `LINKFLAGS`/`LIBS`) was being handed the raw `source_files` list for the SavegameSafetyHarness build. Since almost every object in that list (BuildingUtils.o, Bullet.o, Campaign.o, ...) is also built by `local.Program()` elsewhere in this file, scons ends up registering two different `Environment` instances against the same target object -- same compile action, different env object -- and warns `Two different environments were specified for target ...` once per shared file on every build.

Fix: compile the shared sources through `local.Object()` first (the same environment every other target in this file uses) and only apply `savegame_env` at the link step, where the LINKFLAGS/LIBS override actually matters.

Verified locally: clean `scons -j4` and `scons -j4 server=1`, plus every `test/*-test` alias (`savegame-safety-test`, `selection-test`, `terrain-test`, `lan-test`, `speed-tests`, `building-footprint-test`, `entering-unit-save-test`), build and link successfully with zero `Two different environments` warnings.