### PR TITLE
Let units survive building destruction (#185)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,11 @@ jobs:
           scons -j$(nproc) release=1 server=0 immobile-unit-gradient-test
           ./build/src/ImmobileUnitGradientHarness
 
+      - name: Build and run the building expulsion regression
+        run: |
+          scons -j$(nproc) release=1 server=0 building-expel-test
+          timeout 300s ./build/src/BuildingExpelHarness
+
       - name: Build and run the hiring bucket regression
         run: |
           scons -j$(nproc) release=1 server=0 hiring-bucket-test

--- a/src/Game_io.cpp
+++ b/src/Game_io.cpp
@@ -322,6 +322,8 @@ bool Game::checkBuildingsDoNotOverlapAndHealMissing() {
 			const auto building = team->myBuildings[bi];
 			if (!building)
 				continue;
+			if (building->buildingState==Building::DEAD)  // kill() cleared its footprint
+				continue;
 			const auto x = building->posX;
 			const auto y = building->posY;
 			const auto type = building->type;

--- a/src/SConscript
+++ b/src/SConscript
@@ -648,3 +648,10 @@ if not env['server'] and 'custom-setup-test' in COMMAND_LINE_TARGETS:
     custom_sources += local.Object('CustomGameSetupHarness.o', '#test/CustomGameSetupHarness.cpp')
     custom_test = local.Program('CustomGameSetupHarness', custom_sources)
     local.Alias('custom-setup-test', custom_test)
+
+# Real engine regression for units surviving building destruction, built only by its explicit target.
+if not env['server']:
+    regression_sources = [source for source in source_files if source != 'Glob2.cpp']
+    regression_sources += local.Object('BuildingExpelHarness.o', '#test/BuildingExpelHarness.cpp')
+    regression_test = local.Program('BuildingExpelHarness', regression_sources)
+    local.Alias('building-expel-test', regression_test)

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -216,8 +216,8 @@ public:
 	void swarmStep(void);
 	/// This function searches for enemies, computes the best target, and fires a bullet
 	void turretStep(Uint32 stepCounter);
-	/// Kills the building, removing all units that are working or inside the building,
-	/// changing the state and adding it to the list of buildings to be deleted
+	/// Kills the building: releases its workers, expels the units inside onto
+	/// the footprint or the ring around it, and queues it for deletion.
 	void kill(void);
 
 	/// This function removes the unit from the list of units working on the building. Units will remove themselves
@@ -263,6 +263,9 @@ public:
 	/// and provides the x and y coordinates, along with the direction the unit should be travelling
 	/// when it leaves.
 	bool findAirExit(int *posX, int *posY, int *dx, int *dy);
+
+	/// Free tile for a unit expelled by kill(): footprint first, then the ring; dx/dy point outwards.
+	bool findExpelTile(bool fly, bool canSwim, int *posX, int *posY, int *dx, int *dy);
 
 	/// Returns the script level number. Construction sites are odd numbers and completed buildings
 	/// even, from 0 to 5

--- a/src/building/Misc.cpp
+++ b/src/building/Misc.cpp
@@ -30,22 +30,26 @@ void Building::kill(void)
 		return;
 
 
+	// Units inside need the footprint freed before they can be placed.
+	std::vector<Unit *> unitsToExpel;
 	for (std::list<Unit *>::iterator it=unitsInside.begin(); it!=unitsInside.end(); ++it)
 	{
-		//TODO: We should somehow try to save their lives. In training buildings they should just drop out untrained etc.
 		Unit *u=*it;
-		if (u->displacement==Unit::DIS_INSIDE)
-			u->isDead=true;
-
-		if (u->displacement==Unit::DIS_ENTERING_BUILDING)
+		if (u->displacement==Unit::DIS_INSIDE || u->displacement==Unit::DIS_EXITING_BUILDING)
+			unitsToExpel.push_back(u);
+		else if (u->displacement==Unit::DIS_ENTERING_BUILDING)
 		{
+			// An entering unit still owns the tile it came from: step back onto it.
+			int x=(u->posX-u->dx)&owner->map->getMaskW();
+			int y=(u->posY-u->dy)&owner->map->getMaskH();
 			if (u->performance[FLY])
-				owner->map->setAirUnit(u->posX-u->dx, u->posY-u->dy, NOGUID);
+				owner->map->setAirUnit(x, y, NOGUID);
 			else
-				owner->map->setGroundUnit(u->posX-u->dx, u->posY-u->dy, NOGUID);
-			u->isDead=true;
+				owner->map->setGroundUnit(x, y, NOGUID);
+			u->expelFromBuilding(x, y, -u->dx, -u->dy);
 		}
-		u->standardRandomActivity();
+		else
+			u->standardRandomActivity();
 	}
 	unitsInside.clear();
 
@@ -83,6 +87,19 @@ void Building::kill(void)
 				owner->noMoreBuildingSitesCountdown=Team::noMoreBuildingSitesCountdownMax;
 		}
 
+	}
+
+	for (std::vector<Unit *>::iterator it=unitsToExpel.begin(); it!=unitsToExpel.end(); ++it)
+	{
+		Unit *u=*it;
+		int x, y, dx, dy;
+		if (findExpelTile(u->performance[FLY], u->performance[SWIM], &x, &y, &dx, &dy))
+			u->expelFromBuilding(x, y, dx, dy);
+		else
+		{
+			u->isDead=true;
+			u->standardRandomActivity();
+		}
 	}
 
 	buildingState=DEAD;
