### PR TITLE
Reduce work in global gradient sweeps without changing results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,11 @@ jobs:
           scons -j$(nproc) release=1 server=0 terrain-test
           ./build/src/TerrainResourcesHarness
 
+      - name: Build and run the global gradient regression
+        run: |
+          scons -j$(nproc) release=1 server=0 global-gradient-test
+          ./build/src/GlobalGradientHarness
+
       - name: Build and run the LAN session regression
         run: |
           scons -j$(nproc) release=1 server=0 lan-test

--- a/src/SConscript
+++ b/src/SConscript
@@ -485,6 +485,12 @@ if not env['server']:
     local.Alias('terrain-test', terrain_test)
 
 if not env['server']:
+    gradient_sources = [source for source in source_files if source != 'Glob2.cpp']
+    gradient_sources += local.Object('GlobalGradientHarness.o', '#test/GlobalGradientHarness.cpp')
+    gradient_test = local.Program('GlobalGradientHarness', gradient_sources)
+    local.Alias('global-gradient-test', gradient_test)
+
+if not env['server']:
     lan_sources = [source for source in source_files if source != 'Glob2.cpp']
     lan_sources += local.Object('LANSessionHarness.o', '#test/LANSessionHarness.cpp')
     lan_test = local.Program('LANSessionHarness', lan_sources)

--- a/src/map/gradient/MapGradientGlobal.cpp
+++ b/src/map/gradient/MapGradientGlobal.cpp
@@ -6,6 +6,8 @@
 #include "Unit.h"
 #include "MapInternal.h"
 
+#include <algorithm>
+
 // Chamfer distance transform with orthogonal=1, diagonal=1 weights (Chebyshev
 // distance) on a toroidal grid. Two sweeps per pass — forward (NW, N, NE, W)
 // then backward (SE, S, SW, E) — repeated until a full pass writes nothing.
