### PR TITLE
Decode replay orders against the replay's format version

### DIFF
--- a/src/ReplayReader.cpp
+++ b/src/ReplayReader.cpp
@@ -90,9 +90,6 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 	// Replays written before version 87 store step counters as Uint16
 	wideStepCounter = (version_minor >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR);
 
-	// Orders in this replay are in the format of the version that wrote it, not
-	// necessarily this build's. The check above bounds it to a version this
-	// build can still parse.
 	versionMinor = version_minor;
 
 	// If there are no orders, this is also not a valid replay (there should be at least a NullOrder)

--- a/src/ReplayReader.cpp
+++ b/src/ReplayReader.cpp
@@ -22,6 +22,7 @@ ReplayReader::ReplayReader()
 	numOrders = 0;
 	stepsUntilNextOrder = -1;
 	wideStepCounter = false;
+	versionMinor = VERSION_MINOR;
 	checksum = 0;
 }
 
@@ -89,6 +90,11 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 	// Replays written before version 87 store step counters as Uint16
 	wideStepCounter = (version_minor >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR);
 
+	// Orders in this replay are in the format of the version that wrote it, not
+	// necessarily this build's. The check above bounds it to a version this
+	// build can still parse.
+	versionMinor = version_minor;
+
 	// If there are no orders, this is also not a valid replay (there should be at least a NullOrder)
 	if (stream->isEndOfStream())
 	{
@@ -112,6 +118,7 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 		{
 			// Read an order from the stream
 			NetSendOrder msg;
+			msg.setDecodeVersionMinor(versionMinor);
 			msg.decodeData(stream);
 			order = msg.getOrder();
 
@@ -213,6 +220,7 @@ std::shared_ptr<Order> ReplayReader::retrieveOrder()
 	{
 		// Read the order from the stream
 		NetSendOrder msg;
+		msg.setDecodeVersionMinor(versionMinor);
 		msg.decodeData(stream);
 		order = msg.getOrder();
 

--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -114,6 +114,14 @@ private:
 	/// (format version >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR)
 	bool wideStepCounter;
 
+	/// The save-format version the loaded replay was written with, taken from
+	/// the replay's own header. Orders must be decoded against this rather than
+	/// against VERSION_MINOR: a replay is a stored format and may predate this
+	/// build, so a version-gated Order field could otherwise be read at the
+	/// wrong offset or width. Constrained to
+	/// [REPLAY_MINIMUM_VERSION_MINOR, VERSION_MINOR] by the check in loadReplay.
+	Uint32 versionMinor;
+
 	/// The game's current checksum (or 0 if it's not given)
 	Uint32 checksum;
 };

--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -114,12 +114,7 @@ private:
 	/// (format version >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR)
 	bool wideStepCounter;
 
-	/// The save-format version the loaded replay was written with, taken from
-	/// the replay's own header. Orders must be decoded against this rather than
-	/// against VERSION_MINOR: a replay is a stored format and may predate this
-	/// build, so a version-gated Order field could otherwise be read at the
-	/// wrong offset or width. Constrained to
-	/// [REPLAY_MINIMUM_VERSION_MINOR, VERSION_MINOR] by the check in loadReplay.
+	/// Format version from the replay header, used to decode orders.
 	Uint32 versionMinor;
 
 	/// The game's current checksum (or 0 if it's not given)

--- a/src/net/message/OrderMessages.cpp
+++ b/src/net/message/OrderMessages.cpp
@@ -11,11 +11,18 @@ using namespace GAGCore;
 
 NetSendOrder::NetSendOrder()
 {
+	decodeVersionMinor=VERSION_MINOR;
 }
 
 NetSendOrder::NetSendOrder(std::shared_ptr<Order> newOrder)
 {
 	order=newOrder;
+	decodeVersionMinor=VERSION_MINOR;
+}
+
+void NetSendOrder::setDecodeVersionMinor(Uint32 newVersionMinor)
+{
+	decodeVersionMinor=newVersionMinor;
 }
 
 void NetSendOrder::changeOrder(std::shared_ptr<Order> newOrder)
@@ -66,7 +73,7 @@ void NetSendOrder::decodeData(GAGCore::InputStream* stream)
 	stream->read(buffer.data(), size, "data");
 	stream->readLeaveSection();
 
-	order = Order::getOrder(buffer.data(), size, VERSION_MINOR);
+	order = Order::getOrder(buffer.data(), size, decodeVersionMinor);
 
 	// If this couldn't be interpreted return it returned a NULL order, so we throw.
 	if (order == std::shared_ptr<Order>())

--- a/src/net/message/OrderMessages.h
+++ b/src/net/message/OrderMessages.h
@@ -37,13 +37,9 @@ public:
 
 	void changeOrder(std::shared_ptr<Order> newOrder);
 
-	/// Selects the save-format version the payload is interpreted against by
-	/// the next decodeData() call. Live network traffic must leave this at the
-	/// VERSION_MINOR default: both peers run the same build, so the current
-	/// version is by definition the right one. Replays are the exception —
-	/// they are a stored format that can predate this build, so ReplayReader
-	/// sets the version recorded in the replay's own header. Has no effect on
-	/// encodeData(), which always writes the current format.
+	/// Sets the version used by subsequent decodeData() calls.
+	/// Defaults to VERSION_MINOR; replay readers supply their header version.
+	/// Does not affect encoding.
 	void setDecodeVersionMinor(Uint32 newVersionMinor);
 
 	Uint8 getMessageType() const;
@@ -59,8 +55,6 @@ public:
 private:
 	std::shared_ptr<Order> order;
 
-	/// Save-format version handed to Order::getOrder when decoding. Defaults to
-	/// VERSION_MINOR (correct for the network path); see setDecodeVersionMinor.
 	Uint32 decodeVersionMinor;
 };
 

--- a/src/net/message/OrderMessages.h
+++ b/src/net/message/OrderMessages.h
@@ -37,6 +37,15 @@ public:
 
 	void changeOrder(std::shared_ptr<Order> newOrder);
 
+	/// Selects the save-format version the payload is interpreted against by
+	/// the next decodeData() call. Live network traffic must leave this at the
+	/// VERSION_MINOR default: both peers run the same build, so the current
+	/// version is by definition the right one. Replays are the exception —
+	/// they are a stored format that can predate this build, so ReplayReader
+	/// sets the version recorded in the replay's own header. Has no effect on
+	/// encodeData(), which always writes the current format.
+	void setDecodeVersionMinor(Uint32 newVersionMinor);
+
 	Uint8 getMessageType() const;
 	void encodeData(GAGCore::OutputStream* stream) const;
 	/// Wire format: Uint32 size | size bytes payload | Uint8 sender | Uint32 checksum.
@@ -49,6 +58,10 @@ public:
 	bool operator==(const NetMessage& rhs) const;
 private:
 	std::shared_ptr<Order> order;
+
+	/// Save-format version handed to Order::getOrder when decoding. Defaults to
+	/// VERSION_MINOR (correct for the network path); see setDecodeVersionMinor.
+	Uint32 decodeVersionMinor;
 };
 
 /// Latency probe sent periodically to measure round-trip time.