@@ -342,6 +359,30 @@ bool Building::findAirExit(int *posX, int *posY, int *dx, int *dy)
 					*dy=0;
 				else
 					*dy=1;
+				return true;
+			}
+	return false;
+}
+
+bool Building::findExpelTile(bool fly, bool canSwim, int *posX, int *posY, int *dx, int *dy)
+{
+	// Pass 0 takes the footprint, pass 1 the ring around it.
+	for (int pass=0; pass<2; pass++)
+		for (int y=this->posY-1; y<=this->posY+type->height; y++)
+			for (int x=this->posX-1; x<=this->posX+type->width; x++)
+			{
+				int ox=(x>=this->posX+type->width)-(x<this->posX);
+				int oy=(y>=this->posY+type->height)-(y<this->posY);
+				if ((ox!=0 || oy!=0)!=(pass==1))
+					continue;
+				int wx=x&owner->map->getMaskW();
+				int wy=y&owner->map->getMaskH();
+				if (fly ? !owner->map->isFreeForAirUnit(wx, wy) : !owner->map->isFreeForGroundUnit(wx, wy, canSwim, owner->me))
+					continue;
+				*posX=wx;
+				*posY=wy;
+				*dx=ox;
+				*dy=oy;
 				return true;
 			}
 	return false;

--- a/src/unit/Unit.h
+++ b/src/unit/Unit.h
@@ -73,6 +73,8 @@ public:
 	void selectPreferredGroundMovement(void);
 	bool isUnitHungry(void);
 	void standardRandomActivity();
+	/// Puts a unit from a destroyed building back on the map at (x, y), walking out along (dx, dy).
+	void expelFromBuilding(int x, int y, int dx, int dy);
 	
 	int getRealArmor(bool isMagic) const;
 	int getRealAttackStrength(void) const; //!< Return the real attack strength for warriors
@@ -190,6 +192,7 @@ protected:
 	void handleActionGoingDxDy();
 	void handleActionEnteringBuilding();
 	void handleActionExitingBuilding();
+	void applyPartialInsideBenefit();
 	void handleActionFilling();
 	void handleActionAttackingTarget();
 	void handleActionHarvesting();

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2001-2004 Stephane Magnenat & Luc-Olivier de Charrière
 
+#include <algorithm>
 #include "Unit.h"
 #include "Race.h"
 #include "Team.h"
@@ -437,4 +438,45 @@ bool Unit::locationIsInEnemyGuardTowerRange(int x, int y)const
 		}
 	}
 	return false;
+}
+
+// Training is all-or-nothing; a meal or a healing is granted pro rata, and
+// a started meal costs a whole wheat.
+void Unit::applyPartialInsideBenefit()
+{
+	if (displacement!=DIS_INSIDE)
+		return;
+	int total;
+	if (destinationPurpose==FEED)
+		total=attachedBuilding->type->timeToFeedUnit;
+	else if (destinationPurpose==HEAL)
+		total=attachedBuilding->type->timeToHealUnit;
+	else
+		return;
+	int elapsed=std::min(total, total+insideTimeout);
+	if (total<=0 || elapsed<=0)
+		return;
+	if (destinationPurpose==FEED)
+	{
+		if (attachedBuilding->resources[CORN]<=0)
+			return;
+		hungry+=((HUNGRY_MAX-hungry)*elapsed)/total;
+		fruitCount=attachedBuilding->eatOnce(&fruitMask);
+	}
+	else
+		hp+=((performance[HP]-hp)*elapsed)/total;
+}
+
+void Unit::expelFromBuilding(int x, int y, int dx, int dy)
+{
+	applyPartialInsideBenefit();
+	standardRandomActivity();
+	insideTimeout=0;
+	posX=x;
+	posY=y;
+	this->dx=dx;
+	this->dy=dy;
+	delta=0;
+	movement=MOV_EXITING_BUILDING;
+	handleActionExitingBuilding();
 }