@@ -39,57 +41,48 @@ void Map::updateGlobalGradient(Uint8 *gradient)
 	{
 		changed = false;
 
-		// Forward sweep: in-set neighbors are NW, N, NE, W (already visited).
+		// Only the strongest neighbor matters: subtracting one preserves their order.
+		// Keep the in-place sweep order, including reads across the toroidal seams.
 		for (size_t y = 0; y < (size_t)h; y++)
 		{
-			size_t yu = ((y - 1) & hMask);
+			Uint8* row = gradient + (y << wDec);
+			const Uint8* previousRow = gradient + (((y - 1) & hMask) << wDec);
 			for (size_t x = 0; x < (size_t)w; x++)
 			{
-				Uint8 g = gradient[(y << wDec) | x];
-				if (g == 0)
+				const Uint8 g = row[x];
+				// Obstacles stay zero; a goal is already at the maximum possible value.
+				if (g == GRADIENT_FORBIDDEN || g == GRADIENT_AT_GOAL)
 					continue;
-				size_t xl = ((x - 1) & wMask);
-				size_t xr = ((x + 1) & wMask);
-				Uint8 best = g;
-				Uint8 vNW = gradient[(yu << wDec) | xl];
-				Uint8 vN  = gradient[(yu << wDec) | x ];
-				Uint8 vNE = gradient[(yu << wDec) | xr];
-				Uint8 vW  = gradient[(y  << wDec) | xl];
-				if (vNW >= 3 && (Uint8)(vNW - 1) > best) best = vNW - 1;
-				if (vN  >= 3 && (Uint8)(vN  - 1) > best) best = vN  - 1;
-				if (vNE >= 3 && (Uint8)(vNE - 1) > best) best = vNE - 1;
-				if (vW  >= 3 && (Uint8)(vW  - 1) > best) best = vW  - 1;
-				if (best != g)
+				const size_t xl = (x - 1) & wMask;
+				const size_t xr = (x + 1) & wMask;
+				// Forward neighbors: NW, N, NE, W.
+				const Uint8 neighborMax = std::max(std::max(previousRow[xl], previousRow[x]),
+					std::max(previousRow[xr], row[xl]));
+				if (neighborMax >= 3 && neighborMax - 1 > g)
 				{
-					gradient[(y << wDec) | x] = best;
+					row[x] = neighborMax - 1;
 					changed = true;
 				}
 			}
 		}
 
-		// Backward sweep: in-set neighbors are SE, S, SW, E (already visited).
 		for (size_t y = (size_t)h; y-- > 0; )
 		{
-			size_t yd = ((y + 1) & hMask);
+			Uint8* row = gradient + (y << wDec);
+			const Uint8* nextRow = gradient + (((y + 1) & hMask) << wDec);
 			for (size_t x = (size_t)w; x-- > 0; )
 			{
-				Uint8 g = gradient[(y << wDec) | x];
-				if (g == 0)
+				const Uint8 g = row[x];
+				if (g == GRADIENT_FORBIDDEN || g == GRADIENT_AT_GOAL)
 					continue;
-				size_t xl = ((x - 1) & wMask);
-				size_t xr = ((x + 1) & wMask);
-				Uint8 best = g;
-				Uint8 vSE = gradient[(yd << wDec) | xr];
-				Uint8 vS  = gradient[(yd << wDec) | x ];
-				Uint8 vSW = gradient[(yd << wDec) | xl];
-				Uint8 vE  = gradient[(y  << wDec) | xr];
-				if (vSE >= 3 && (Uint8)(vSE - 1) > best) best = vSE - 1;
-				if (vS  >= 3 && (Uint8)(vS  - 1) > best) best = vS  - 1;
-				if (vSW >= 3 && (Uint8)(vSW - 1) > best) best = vSW - 1;
-				if (vE  >= 3 && (Uint8)(vE  - 1) > best) best = vE  - 1;
-				if (best != g)
+				const size_t xl = (x - 1) & wMask;
+				const size_t xr = (x + 1) & wMask;
+				// Backward neighbors: SE, S, SW, E.
+				const Uint8 neighborMax = std::max(std::max(nextRow[xr], nextRow[x]),
+					std::max(nextRow[xl], row[xr]));
+				if (neighborMax >= 3 && neighborMax - 1 > g)
 				{
-					gradient[(y << wDec) | x] = best;
+					row[x] = neighborMax - 1;
 					changed = true;
 				}
 			}

--- a/test/GlobalGradientHarness.cpp
+++ b/test/GlobalGradientHarness.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Compare the real global gradient implementation with an independent frontier solver.
+#include "GlobalContainer.h"
+#include "Map.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <queue>
+#include <random>
+#include <utility>
+#include <vector>
+
+GlobalContainer* globalContainer = nullptr;
+
+namespace
+{
+// Only grid geometry is needed for propagation; avoid allocating game state.
+struct GradientMap : Map
+{
+	GradientMap(int widthShift, int heightShift)
+	{
+		wDec = widthShift;
+		hDec = heightShift;
+		w = 1 << wDec;
+		h = 1 << hDec;
+		wMask = w - 1;
+		hMask = h - 1;
+		size = static_cast<size_t>(w) * h;
+	}
+
+	~GradientMap()
+	{
+		// Map::clear expects zero geometry when setSize has not allocated its arrays.
+		w = h = wMask = hMask = wDec = hDec = 0;
+		size = 0;
+	}
+};
+
+// Process the strongest contributions first instead of using directional sweeps.
+// The frontier includes intermediate seeds, not just 255-valued destinations.
+std::vector<Uint8> referenceGradient(std::vector<Uint8> values, int width, int height)
+{
+	using Entry = std::pair<int, size_t>;
+	std::priority_queue<Entry> frontier;
+	for (size_t i = 0; i < values.size(); ++i)
+		if (values[i] >= 3)
+			frontier.emplace(values[i], i);
+
+	while (!frontier.empty())
+	{
+		const auto [value, index] = frontier.top();
+		frontier.pop();
+		if (values[index] != value || value < 3)
+			continue;
+		const int x = index % width;
+		const int y = index / width;
+		for (int dy = -1; dy <= 1; ++dy)
+			for (int dx = -1; dx <= 1; ++dx)
+			{
+				if (dx == 0 && dy == 0)
+					continue;
+				const int nx = (x + dx + width) % width;
+				const int ny = (y + dy + height) % height;
+				const size_t neighbor = static_cast<size_t>(ny) * width + nx;
+				if (values[neighbor] != 0 && values[neighbor] < value - 1)
+				{
+					values[neighbor] = value - 1;
+					frontier.emplace(value - 1, neighbor);
+				}
+			}
+	}
+	return values;
+}
+
+void check(int widthShift, int heightShift, const std::vector<Uint8>& input)
+{
+	GradientMap map(widthShift, heightShift);
+	if (input.size() != static_cast<size_t>(map.getW()) * map.getH())
+		std::abort();
+	const auto expected = referenceGradient(input, map.getW(), map.getH());
+	auto actual = input;
+	map.updateGlobalGradient(actual.data());
+	if (actual != expected)
+	{
+		std::fprintf(stderr, "Global gradient differs on %dx%d grid\n", map.getW(), map.getH());
+		std::abort();
+	}
+	map.updateGlobalGradient(actual.data());
+	if (actual != expected)
+	{
+		std::fprintf(stderr, "Global gradient is not idempotent\n");
+		std::abort();
+	}
+}
+
+void checkBoundariesAndObstacles()
+{
+	// Exercise both wrap seams and diagonals, including aliased neighbors on thin grids.
+	for (const auto [widthShift, heightShift] : {std::pair{0, 0}, {0, 5}, {5, 0}, {3, 2}, {2, 3}})
+	{
+		const size_t size = size_t{1} << (widthShift + heightShift);
+		std::vector<Uint8> values(size, 1);
+		values.front() = 255;
+		check(widthShift, heightShift, values);
+		values.assign(size, 1);
+		values.back() = 254;
+		check(widthShift, heightShift, values);
+	}
+
+	// A path longer than the byte-valued propagation range must retain unreachable cells.
+	std::vector<Uint8> corridor(1024, 1);
+	corridor.front() = 255;
+	check(10, 0, corridor);
+
+	// Alternating connectors force repeated sweep direction changes without seam shortcuts.
+	std::vector<Uint8> maze(64 * 64, 0);
+	for (int y = 1; y < 63; y += 2)
+	{
+		for (int x = 1; x < 63; ++x)
+			maze[y * 64 + x] = 1;
+		if (y < 61)
+			maze[(y + 1) * 64 + ((y / 2) % 2 == 0 ? 62 : 1)] = 1;
+	}
+	maze[65] = 255;
+	check(6, 6, maze);
+}
+
+void checkRandomFields()
+{
+	std::mt19937 random(424242);
+	for (int trial = 0; trial < 3000; ++trial)
+	{
+		const int widthShift = trial % 9;
+		const int heightShift = (trial / 9) % 9;
+		std::vector<Uint8> values(size_t{1} << (widthShift + heightShift));
+		for (auto& value : values)
+		{
+			const auto choice = random() % 100;
+			value = choice < 25 ? 0 : choice < 90 ? 1 : 2 + random() % 254;
+		}
+		check(widthShift, heightShift, values);
+	}
+}
+}
+
+int main()
+{
+	checkBoundariesAndObstacles();
+	checkRandomFields();
+	std::puts("GlobalGradientHarness: boundaries, obstacles, cutoff, mixed seeds and 3000 random fields PASS");
+}

--- a/test/README.md
+++ b/test/README.md
@@ -185,3 +185,18 @@ streams, recovery after failed loads, and oversized map-area strings. Atomic
 replacement tests cover callback/open/rename failures and temporary-file cleanup.
 On POSIX, child processes impose file-size limits to exercise short writes and
 buffered flush errors while checking that the previous save survives unchanged.
+
+## Global gradient regression
+
+From the repository root:
+
+```sh
+scons -j8 release=1 server=0 global-gradient-test
+./build/src/GlobalGradientHarness
+```
+
+The harness calls the real `Map::updateGlobalGradient` and compares every output
+byte against an independent priority-frontier solver. It covers toroidal seams,
+diagonals, one-cell dimensions, winding obstacles, mixed seed strengths, the
+byte-distance cutoff, idempotence and 3,000 fixed-seed randomized fields. It runs
+without a window or game assets and is included in the Linux CI jobs.


### PR DESCRIPTION
Global gradient propagation visits every cell repeatedly, but only the strongest of its four directional neighbors can improve a cell. Compute that maximum once, use row pointers for neighbor access, and skip immutable 255-valued goals. This reduces hot-loop work while preserving the exact in-place forward/backward order, toroidal wrapping, byte-value semantics and convergence cap.

Comments explain the equivalence and wraparound constraints. There is no change to refresh scheduling, seed construction, the local gradient routine, or serialization.

### Measured performance

Fresh measurements of this exact patch against `master` at `b47c7d23b`, on an Apple M3 with an optimized Apple Clang build. Each value is median **core simulation CPU time** across three serial 15,000-tick runs:

| Scenario | Baseline | This PR | Reduction |
|---|---:|---:|---:|
| G2 | 4.134 s | 3.614 s | **12.6%** |
| Playground, eight Numbi AIs | 3.981 s | 3.430 s | **13.8%** |

The timer covers advancing `Game::syncStep` calls; it excludes AI order generation, startup, order execution and replay I/O. Temporary timing instrumentation is not included in this PR. Variant order was alternated and runs with competing compiler/game jobs were rejected. These are single-machine measurements, not FPS or portable speedup guarantees.

The earlier exploratory branch showed larger combined gains (22–24%) but included other changes and used a different base. Those figures are not attributed to this isolated patch.

### Validation

- Added `global-gradient-test`, linked to the real production method, and wired it into both Linux CI jobs.
- Compared every output byte against an independent priority-frontier solver across 3,000 fixed-seed random fields, toroidal seams, diagonals, thin dimensions, winding obstacles, mixed seed strengths, the distance cutoff and idempotence. The harness passes against both the unmodified baseline and this kernel.
- Ran **six saved-game scenarios for 15,000 ticks each** against the unmodified baseline: G2, gd-small-2ai, gd-large-4ai, gd-archipelago, gd-bigarena-long and fixed-seed eight-AI Playground. **All replay bytes and complete per-tick unit/building checksum sidecars matched**: 90,000 ticks per executable.
- The kernel and harness also passed with AddressSanitizer and UndefinedBehaviorSanitizer enabled for those translation units; remaining linked engine objects were uninstrumented.
- Optimized client build and `git diff --check` pass. Hosted CI is pending.

Run the maintained harness from the repository root:

```sh
scons -j8 release=1 server=0 global-gradient-test
./build/src/GlobalGradientHarness
```

This is the first of two focused PRs. The stacked follow-up #196 adds only a no-source fast path, its edge-case tests, and the [combined benchmark/evidence report](https://github.com/Globulation2/glob2/blob/codex/skip-inert-global-gradients/docs/performance/global-gradients.md). No experimental cache, local spiral rewrite, runtime switches or profiling machinery is retained.