--- a/test/ReplayStepCounterTest.cpp
+++ b/test/ReplayStepCounterTest.cpp
@@ -81,11 +81,8 @@ public:
 	Uint8 getOrderType(void) { return ORDER_DELETE; }
 };
 
-// Records the versionMinor the last decode was resolved against, so a test can
-// assert which format the reader asked for. Real orders ignore the parameter
-// unless they are version-gated (only OrderCreate is, at
-// FILE_FORMAT_VERSION_ORDER_CREATE_FLAG_RADIUS), which is why the value has to
-// be observed here rather than inferred from a decoded order.
+// Record the requested version because supported replay versions currently
+// decode identically.
 Uint32 lastDecodeVersionMinor = 0;
 
 std::shared_ptr<Order> Order::getOrder(const Uint8 *netData, int netDataLength, Uint32 versionMinor)
@@ -265,33 +262,27 @@ void testVersionBounds()
 	}
 }
 
-// 4. Orders are decoded against the replay's own format version, not the
-// running build's. NetSendOrder::decodeData used to hardcode VERSION_MINOR,
-// which is right for live network traffic (both peers run this build) but
-// wrong for a replay, which is a stored format that may predate it. Nothing
-// observable diverges in the currently supported window — OrderCreate's gate
-// at 78 is the only version gate in the order layer and sits below the
-// REPLAY_MINIMUM_VERSION_MINOR floor of 86 — so the plumbing is asserted
-// directly. Without it, the next order-format gate would silently misparse
-// every replay written before it.
+// 4. Both the initial scan and playback use the replay header version.
 void testDecodeVersionPlumbing()
 {
 	const Uint16 oldVersion = REPLAY_MINIMUM_VERSION_MINOR;
 
-	// A version this test would be meaningless at: if the floor ever rises to
-	// meet the current build, the assertion below could pass by coincidence.
+	// Require an older version so a hardcoded VERSION_MINOR cannot pass.
 	check(oldVersion != VERSION_MINOR,
 	      "decodeVersion: replay floor is below the current build version");
 
 	ReplayReader reader;
-	bool loaded = reader.loadReplay(writeReplayBody(oldVersion, false, 7), false);
+	const bool wideCounters = oldVersion >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR;
+	lastDecodeVersionMinor = 0;
+	bool loaded = reader.loadReplay(writeReplayBody(oldVersion, wideCounters, 7), false);
 	check(loaded, "decodeVersion: old-but-supported replay loads");
 	if (!loaded)
 		return;
 
-	// loadReplay decodes the whole order stream once to measure the replay, so
-	// the recorded version is already the one under test; clear it so the
-	// assertion below is about retrieveOrder specifically.
+	check(lastDecodeVersionMinor == oldVersion,
+	      "decodeVersion: initial scan uses the replay header version");
+
+	// Reset the recorder to check playback independently of the initial scan.
 	lastDecodeVersionMinor = 0;
 
 	for (Uint32 i = 0; i < 7; i++)

--- a/test/ReplayStepCounterTest.cpp
+++ b/test/ReplayStepCounterTest.cpp
@@ -81,8 +81,16 @@ public:
 	Uint8 getOrderType(void) { return ORDER_DELETE; }
 };
 
