### PR TITLE
Fix Team::load double-pushing canExchange buildings

### DIFF
--- a/src/team/TeamSerialization.cpp
+++ b/src/team/TeamSerialization.cpp
@@ -92,8 +92,6 @@ bool Team::load(GAGCore::InputStream *stream, BuildingsTypes *buildingstypes, Si
 		{
 			stream->readEnterSection(i);
 			myBuildings[i]->loadCrossRef(stream, buildingstypes, this, versionMinor);
-			if (myBuildings[i]->type->canExchange)
-				canExchange.push_back(myBuildings[i]);
 			stream->readLeaveSection();
 		}
 	}


### PR DESCRIPTION
`Team::load` pushes every canExchange-capable building onto the `canExchange` list twice: once during the initial load pass (`src/team/TeamSerialization.cpp`, building construction loop) and again during the cross-reference pass. This duplicates every entry on every load.

Removed the redundant push in the cross-reference pass — the initial pass already handles it consistently with `swarms`/`turrets`/`virtualBuildings`/`clearingFlags`, none of which are re-pushed there.

Verified: full `scons release=1` build succeeds (exit 0), single-line-context diff, no behavior change beyond the list no longer being doubled.

Found while auditing the codebase for dead code/duplication at Leo's request; this bug turned up along the way.