### PR TITLE
Skip global gradient propagation when no source can contribute

### DIFF
--- a/docs/performance/global-gradient-results.json
+++ b/docs/performance/global-gradient-results.json
@@ -1,0 +1,396 @@
+{
+  "metadata": {
+    "date": "2026-09-07",
+    "baseline_commit": "b47c7d23b",
+    "kernel_commit": "af8510619",
+    "cpu": "Apple M3, 8 cores, 24 GiB RAM",
+    "compiler": "Apple clang version 21.0.0 (clang-2100.1.1.101)",
+    "build": "scons release=1 server=0 CXXFLAGS= LINKFLAGS= (-O3)",
+    "core_metric": "CLOCK_THREAD_CPUTIME_ID around advancing Game::syncStep ticks; identical temporary instrumentation in all timed binaries",
+    "measurement_scope": "three serial repetitions of 15000 ticks, alternating order; AI order generation, startup, order execution and replay output outside core timer",
+    "original_experiment_base": "c71373bb2",
+    "fast_path_source_blob": "975f991a9a884602acefc80bc530d4748c2adab4"
+  },
+  "timing": [
+    {
+      "variant": "baseline",
+      "game": "G2",
+      "rep": 0,
+      "wall_s": 5.801870208000764,
+      "metrics": {
+        "ns": 4164610631,
+        "cpu_ns": 4144475680,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "G2",
+      "rep": 0,
+      "wall_s": 5.10747133300174,
+      "metrics": {
+        "ns": 3644431360,
+        "cpu_ns": 3628180157,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "G2",
+      "rep": 0,
+      "wall_s": 5.405219332998968,
+      "metrics": {
+        "ns": 3773748629,
+        "cpu_ns": 3514916824,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "baseline",
+      "game": "playground-8numbi",
+      "rep": 0,
+      "wall_s": 5.493210915999953,
+      "metrics": {
+        "ns": 4028226048,
+        "cpu_ns": 4011635237,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "playground-8numbi",
+      "rep": 0,
+      "wall_s": 4.838938708002388,
+      "metrics": {
+        "ns": 3425710245,
+        "cpu_ns": 3420385652,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "playground-8numbi",
+      "rep": 0,
+      "wall_s": 4.567341875001148,
+      "metrics": {
+        "ns": 3113018791,
+        "cpu_ns": 3107788574,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "G2",
+      "rep": 1,
+      "wall_s": 4.6992977499976405,
+      "metrics": {
+        "ns": 3435232387,
+        "cpu_ns": 3426951622,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "G2",
+      "rep": 1,
+      "wall_s": 4.83644245799951,
+      "metrics": {
+        "ns": 3571558216,
+        "cpu_ns": 3563702329,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "baseline",
+      "game": "G2",
+      "rep": 1,
+      "wall_s": 5.511072958004661,
+      "metrics": {
+        "ns": 4149414096,
+        "cpu_ns": 4133985276,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "playground-8numbi",
+      "rep": 1,
+      "wall_s": 4.584350542005268,
+      "metrics": {
+        "ns": 3140286451,
+        "cpu_ns": 3128528389,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "playground-8numbi",
+      "rep": 1,
+      "wall_s": 4.961664000002202,
+      "metrics": {
+        "ns": 3440331207,
+        "cpu_ns": 3430442594,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "baseline",
+      "game": "playground-8numbi",
+      "rep": 1,
+      "wall_s": 5.605888375001086,
+      "metrics": {
+        "ns": 4020578826,
+        "cpu_ns": 3980751184,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "baseline",
+      "game": "G2",
+      "rep": 2,
+      "wall_s": 5.495013499996276,
+      "metrics": {
+        "ns": 4118387771,
+        "cpu_ns": 4110742668,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "G2",
+      "rep": 2,
+      "wall_s": 4.830908749994705,
+      "metrics": {
+        "ns": 3628030170,
+        "cpu_ns": 3613535876,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "G2",
+      "rep": 2,
+      "wall_s": 4.92502383300598,
+      "metrics": {
+        "ns": 3548725874,
+        "cpu_ns": 3509949592,
+        "calls": 15000
+      },
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "interference": []
+    },
+    {
+      "variant": "baseline",
+      "game": "playground-8numbi",
+      "rep": 2,
+      "wall_s": 5.507162542002334,
+      "metrics": {
+        "ns": 3955457213,
+        "cpu_ns": 3946743497,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "kernel",
+      "game": "playground-8numbi",
+      "rep": 2,
+      "wall_s": 4.970596416998887,
+      "metrics": {
+        "ns": 3443206920,
+        "cpu_ns": 3432567468,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    },
+    {
+      "variant": "fast",
+      "game": "playground-8numbi",
+      "rep": 2,
+      "wall_s": 4.571422833003453,
+      "metrics": {
+        "ns": 3104834674,
+        "cpu_ns": 3100118977,
+        "calls": 15000
+      },
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "interference": []
+    }
+  ],
+  "validation": [
+    {
+      "variant": "baseline",
+      "game": "G2",
+      "steps": 15000,
+      "wall_s": 7.834986166002636,
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "checksums_sha256": "2d140199882888da1ceb23050f612d94ccb3eafa9656f29215177e767e06b60c"
+    },
+    {
+      "variant": "baseline",
+      "game": "gd-small-2ai",
+      "steps": 15000,
+      "wall_s": 1.9549165419957717,
+      "replay_sha256": "c2e6f1332b4fc3ddef139d82fd9166b8f85ce2ca2b377ca7bd9faaaf78bb6941",
+      "checksums_sha256": "ddfd8d0d285ccb1d036e5c482f6ace18fd6f08611ca4664122b9072272a93455"
+    },
+    {
+      "variant": "baseline",
+      "game": "gd-large-4ai",
+      "steps": 15000,
+      "wall_s": 6.552901249997376,
+      "replay_sha256": "b360042b5e9ea6ba48635c3b81ef370213d91670e2896282740f9c5b9bb334d7",
+      "checksums_sha256": "0f06beb5dace39a997c3d8709c2d19f3889e5d524db252161ed5f2c9896c97da"
+    },
+    {
+      "variant": "baseline",
+      "game": "gd-archipelago",
+      "steps": 15000,
+      "wall_s": 6.455199709002045,
+      "replay_sha256": "a761e0da41966fec0e4796ed6011a0e8d51039b78dc20d3133c3409850339ca8",
+      "checksums_sha256": "220bc65e2c94b618f9331565083b2eeb601a192775ec5f13688b1435fc53ef60"
+    },
+    {
+      "variant": "baseline",
+      "game": "gd-bigarena-long",
+      "steps": 15000,
+      "wall_s": 40.512225083002704,
+      "replay_sha256": "ced2f4b422eeef807817f971f4c7f236df9838c9d04eb6b56e80f5a0ae5fbb9b",
+      "checksums_sha256": "b75f69f5b8ff8b5f3b8968bcf85958709e2087f486c92a78b1c7a0cb7b5993e7"
+    },
+    {
+      "variant": "baseline",
+      "game": "playground-8numbi",
+      "steps": 15000,
+      "wall_s": 9.110053709002386,
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "checksums_sha256": "cb781f6639c11eee60e9fc11f409b67b45945c47bc2175e080650e41b6c90ed0"
+    },
+    {
+      "variant": "kernel",
+      "game": "G2",
+      "steps": 15000,
+      "wall_s": 7.880810874994495,
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "checksums_sha256": "2d140199882888da1ceb23050f612d94ccb3eafa9656f29215177e767e06b60c"
+    },
+    {
+      "variant": "kernel",
+      "game": "gd-small-2ai",
+      "steps": 15000,
+      "wall_s": 1.950268499997037,
+      "replay_sha256": "c2e6f1332b4fc3ddef139d82fd9166b8f85ce2ca2b377ca7bd9faaaf78bb6941",
+      "checksums_sha256": "ddfd8d0d285ccb1d036e5c482f6ace18fd6f08611ca4664122b9072272a93455"
+    },
+    {
+      "variant": "kernel",
+      "game": "gd-large-4ai",
+      "steps": 15000,
+      "wall_s": 5.945228958997177,
+      "replay_sha256": "b360042b5e9ea6ba48635c3b81ef370213d91670e2896282740f9c5b9bb334d7",
+      "checksums_sha256": "0f06beb5dace39a997c3d8709c2d19f3889e5d524db252161ed5f2c9896c97da"
+    },
+    {
+      "variant": "kernel",
+      "game": "gd-archipelago",
+      "steps": 15000,
+      "wall_s": 5.855624707997777,
+      "replay_sha256": "a761e0da41966fec0e4796ed6011a0e8d51039b78dc20d3133c3409850339ca8",
+      "checksums_sha256": "220bc65e2c94b618f9331565083b2eeb601a192775ec5f13688b1435fc53ef60"
+    },
+    {
+      "variant": "kernel",
+      "game": "gd-bigarena-long",
+      "steps": 15000,
+      "wall_s": 34.268072790997394,
+      "replay_sha256": "ced2f4b422eeef807817f971f4c7f236df9838c9d04eb6b56e80f5a0ae5fbb9b",
+      "checksums_sha256": "b75f69f5b8ff8b5f3b8968bcf85958709e2087f486c92a78b1c7a0cb7b5993e7"
+    },
+    {
+      "variant": "kernel",
+      "game": "playground-8numbi",
+      "steps": 15000,
+      "wall_s": 9.329681999995955,
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "checksums_sha256": "cb781f6639c11eee60e9fc11f409b67b45945c47bc2175e080650e41b6c90ed0"
+    },
+    {
+      "variant": "fast",
+      "game": "G2",
+      "steps": 15000,
+      "wall_s": 8.171962957996584,
+      "replay_sha256": "1086f62c59f68840cd79e54a7e048cc4f06a6b49c440d8282620aab33b0a246b",
+      "checksums_sha256": "2d140199882888da1ceb23050f612d94ccb3eafa9656f29215177e767e06b60c"
+    },
+    {
+      "variant": "fast",
+      "game": "gd-small-2ai",
+      "steps": 15000,
+      "wall_s": 1.8019599170002039,
+      "replay_sha256": "c2e6f1332b4fc3ddef139d82fd9166b8f85ce2ca2b377ca7bd9faaaf78bb6941",
+      "checksums_sha256": "ddfd8d0d285ccb1d036e5c482f6ace18fd6f08611ca4664122b9072272a93455"
+    },
+    {
+      "variant": "fast",
+      "game": "gd-large-4ai",
+      "steps": 15000,
+      "wall_s": 5.643594834000396,
+      "replay_sha256": "b360042b5e9ea6ba48635c3b81ef370213d91670e2896282740f9c5b9bb334d7",
+      "checksums_sha256": "0f06beb5dace39a997c3d8709c2d19f3889e5d524db252161ed5f2c9896c97da"
+    },
+    {
+      "variant": "fast",
+      "game": "gd-archipelago",
+      "steps": 15000,
+      "wall_s": 5.507952250001836,
+      "replay_sha256": "a761e0da41966fec0e4796ed6011a0e8d51039b78dc20d3133c3409850339ca8",
+      "checksums_sha256": "220bc65e2c94b618f9331565083b2eeb601a192775ec5f13688b1435fc53ef60"
+    },
+    {
+      "variant": "fast",
+      "game": "gd-bigarena-long",
+      "steps": 15000,
+      "wall_s": 33.83202566699765,
+      "replay_sha256": "ced2f4b422eeef807817f971f4c7f236df9838c9d04eb6b56e80f5a0ae5fbb9b",
+      "checksums_sha256": "b75f69f5b8ff8b5f3b8968bcf85958709e2087f486c92a78b1c7a0cb7b5993e7"
+    },
+    {
+      "variant": "fast",
+      "game": "playground-8numbi",
+      "steps": 15000,
+      "wall_s": 8.597938499995507,
+      "replay_sha256": "40f20c790e95dcc0c0e5d1c66ea94a211efbec45bf01f96a464cfde41c746e9b",
+      "checksums_sha256": "cb781f6639c11eee60e9fc11f409b67b45945c47bc2175e080650e41b6c90ed0"
+    }
+  ]
+}

--- a/docs/performance/global-gradients.md
+++ b/docs/performance/global-gradients.md
@@ -1,0 +1,103 @@
+# Global gradient performance evidence
+
+Measurements on 2026-09-07 compare `master` at `b47c7d23b`, the global sweep
+simplification, and that simplification plus the no-source fast path. No local
+traversal rewrite, seed cache, refresh scheduling change, or runtime profiling
+code is part of the production patches.
+
+## Clean-patch measurements
+
+| Game | Baseline core CPU | Kernel only | Kernel + fast path | Combined reduction |
+|---|---:|---:|---:|---:|
+| G2 | 4.134 s | 3.614 s | 3.510 s | 15.1% |
+| playground-8numbi | 3.981 s | 3.430 s | 3.108 s | 21.9% |
+
+Each number is the median of three serial 15,000-tick runs on an Apple M3
+(8 cores, 24 GiB RAM), compiled with Apple Clang and `-O3`. The Playground case
+uses eight Numbi-controlled teams, seed 424242, plus the passive local controller
+on team 0 required by headless setup. It approximates the reported eight-player
+filled-AI workload; it is not the original profiling session's saved game.
+
+The core metric is thread CPU time around advancing `Game::syncStep` calls.
+Temporary instrumentation was identical in all three timed binaries and is
+absent from the production commits. This scope includes teams, units, buildings,
+map updates and scheduled world logic; it excludes AI order generation, order
+execution, startup and replay/checksum output. Whole-process elapsed samples
+are retained separately and are not interchangeable with core CPU time.
+
+Runs alternated variant order. The runner waited for other compiler/game jobs
+to settle and rejected runs with those jobs present. This does not eliminate OS
+noise or CPU-frequency variation. No hardware cache-miss counters were measured.
+
+[Raw samples and validation digests](global-gradient-results.json) include all
+accepted repetitions, exact baseline/patch identifiers, and compiler details.
+
+## Why the changes help
+
+The global sweep uses row pointers and a single maximum over its four directional
+neighbors. Subtraction by one preserves neighbor ordering, so only that maximum
+needs the propagation threshold and improvement tests. Zero-valued obstacles and
+255-valued goals are immutable. The forward/backward in-place order, toroidal
+wrapping, value floor and convergence cap remain intact.
+
+The fast path checks whether any input byte is at least 3. If none is, propagation
+cannot raise any cell: zero is immutable and neither 1 nor 2 can contribute a
+value above a free cell's seed of 1. The existing seed buffer is already final.
+This also handles a contributing seed of 3 or 254 correctly; it does not assume
+all sources are 255-valued goals.
+
+## Behavior preservation
+
+Both exact production patches and the unmodified baseline ran G2,
+`gd-small-2ai`, `gd-large-4ai`, `gd-archipelago`, `gd-bigarena-long`, and the
+fixed-seed Playground case for 15,000 ticks each. Each variant produced identical
+replay bytes and identical complete per-tick unit/building checksum sidecars:
+90,000 ticks per executable. Every timed run also matched its baseline replay.
+
+`GlobalGradientHarness` calls the real production function and compares every
+byte against an independent priority-frontier solver. It tests 3,000 fixed-seed
+random fields, mixed seed strengths, toroidal seams, diagonals, thin dimensions,
+winding obstacles, the distance cutoff and idempotence. The fast-path tests add
+inert 0/1/2 fields and contributing seeds at the final input position. Both kernel
+variants passed with the harness and gradient translation unit instrumented by
+AddressSanitizer and UndefinedBehaviorSanitizer; the remaining linked engine
+objects were uninstrumented. Linux CI also builds and runs the harness.
+
+Build the harness from the repository root:
+
+```sh
+scons -j8 release=1 server=0 global-gradient-test
+./build/src/GlobalGradientHarness
+```
+
+To reproduce a replay comparison, build baseline and candidate executables,
+then run each from the same checkout/assets with distinct absolute output paths:
+
+```sh
+GLOB2_CHECKSUM_SIDECAR=1 GLOB2_REPLAY_PATH=/tmp/baseline.replay \
+  /path/to/baseline --nox games/G2.game 15000 1
+GLOB2_CHECKSUM_SIDECAR=1 GLOB2_REPLAY_PATH=/tmp/candidate.replay \
+  /path/to/candidate --nox games/G2.game 15000 1
+cmp /tmp/baseline.replay /tmp/candidate.replay
+cmp /tmp/baseline.replay.checksums /tmp/candidate.replay.checksums
+```
+
+Use relative input paths with this baseline's `--nox` loader. Generate Playground
+once from the baseline with `GLOB2_TEST_SEED=424242`, `-test-games-nox 1`,
+`--map Playground`, `--matchup numbi,numbi,numbi,numbi,numbi,numbi,numbi,numbi`, and
+`--save-game-as` pointing to an absolute path under the checkout's `games/`
+directory. Reuse that saved state for every comparison.
+
+## Earlier exploratory evidence
+
+The preceding experiments used a different base, `c71373bb2`, and runtime variant
+switches. Their combined variant also included the local traversal rewrite and
+measured 22.0% less core CPU on Playground and 24.1% on G2. Those percentages are
+not attributed to either isolated PR or substituted for the clean-patch results
+above. That exploration compared 112,517 live global fields and 5,302 local fields
+against the original routines, plus 23,000 randomized kernel cases, with no
+mismatches. Seed caching had one hit in 16,040 Playground updates and added no
+meaningful benefit; local propagation saved only a few milliseconds overall.
+
+These measurements and differential checks establish behavior on the tested
+workloads, not a proof for every game or a speedup guarantee on other hardware.

--- a/src/map/gradient/MapGradientGlobal.cpp
+++ b/src/map/gradient/MapGradientGlobal.cpp
@@ -35,6 +35,11 @@
 // throttle. On correct code the loop exits in a handful of passes.
 void Map::updateGlobalGradient(Uint8 *gradient)
 {
+	// Values below 3 cannot raise a free cell above its seed of 1.
+	// Without a stronger source, the initialized buffer is already the final field.
+	if (std::none_of(gradient, gradient + size, [](Uint8 value) { return value >= 3; }))
+		return;
+
 	int passes = 0;
 	bool changed;
 	do

--- a/test/GlobalGradientHarness.cpp
+++ b/test/GlobalGradientHarness.cpp
@@ -125,6 +125,29 @@ void checkBoundariesAndObstacles()
 	check(6, 6, maze);
 }
 
+void checkInertFields()
+{
+	for (Uint8 value : {0, 1, 2})
+	{
+		check(0, 0, std::vector<Uint8>(1, value));
+		check(6, 6, std::vector<Uint8>(64 * 64, value));
+	}
+
+	std::vector<Uint8> values(64 * 64);
+	for (size_t i = 0; i < values.size(); ++i)
+		values[i] = i % 3;
+	check(6, 6, values);
+
+	// Even the weakest contributing source must prevent the early return.
+	// Put it last so the source scan must inspect the entire buffer.
+	for (Uint8 source : {3, 254, 255})
+	{
+		values.assign(values.size(), 1);
+		values.back() = source;
+		check(6, 6, values);
+	}
+}
+
 void checkRandomFields()
 {
 	std::mt19937 random(424242);
@@ -146,6 +169,7 @@ void checkRandomFields()
 int main()
 {
 	checkBoundariesAndObstacles();
+	checkInertFields();
 	checkRandomFields();
-	std::puts("GlobalGradientHarness: boundaries, obstacles, cutoff, mixed seeds and 3000 random fields PASS");
+	std::puts("GlobalGradientHarness: boundaries, obstacles, cutoff, inert fields, mixed seeds and 3000 random fields PASS");
 }

--- a/test/README.md
+++ b/test/README.md
@@ -198,5 +198,7 @@ scons -j8 release=1 server=0 global-gradient-test
 The harness calls the real `Map::updateGlobalGradient` and compares every output
 byte against an independent priority-frontier solver. It covers toroidal seams,
 diagonals, one-cell dimensions, winding obstacles, mixed seed strengths, the
-byte-distance cutoff, idempotence and 3,000 fixed-seed randomized fields. It runs
+byte-distance cutoff, idempotence and 3,000 fixed-seed randomized fields.
+It also checks inert fields containing only 0/1/2 and contributing sources at
+the end of the input buffer. It runs
 without a window or game assets and is included in the Linux CI jobs.


### PR DESCRIPTION
**Stacked on #195; merge that PR first.** This diff contains a five-line production fast path, focused tests, and the performance/equivalence evidence report.

A freshly seeded global gradient containing only values 0, 1 and 2 cannot change during propagation: zero is immutable, and neither 1 nor 2 can raise a free cell above its seed of 1. Return immediately when no input byte is at least 3, avoiding the two full-map sweeps that would otherwise discover this fixed point.

The comment states that invariant. The check deliberately accepts contributing seeds of 3 and 254 as well as 255-valued goals. It changes neither seed construction nor when callers refresh gradients, and introduces no cache or new persistent state.

### Measured performance

Fresh measurements of the exact clean patches against `master` at `b47c7d23b`, on an Apple M3 with an optimized Apple Clang build. Median core simulation CPU time over three serial 15,000-tick runs:

| Scenario | Baseline | #195 only | Both PRs | Additional reduction vs #195 | Total reduction vs baseline |
|---|---:|---:|---:|---:|---:|
| G2 | 4.134 s | 3.614 s | 3.510 s | **2.9%** | **15.1%** |
| Playground, eight Numbi AIs | 3.981 s | 3.430 s | 3.108 s | **9.4%** | **21.9%** |

The timer covers advancing `Game::syncStep` calls, excluding AI order generation, order execution, startup and replay I/O. It was identical in all timed binaries and is absent from these commits. Runs were serial, variant order alternated, and competing compiler/game jobs triggered retries. The Playground setup uses Numbi on all eight teams, seed 424242, plus the headless passive local controller on team 0. These are CPU-time measurements on one machine, not FPS claims.

The [evidence report](https://github.com/Globulation2/glob2/blob/codex/skip-inert-global-gradients/docs/performance/global-gradients.md) and [raw samples/checksum digests](https://github.com/Globulation2/glob2/blob/codex/skip-inert-global-gradients/docs/performance/global-gradient-results.json) include methodology and reproduction steps. They distinguish these results from the earlier 22–24% combined exploratory results on a different base, which also included a local-gradient rewrite. The experimental cache and local rewrite are not part of either PR.

### Validation

- Extended the maintained production harness with all-zero, all-one, all-two and mixed 0/1/2 fields, including one-cell inputs. Added seeds of 3, 254 and 255 at the last input position to check the threshold and full-buffer scan.
- The independent priority-frontier oracle still matches every byte for 3,000 random fields, toroidal seams, diagonals, thin dimensions, winding obstacles, mixed seeds, cutoff and idempotence.
- **Both exact clean patches independently match the unmodified baseline** on six 15,000-tick games: G2, gd-small-2ai, gd-large-4ai, gd-archipelago, gd-bigarena-long and fixed-seed eight-AI Playground. Replay bytes and complete per-tick unit/building checksum sidecars match across all **90,000 ticks per executable**. Timed runs also match baseline replays.
- Both kernel variants passed with the harness and gradient translation unit instrumented by AddressSanitizer/UndefinedBehaviorSanitizer; other linked engine objects were uninstrumented.
- Optimized client and final `global-gradient-test` builds pass. The harness is wired into Linux CI by #195; hosted CI is pending.

```sh
scons -j8 release=1 server=0 global-gradient-test
./build/src/GlobalGradientHarness
```