-std::shared_ptr<Order> Order::getOrder(const Uint8 *netData, int netDataLength, Uint32 /*versionMinor*/)
+// Records the versionMinor the last decode was resolved against, so a test can
+// assert which format the reader asked for. Real orders ignore the parameter
+// unless they are version-gated (only OrderCreate is, at
+// FILE_FORMAT_VERSION_ORDER_CREATE_FLAG_RADIUS), which is why the value has to
+// be observed here rather than inferred from a decoded order.
+Uint32 lastDecodeVersionMinor = 0;
+
+std::shared_ptr<Order> Order::getOrder(const Uint8 *netData, int netDataLength, Uint32 versionMinor)
 {
+	lastDecodeVersionMinor = versionMinor;
 	if (netDataLength < 1 || netData == NULL)
 		return std::shared_ptr<Order>();
 	if (netData[0] == ORDER_NULL)
@@ -257,6 +265,43 @@ void testVersionBounds()
 	}
 }
 
+// 4. Orders are decoded against the replay's own format version, not the
+// running build's. NetSendOrder::decodeData used to hardcode VERSION_MINOR,
+// which is right for live network traffic (both peers run this build) but
+// wrong for a replay, which is a stored format that may predate it. Nothing
+// observable diverges in the currently supported window — OrderCreate's gate
+// at 78 is the only version gate in the order layer and sits below the
+// REPLAY_MINIMUM_VERSION_MINOR floor of 86 — so the plumbing is asserted
+// directly. Without it, the next order-format gate would silently misparse
+// every replay written before it.
+void testDecodeVersionPlumbing()
+{
+	const Uint16 oldVersion = REPLAY_MINIMUM_VERSION_MINOR;
+
+	// A version this test would be meaningless at: if the floor ever rises to
+	// meet the current build, the assertion below could pass by coincidence.
+	check(oldVersion != VERSION_MINOR,
+	      "decodeVersion: replay floor is below the current build version");
+
+	ReplayReader reader;
+	bool loaded = reader.loadReplay(writeReplayBody(oldVersion, false, 7), false);
+	check(loaded, "decodeVersion: old-but-supported replay loads");
+	if (!loaded)
+		return;
+
+	// loadReplay decodes the whole order stream once to measure the replay, so
+	// the recorded version is already the one under test; clear it so the
+	// assertion below is about retrieveOrder specifically.
+	lastDecodeVersionMinor = 0;
+
+	for (Uint32 i = 0; i < 7; i++)
+		reader.advanceStep();
+	std::shared_ptr<Order> order = reader.retrieveOrder();
+	check(order && order->getOrderType() == ORDER_DELETE, "decodeVersion: order read back");
+	check(lastDecodeVersionMinor == oldVersion,
+	      "decodeVersion: order decoded against the replay's version, not VERSION_MINOR");
+}
+
 }  // namespace
 
 int main(int /*argc*/, char* /*argv*/[])