--- a/test/BuildingExpelHarness.cpp
+++ b/test/BuildingExpelHarness.cpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Units survive their building being destroyed (issue #185).
+#include "GlobalContainer.h"
+#include "Game.h"
+#include "GameGUI.h"
+#include "Unit.h"
+#include "Building.h"
+#include "BuildingType.h"
+#include "IntBuildingType.h"
+#include "Race.h"
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+	if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+struct World
+{
+	GameGUI gui;
+	Game& game = gui.game;
+	Team* team = nullptr;
+	int parked = 0;
+	static const int bx = 8, by = 8;  // where addInn() puts the inn
+
+	World()
+	{
+		game.map.setSize(5, 5, GRASS);
+		game.map.setGame(&game);
+		game.addTeam(0);
+		team = game.teams[0];
+		// The gradient scheduler expects an in-use field; allocation is now lazy.
+		game.map.getResourceGradient(0, WOOD, 0);
+	}
+
+	// Game::addBuilding creates the building; the map footprint is registered separately.
+	Building* addBuilding(const char* name, int x, int y)
+	{
+		const int typeNum = globalContainer->buildingsTypes.getTypeNum(name, 0, false);
+		require(typeNum >= 0, "building type exists");
+		Building* b = game.addBuilding(x, y, typeNum, 0);
+		require(b != nullptr, "building placed");
+		game.map.setBuilding(x, y, b->type->width, b->type->height, b->gid);
+		return b;
+	}
+
+	Building* addInn() { return addBuilding("inn", bx, by); }
+
+	// A unit created on a far-away tile, so scenarios can move it wherever they need.
+	Unit* addUnit(int typeNum, int x = -1, int y = -1)
+	{
+		if (x < 0) { x = 20 + parked % 10; y = 20 + parked / 10; ++parked; }
+		Unit* u = game.addUnit(x, y, 0, typeNum, 0, 0, 0, 0);
+		require(u != nullptr, "unit placed");
+		return u;
+	}
+
+	// The state Unit::handleActivity leaves after a unit subscribes to go inside.
+	void subscribe(Unit* u, Building* b, int purpose, Unit::Displacement displacement)
+	{
+		u->attachedBuilding = b;
+		u->setTargetBuilding(b);
+		u->activity = Unit::ACT_UPGRADING;
+		u->displacement = displacement;
+		u->destinationPurpose = purpose;
+		u->needToRecheckMedical = false;
+		b->unitsInside.push_back(u);
+	}
+
+	// Mirrors the state Unit::handleDisplacement leaves after DIS_ENTERING_BUILDING -> DIS_INSIDE.
+	Unit* addInside(Building* b, int typeNum, int purpose, int elapsed, int total)
+	{
+		Unit* u = addUnit(typeNum);
+		if (u->performance[FLY])
+			game.map.setAirUnit(u->posX, u->posY, NOGUID);
+		else
+			game.map.setGroundUnit(u->posX, u->posY, NOGUID);
+		u->posX = b->getMidX();
+		u->posY = b->getMidY();
+		subscribe(u, b, purpose, Unit::DIS_INSIDE);
+		u->movement = Unit::MOV_INSIDE;
+		u->insideTimeout = -(total - elapsed);
+		u->speed = b->type->insideSpeed;
+		return u;
+	}
+
+	Unit* addEntering(Building* b, int typeNum, int fromX, int fromY, int dx, int dy)
+	{
+		Unit* u = addUnit(typeNum, fromX, fromY);
+		u->posX = (fromX + dx) & game.map.getMaskW();
+		u->posY = (fromY + dy) & game.map.getMaskH();
+		u->dx = dx;
+		u->dy = dy;
+		subscribe(u, b, FEED, Unit::DIS_ENTERING_BUILDING);
+		u->movement = Unit::MOV_ENTERING_BUILDING;
+		return u;
+	}
+
+	bool alive(const Unit* u) const
+	{
+		return u && !u->isDead && team->myUnits[Unit::GIDtoID(u->gid)] == u;
+	}
+
+	bool registered(const Unit* u) const
+	{
+		if (u->performance[FLY])
+			return game.map.getAirUnit(u->posX, u->posY) == u->gid;
+		return game.map.getGroundUnit(u->posX, u->posY) == u->gid;
+	}
+
+	bool inFootprintOrRing(const Unit* u, int bx, int by, int w, int h) const
+	{
+		const int ox = (u->posX - bx + 1) & game.map.getMaskW();
+		const int oy = (u->posY - by + 1) & game.map.getMaskH();
+		return ox <= w + 1 && oy <= h + 1;
+	}
+
+	void step(int steps)
+	{
+		for (int i = 0; i < steps; ++i)
+			game.syncStep(0);
+		require(game.integrity(), "integrity after simulation steps");
+	}
+};
+
+static void destroyedInnExpelsEveryone()
+{
+	World world;
+	const int bx = World::bx, by = World::by;
+	Building* inn = world.addInn();
+	const int w = inn->type->width, h = inn->type->height;
+	const int total = inn->type->timeToFeedUnit;
+	require(total > 0, "inn feeds units");
+	Unit* units[5];
+	units[0] = world.addInside(inn, WORKER, FEED, total / 2, total);
+	units[1] = world.addInside(inn, WARRIOR, FEED, total / 2, total);
+	units[2] = world.addInside(inn, EXPLORER, FEED, total / 2, total);
+	units[3] = world.addInside(inn, WORKER, FEED, 0, total);
+	units[4] = world.addEntering(inn, WORKER, bx - 1, by, 1, 0);
+	for (Unit* u : units)
+		u->hungry = 0;
+	units[3]->displacement = Unit::DIS_EXITING_BUILDING;  // waiting for a free exit
+	inn->resources[CORN] = 10;
+	require(world.game.integrity(), "scenario setup is consistent");
+
+	const Uint16 innGid = inn->gid;
+	inn->kill();
+	require(inn->buildingState == Building::DEAD && inn->unitsInside.empty(), "inn is dead and empty");
+	for (Unit* u : units)
+	{
+		require(world.alive(u), "unit survives the destruction");
+		require(u->attachedBuilding == nullptr && u->targetBuilding == nullptr, "unit is detached");
+		require(u->activity == Unit::ACT_RANDOM && u->displacement == Unit::DIS_RANDOM, "unit is free");
+		require(u->movement == Unit::MOV_EXITING_BUILDING && u->delta == 0, "unit walks out");
+		require(u->insideTimeout == 0 && u->needToRecheckMedical, "unit is out and re-evaluates its needs");
+		require(u->speed > 0, "unit has a speed");
+		require(world.registered(u), "unit is registered on its tile");
+		require(world.inFootprintOrRing(u, bx, by, w, h), "unit lands on the footprint or the ring");
+	}
+	for (int i = 0; i < 3; ++i)
+		require(units[i]->hungry == (Unit::HUNGRY_MAX * (total / 2)) / total, "half a meal is kept");
+	require(inn->resources[CORN] == 7, "each started meal cost one wheat, nothing else did");
+	require(units[3]->hungry == 0, "a unit already on its way out gets nothing more");
+	require(units[4]->posX == bx - 1 && units[4]->posY == by && units[4]->dx == -1 && units[4]->dy == 0,
+	        "entering unit steps back onto the tile it came from");
+	require(units[4]->hungry == 0, "entering unit had not started eating");
+	require(world.game.integrity(), "integrity right after the destruction");
+	world.step(40);
+	for (Unit* u : units)
+		require(world.alive(u) && world.registered(u), "expelled unit keeps living");
+	require(world.team->myBuildings[Building::GIDtoID(innGid)] == nullptr, "dead inn was collected");  // inn is freed by now
+	std::puts("PASS destroyed inn expels inside, exiting and entering units alive");
+}
+
+static void noRoomKillsTheSurplus()
+{
+	World world;
+	const int bx = World::bx, by = World::by;
+	Building* inn = world.addInn();
+	const int w = inn->type->width, h = inn->type->height;
+	const int total = inn->type->timeToFeedUnit;
+	for (int y = by - 1; y <= by + h; ++y)
+		for (int x = bx - 1; x <= bx + w; ++x)
+			if (y == by - 1 || y == by + h || x == bx - 1 || x == bx + w)
+				world.addUnit(WORKER, x, y);
+	const int footprint = w * h;
+	std::vector<Unit*> inside;
+	for (int i = 0; i < footprint + 1; ++i)
+		inside.push_back(world.addInside(inn, WORKER, FEED, 0, total));
+	require(world.game.integrity(), "scenario setup is consistent");
+
+	inn->kill();
+	int survivors = 0, dead = 0;
+	for (Unit* u : inside)
+	{
+		if (u->isDead) { ++dead; continue; }
+		++survivors;
+		require(world.registered(u), "survivor is registered");
+		require(((u->posX - bx) & world.game.map.getMaskW()) < w && ((u->posY - by) & world.game.map.getMaskH()) < h,
+		        "survivor stands on the footprint");
+	}
+	require(survivors == footprint && dead == 1, "exactly the units without a free tile die");
+	require(world.game.integrity(), "integrity right after the destruction");
+	world.step(5);
+	std::puts("PASS a unit with no free tile still dies");
+}
+
+static void healingIsKeptProRata()
+{
+	World world;
+	Building* hospital = world.addBuilding("hospital", 8, 8);
+	const int total = hospital->type->timeToHealUnit;
+	require(total > 0, "hospital heals units");
+	Unit* u = world.addInside(hospital, WARRIOR, HEAL, (3 * total) / 4, total);
+	const int maxHp = u->performance[HP];
+	u->hp = maxHp / 10;
+	const int expected = u->hp + ((maxHp - u->hp) * ((3 * total) / 4)) / total;
+	hospital->kill();
+	require(world.alive(u) && u->hp == expected, "three quarters of the healing is kept");
+	world.step(10);
+	std::puts("PASS healing is kept pro rata");
+}
+
+int main()
+{
+	GlobalContainer globals;
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+	destroyedInnExpelsEveryone();
+	noRoomKillsTheSurplus();
+	healingIsKeptProRata();
+	std::puts("Building expulsion regressions passed");
+	return 0;
+}

--- a/test/README.md
+++ b/test/README.md
@@ -217,6 +217,18 @@ the initial occupancy explicitly, so failures in painting or occupancy can be
 reproduced independently of the fresh-map initialization bug. Linux CI runs all
 scenarios.
 
+## Building expulsion regression
+
+From the repository root, run `scons -j8 release=1 server=0 building-expel-test`
+and `./build/src/BuildingExpelHarness`. The harness links the real engine and
+checks that a destroyed building puts the units inside it, entering it, or
+waiting to leave it back on the map alive (footprint first, then the ring around
+it; a unit with no free tile dies), and that the expelled units keep the share of
+the meal or healing they had already received while a started meal still costs
+the building one wheat. Every scenario then runs real simulation steps and
+re-checks `Game::integrity`. It needs no display, AI tournament tooling, or
+external save files.
+
 ### Savegame safety
 
 Build `scons release=1 server=0 savegame-safety-test`, then run


### PR DESCRIPTION
Closes #185.

Units inside a building no longer die with it.

**Destruction.** `Building::kill()` puts occupants back on the map alive. Units inside or waiting to leave land on a free tile of the footprint first, then on the ring around it (`Building::findExpelTile`), so a building surrounded by enemies still spawns its occupants on its own tiles. A unit with no free tile at all still dies. A unit halfway through the door steps back onto the tile it came from.

**Partial benefit.** Expelled units keep the share of the meal or healing they already sat through; training stays all-or-nothing. A started meal still costs the inn one wheat (it cannot be split), so nobody eats for free; a unit that finds no wheat left gets nothing.

**Capacity is unchanged by damage.** A building holds its full `type->maxUnitInside` until it dies. The earlier revision shrank the inside capacity as the building took damage, with reservation cancellations and eviction ordering. Per @genixpro ("my preference is to keep capacity unchanged until destruction, then release the occupants") and @stephanemagnenat's "keep it simple" in #185, that mechanism is gone: `Building::updateInsideCapacity`, its per-step call, `Unit::leaveBuildingEarly`, the walker-cancellation ordering, the defence-tower and swarm exemption, and the two renderer clamps that only existed because capacity could shrink under a full building.

**Engine fix on the way.** `Game::checkBuildingsDoNotOverlapAndHealMissing` no longer stamps the footprint of a dead building back onto the map. `kill()` clears it, and re-adding it left a dangling id once the building was collected (segfault in `Map::setMapBuildingsDiscovered`).

**Test.** `test/BuildingExpelHarness.cpp` links the real engine and covers: a destroyed inn expelling its inside, exiting and entering units alive; a unit with no free tile still dying; healing kept pro rata. Each scenario runs real simulation steps and re-checks `Game::integrity`. Like `TrappedUnitLifecycleTest` it touches one resource gradient at setup, because the round-robin in `Map::syncStep` skips fields that were never allocated and a bare test world has none.

```
scons release=1 server=0 building-expel-test && ./build/src/BuildingExpelHarness
```

CI builds and runs it under a timeout, next to the other real-engine regressions.
