### PR TITLE
Value-initialize the settings screen's flag-default widget arrays

### DIFF
--- a/src/SettingsScreen.cpp
+++ b/src/SettingsScreen.cpp
@@ -29,7 +29,7 @@
 #include <string>
 
 SettingsScreen::SettingsScreen()
- : Glob2TabScreen(false, true), unitRatioGroupNumbers(), mapeditKeyboardManager(MapEditShortcuts), guiKeyboardManager(GameGUIShortcuts)
+ : Glob2TabScreen(false, true), unitRatioGroupNumbers(), flagRadii(), flagRadiusTexts(), flagRadiusGroupNumbers(), mapeditKeyboardManager(MapEditShortcuts), guiKeyboardManager(GameGUIShortcuts)
 {
 	old_settings=globalContainer->settings;
 

--- a/src/SettingsScreen.h
+++ b/src/SettingsScreen.h
@@ -79,6 +79,9 @@ private:
 	Number* unitRatios[IntBuildingType::NB_BUILDING][6];
 	Text* unitRatioTexts[IntBuildingType::NB_BUILDING][6];
 	int unitRatioGroupNumbers[IntBuildingType::NB_BUILDING][6];
+	// One slot per flag type, indexed by type - EXPLORATION_FLAG. buildFlagsGroup()
+	// fills all three unconditionally, so unlike the sparse unitRatios grid these are
+	// never null; the null checks at the read sites are defensive only.
 	Number* flagRadii[3];
 	Text* flagRadiusTexts[3];
 	int flagRadiusGroupNumbers[3];


### PR DESCRIPTION
`flagRadii`, `flagRadiusTexts` and `flagRadiusGroupNumbers` were the only members of the Building Defaults tab left out of `SettingsScreen`'s constructor initializer list. Their `unitRatio*` counterparts are already covered — `unitRatioGroupNumbers` by the initializer list (since 2018), `unitRatios` and `unitRatioTexts` by the nulling loop at the top of `buildBuildingDefaultsTab()` — so the flag arrays were the odd ones out.

### This is hardening, not a bug fix

No read ever preceded a write:

- `buildFlagsGroup()` populates all three slots unconditionally during construction — it walks `EXPLORATION_FLAG..CLEARING_FLAG`, which is exactly 3 types, indexing `type - EXPLORATION_FLAG` into 0..2.
- Every reader (`activateDefaultAssignedGroupNumber`, `retranslateUiStrings`, `flushDefaultsToSettings`) runs from `onAction` or `onGroupActivated`, i.e. strictly after the constructor returns.

The reason to change it anyway is readability. The read sites null-check `flagRadii` and `flagRadiusTexts` even though those can't be null, which reads as a signal that empty slots occur. They don't — that pattern is inherited from the genuinely sparse `unitRatios` grid, where slots for missing building levels stay null on purpose. The comment records the invariant at the declaration so the asymmetry isn't mistaken for a missing case.

### Verification

- `scons -j16` clean, no new warnings.
- `./build/src/glob2 --nox games/G2.game 90000 1` byte-equal against `tests/baselines/cpp-refactor.replay` (game reaches its normal end at tick 56742, 11247 orders). The settings screen is not on the simulation path, so no checksum surface is touched.