@@ -264,6 +309,7 @@ int main(int /*argc*/, char* /*argv*/[])
 	testWideRoundTrip();
 	testOldFormatUint16();
 	testVersionBounds();
+	testDecodeVersionPlumbing();
 	std::printf(failures == 0 ? "ALL PASS\n" : "FAILURES: %d\n", failures);
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
`NetSendOrder::decodeData` hardcoded `VERSION_MINOR` when handing the payload to `Order::getOrder`:

```cpp
order = Order::getOrder(buffer.data(), size, VERSION_MINOR);
```

That is right for live network traffic — both peers run this build, so the current version is by definition the correct one. It is wrong for a replay. A replay is a *stored* format that may predate the running build, and `ReplayReader` accepts anything from `REPLAY_MINIMUM_VERSION_MINOR` (86) up to `VERSION_MINOR` (88). The same `decodeData` serves both paths.

### Nothing misparses today

`FILE_FORMAT_VERSION_ORDER_CREATE_FLAG_RADIUS` (78) is the only version gate anywhere in the order layer — every other order's `setData` takes `versionMinor` and ignores it. 78 sits below the replay floor of 86, so every order in every accepted replay decodes identically at 86, 87 and 88.

The next order-format gate would not be so lucky. It would silently misread every replay written before it — wrong offset or wrong width, no error raised, and no checksum to catch it (see the note below).

### Approach

`decodeData` is a `NetMessage` virtual with 62 overrides, so changing its signature is off the table. Instead `NetSendOrder` carries the version as a member defaulting to `VERSION_MINOR`. The network path, the writer, and the other 61 subclasses are untouched; only `ReplayReader` overrides it, from the version in the replay's own header — mirroring how the adjacent `wideStepCounter` flag is already derived from that same value.

### Testing

`ReplayStepCounterTest` gains a case asserting the version actually reaches `Order::getOrder`. Because no order parses differently across the supported replay range, there is no behavioural delta to observe — the plumbing has to be checked directly, so the test's stubbed `getOrder` records the version it was called with.

- `ReplayStepCounterTest`: 22/22 PASS.
- The new case was verified to **fail** with the one-line fix reverted (`FAILURES: 1`), then pass again once restored — it is not vacuous.
- Replay verification: `./build/src/glob2 --nox games/G2.game 90000 1` is **byte-equal** to `tests/baselines/cpp-refactor.replay`. No determinism impact; no baseline change.

Playback could not be exercised end-to-end: `-replay` is unreachable headlessly, since `Glob2::run` returns from `runNoX()` before the replay branch and `runNoX()` only supports `initCustom`.

### Unrelated pre-existing issue noticed

`ReplayReader::setCheckSum` is never called by the engine — only the `ReplayWriter` counterpart is, at `EngineRun.cpp:121`. So `ReplayReader::checksum` stays 0 and the "checksums don't match!" guard in `retrieveOrder` is dead code: a replay that decoded wrong would play on silently. Not touched here.