### PR TITLE
Use Tile for map cells and their accessor

### DIFF
--- a/src/FertilityCalculator.cpp
+++ b/src/FertilityCalculator.cpp
@@ -139,7 +139,7 @@ namespace FertilityCalculator
 
 		for (int x = 0; x < map.getW(); ++x)
 			for (int y = 0; y < map.getH(); ++y)
-				map.getCase(x, y).fertility = fertility[map.coordToIndex(x, y)];
+				map.getTile(x, y).fertility = fertility[map.coordToIndex(x, y)];
 		map.fertilityMaximum = fertilityMax;
 	}
 }

--- a/src/FertilityCalculator.h
+++ b/src/FertilityCalculator.h
@@ -12,7 +12,7 @@ namespace FertilityCalculator
 	/// Reports compute progress in [0, 1]. Invoked from the worker thread.
 	using ProgressCallback = std::function<void(float)>;
 
-	/// Computes per-tile fertility, writes it into map.getCase(x,y).fertility,
+	/// Computes per-tile fertility, writes it into map.getTile(x,y).fertility,
 	/// and updates map.fertilityMaximum. The optional progress callback is
 	/// invoked once per column. May be called from a worker thread.
 	void compute(Map& map, const ProgressCallback& progress);

--- a/src/Game_io.cpp
+++ b/src/Game_io.cpp
@@ -253,14 +253,14 @@ bool Game::checkBuildingsDoNotOverlapAndHealMissing() {
 					checkInvariant(buildings[index]==NOGBID);
 					buildings[index] = gid;
 					// heal missing cells
-					if (map.getCase(xi, yi).building != gid)
+					if (map.getTile(xi, yi).building != gid)
 					{
 						std::cerr << "Missing map cell GBID at " << xi << "," << yi
 							<< " for team " << ti
 							<< " building " << bi
 							<< " (" << building->type->type << "), healing!"
 							<< std::endl;
-						map.getCase(xi, yi).building = gid;
+						map.getTile(xi, yi).building = gid;
 					}
 				}
 		}
@@ -281,7 +281,7 @@ bool Game::integrity(void)
 	for (int y=0; y<map.getH(); y++)
 		for (int x=0; x<map.getW(); x++)
 		{
-			Case& c = map.getCase(x, y);
+			Tile& c = map.getTile(x, y);
 			if (c.building != NOGBID)
 			{
 				int tid = Building::GIDtoTeam(c.building);
@@ -304,7 +304,7 @@ bool Game::integrity(void)
 							<< " with " << coordName
 							<< " span [" << posValue << ":" << endValue << "[, healing!"
 							<< std::endl;
-						map.getCase(x, y).building = NOGBID;
+						map.getTile(x, y).building = NOGBID;
 					}
 				};
 

--- a/src/Game_orders.cpp
+++ b/src/Game_orders.cpp
@@ -174,7 +174,7 @@ void Game::executeCreate(const OrderCreate& oc, int localPlayer)
 			for (int x=posX; x<posX+w; x++)
 			{
 				size_t index=(x&map.wMask)+(((y&map.hMask)<<map.wDec));
-				map.cases[index].forbidden|=teamMask;
+				map.tiles[index].forbidden|=teamMask;
 				if (oc.teamNumber == players[localPlayer]->teamNumber)
 					map.displayedForbiddenView.set(index, true);
 			}
@@ -300,7 +300,7 @@ void Game::executeAlterForbidden(const OrderAlterForbidden& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].forbidden |= teamMask;
+					map.tiles[index].forbidden |= teamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedForbiddenView.set(index, true);
@@ -320,7 +320,7 @@ void Game::executeAlterForbidden(const OrderAlterForbidden& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].forbidden &= notTeamMask;
+					map.tiles[index].forbidden &= notTeamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedForbiddenView.set(index, false);
@@ -352,7 +352,7 @@ void Game::executeAlterGuardArea(const OrderAlterGuardArea& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].guardArea |= teamMask;
+					map.tiles[index].guardArea |= teamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedGuardAreaView.set(index, true);
@@ -371,7 +371,7 @@ void Game::executeAlterGuardArea(const OrderAlterGuardArea& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].guardArea &= notTeamMask;
+					map.tiles[index].guardArea &= notTeamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedGuardAreaView.set(index, false);
@@ -397,7 +397,7 @@ void Game::executeAlterClearArea(const OrderAlterClearArea& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].clearArea |= teamMask;
+					map.tiles[index].clearArea |= teamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedClearAreaView.set(index, true);
@@ -416,7 +416,7 @@ void Game::executeAlterClearArea(const OrderAlterClearArea& oaa, int localPlayer
 				{
 					size_t index = (x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].clearArea &= notTeamMask;
+					map.tiles[index].clearArea &= notTeamMask;
 					// Update local map
 					if (oaa.teamNumber == players[localPlayer]->teamNumber)
 						map.displayedClearAreaView.set(index, false);

--- a/src/Game_sync.cpp
+++ b/src/Game_sync.cpp
@@ -49,7 +49,7 @@ void Game::buildProjectSyncStep(Sint32 localTeam)
 				{
 					size_t index=(x&map.wMask)+(((y&map.hMask)<<map.wDec));
 					// Update real map
-					map.cases[index].forbidden&=notTeamMask;
+					map.tiles[index].forbidden&=notTeamMask;
 					// Update local map
 					if (teamNumber == localTeam)
 						map.displayedForbiddenView.set(index, false);
@@ -71,7 +71,7 @@ void Game::buildProjectSyncStep(Sint32 localTeam)
 					{
 						size_t index=(x&map.wMask)+(((y&map.hMask)<<map.wDec));
 						// Update real map
-						map.cases[index].forbidden&=notTeamMask;
+						map.tiles[index].forbidden&=notTeamMask;
 						// Update local map
 						if (teamNumber == localTeam)
 							map.displayedForbiddenView.set(index, false);

--- a/src/OverlayAreas.cpp
+++ b/src/OverlayAreas.cpp
@@ -77,7 +77,7 @@ void OverlayArea::compute(Game& game, OverlayType ntype, int localteam)
 		{
 			for(int y=0; y<game.map.getH(); ++y)
 			{
-				overlay[x * height + y] = game.map.getCase(x, y).fertility;
+				overlay[x * height + y] = game.map.getTile(x, y).fertility;
 				overlaymax = game.map.fertilityMaximum;
 			}
 		}

--- a/src/ai/AICastor.h
+++ b/src/ai/AICastor.h
@@ -11,7 +11,7 @@
 #include "AIImplementation.h"
 #include "AICastorTuning.h"
 
-struct Case;
+struct Tile;
 class Game;
 class Map;
 class Order;

--- a/src/ai/AIWarrush.cpp
+++ b/src/ai/AIWarrush.cpp
@@ -653,7 +653,7 @@ void AIWarrush::initializeGradientWithResource(DynamicGradientMapArray &gradient
 	{
 		for(int y=0;y<map->h;y++)
 		{
-			Case c=map->getCase(x,y);
+			Tile c=map->getTile(x,y);
 			if (c.resource.type==resource_type)
 			{
 				gradient(x, y) = AI_WARRUSH_GRADIENT_MAX;
@@ -713,7 +713,7 @@ std::shared_ptr<Order> AIWarrush::buildBuildingOfType(Sint32 shortTypeNum)
 	{
 		for(int y=0;y<map->h;y++)
 		{
-			Case c=map->getCase(x,y);
+			Tile c=map->getTile(x,y);
 			if (c.resource.type!=NO_RES_TYPE)
 			{
 				availability_gradient(x, y) = 0;

--- a/src/ai/castor/Maps.cpp
+++ b/src/ai/castor/Maps.cpp
@@ -21,11 +21,11 @@ void AICastor::computeObstacleUnitMap()
 	int w=map->w;
 	int h=map->h;
 	size_t size=w*h;
-	const auto& cases=map->cases;
+	const auto& tiles=map->tiles;
 	Uint32 teamMask=team->me;
 	for (size_t i=0; i<size; i++)
 	{
-		const auto& c=cases[i];
+		const auto& c=tiles[i];
 		if (c.building!=NOGBID)
 			obstacleUnitMap[i]=0;
 		else if (c.resource.type!=NO_RES_TYPE)
@@ -45,10 +45,10 @@ void AICastor::computeObstacleBuildingMap()
 	int w=map->w;
 	int h=map->h;
 	size_t size=w*h;
-	const auto& cases=map->cases;
+	const auto& tiles=map->tiles;
 	for (size_t i=0; i<size; i++)
 	{
-		const Case& c=cases[i];
+		const Tile& c=tiles[i];
 		if (c.building!=NOGBID)
 			obstacleBuildingMap[i]=0;
 		else  if (c.terrain>=AI_CASTOR_TERRAIN_GRASS_COUNT) // if (!isGrass)
@@ -105,7 +105,7 @@ void AICastor::computeBuildingNeighbourMapOfBuilding(int bx, int by, int bw, int
 	int wDec=map->wDec;
 	
 	Uint8 *gradient=buildingNeighbourMap;
-	const auto& cases=map->cases;
+	const auto& tiles=map->tiles;
 	
 	//Uint8 *wheatGradient=map->resourcesGradient[team->teamNumber][CORN][canSwim];
 	
@@ -116,12 +116,12 @@ void AICastor::computeBuildingNeighbourMapOfBuilding(int bx, int by, int bw, int
 	{
 		int index;
 		index=(xi&wMask)+(((by-1 )&hMask)<<wDec);
-		if (cases[index].building!=NOGBID)
+		if (tiles[index].building!=NOGBID)
 			neighbour=true;
 		//if (wheatGradient[index]==255)
 		//	wheat=true;
 		index=(xi&wMask)+(((by+bh)&hMask)<<wDec);
-		if (cases[index].building!=NOGBID)
+		if (tiles[index].building!=NOGBID)
 			neighbour=true;
 		//if (wheatGradient[index]==255)
 		//	wheat=true;
@@ -131,12 +131,12 @@ void AICastor::computeBuildingNeighbourMapOfBuilding(int bx, int by, int bw, int
 		{
 			int index;
 			index=((bx-1 )&wMask)+((yi&hMask)<<wDec);
-			if (cases[index].building!=NOGBID)
+			if (tiles[index].building!=NOGBID)
 				neighbour=true;
 			//if (wheatGradient[index]==255)
 			//	wheat=true;
 			index=((bx+bw)&wMask)+((yi&hMask)<<wDec);
-			if (cases[index].building!=NOGBID)
+			if (tiles[index].building!=NOGBID)
 				neighbour=true;
 			//if (wheatGradient[index]==255)
 			//	wheat=true;
@@ -420,12 +420,12 @@ void AICastor::computeHydratationMap()
 	
 	Uint16 *gradient=(Uint16 *)malloc(2*size);
 	memset(gradient, 0, 2*size);
-	const auto& cases=map->cases;
+	const auto& tiles=map->tiles;
 	static const int range=AI_CASTOR_HYDRATATION_RANGE;
 	for (int y=0; y<h; y++)
 		for (int x=0; x<w; x++)
 		{
-			Uint16 t=cases[x+(y<<wDec)].terrain;
+			Uint16 t=tiles[x+(y<<wDec)].terrain;
 			if ((t>=AI_CASTOR_TERRAIN_SAND_FIRST)&&(t<AI_CASTOR_TERRAIN_SAND_FIRST+AI_CASTOR_TERRAIN_SAND_COUNT)) // if SAND
 				for (int r=1; r<range; r++)
 				{
@@ -470,10 +470,10 @@ void AICastor::computeNotGrassMap()
 	
 	memset(notGrassMap, 0, size);
 	
-	const auto& cases=map->cases;
+	const auto& tiles=map->tiles;
 	for (size_t i=0; i<size; i++)
 	{
-		Uint16 t=cases[i].terrain;
+		Uint16 t=tiles[i].terrain;
 		// Preserve >16 (not >=16 like obstacleBuildingMap above) — see bug M6.
 		if (t>AI_CASTOR_TERRAIN_GRASS_COUNT)// if !GRASS
 			notGrassMap[i]=AI_CASTOR_GRADIENT_OBSTACLE_NO_OBSTACLE;
@@ -689,7 +689,7 @@ void AICastor::computeEnemyWarriorsMap()
 	{
 		if ((map->fogOfWar[i]&team->me)==0)
 			continue;
-		Uint16 guid=map->cases[i].groundUnit;
+		Uint16 guid=map->tiles[i].groundUnit;
 		if (guid==NOGUID)
 			continue;
 		Uint32 teamMask=(1<<(guid>>AI_CASTOR_GUID_TEAM_SHIFT));

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -168,7 +168,7 @@ void Map::setSize(int wDec, int hDec, TerrainType terrainType)
 	displayedGuardAreaView.resize(size, false);
 	displayedClearAreaView.resize(size, false);
 	
-	cases.assign(size, Case());
+	tiles.assign(size, Tile());
 
 	mapDiscovered.assign(size, 0);
 	

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -17,10 +17,10 @@
 
 class Unit;
 
-//! No global unit identifier. This value means there is no unit. Used at Case::groundUnit or Case::airUnit.
+//! No global unit identifier. This value means there is no unit. Used at Tile::groundUnit or Tile::airUnit.
 #define NOGUID 0xFFFF
 
-//! No global building identifier. This value means there is no building. Used at Case::building.
+//! No global building identifier. This value means there is no building. Used at Tile::building.
 #define NOGBID 0xFFFF
 
 class Map;
@@ -38,7 +38,7 @@ struct Offset
 };
 
 // a 1x1 piece of map
-struct Case
+struct Tile
 {
 	Uint16 terrain = 0; // default, not really meaningful.
 	Uint16 building = NOGBID;
@@ -220,7 +220,7 @@ public:
 	//! Returns true if the position(x, y) is a forbidden area for the given team
 	bool isForbidden(int x, int y, Uint32 teamMask) const
 	{
-		return cases[coordToIndex(x, y)].forbidden&teamMask;
+		return tiles[coordToIndex(x, y)].forbidden&teamMask;
 	}
 
 	//! Return true if (x,y) is a guard area in the locally-displayed team's overlay cache
@@ -233,7 +233,7 @@ public:
 	//! Returns true if the position(x, y) is a guard area for the given team
 	bool isGuardArea(int x, int y, Uint32 teamMask) const
 	{
-		return cases[coordToIndex(x, y)].guardArea&teamMask;
+		return tiles[coordToIndex(x, y)].guardArea&teamMask;
 	}
 
 	//! Return true if (x,y) is a clear area in the locally-displayed team's overlay cache
@@ -246,17 +246,17 @@ public:
 	//! Returns true if the position(x, y) is a clear area for the given team
 	bool isClearArea(int x, int y, Uint32 teamMask) const
 	{
-		return cases[coordToIndex(x, y)].clearArea&teamMask;
+		return tiles[coordToIndex(x, y)].clearArea&teamMask;
 	}
 	
 	// These rebuild the render-only displayed*View caches from the authoritative
-	// cases[] bits, and are only meaningful for the locally-displayed team (the one
+	// tiles[] bits, and are only meaningful for the locally-displayed team (the one
 	// whose areas are drawn on screen). They do not touch checkSum() state.
-	//! Rebuild displayedForbiddenView from cases[].forbidden for the given team.
+	//! Rebuild displayedForbiddenView from tiles[].forbidden for the given team.
 	void computeDisplayedForbidden(int teamNumber);
-	//! Rebuild displayedGuardAreaView from cases[].guardArea for the given team.
+	//! Rebuild displayedGuardAreaView from tiles[].guardArea for the given team.
 	void computeDisplayedGuardArea(int teamNumber);
-	//! Rebuild displayedClearAreaView from cases[].clearArea for the given team.
+	//! Rebuild displayedClearAreaView from tiles[].clearArea for the given team.
 	void computeDisplayedClearArea(int teamNumber);
 
 	//! Sentinel for "no displayed team yet" — used before GameGUI::adjustLocalTeam has run.
@@ -268,28 +268,28 @@ public:
 	void setDisplayedTeam(Sint32 teamNo) { displayedTeam = teamNo; }
 	Sint32 getDisplayedTeam() const { return displayedTeam; }
 	
-	//! Return the case at a given position
-	inline Case &getCase(int x, int y)
+	//! Return the tile at a given position
+	inline Tile &getTile(int x, int y)
 	{
-		return cases[coordToIndex(x, y)];
+		return tiles[coordToIndex(x, y)];
 	}
 
-	//! Return the const case at a given position
-	inline const Case &getCase(int x, int y) const
+	//! Return the const tile at a given position
+	inline const Tile &getTile(int x, int y) const
 	{
-		return cases[coordToIndex(x, y)];
+		return tiles[coordToIndex(x, y)];
 	}
 
 	//! Return the terrain for a given coordinate
 	inline Uint16 getTerrain(int x, int y) const
 	{
-		return cases[coordToIndex(x, y)].terrain;
+		return tiles[coordToIndex(x, y)].terrain;
 	}
 	
-	//! Return the terrain for a given position in case array
+	//! Return the terrain for a given position in tile array
 	inline Uint16 getTerrain(size_t pos) const
 	{
-		return cases[pos].terrain;
+		return tiles[pos].terrain;
 	}
 
 	//! Return the typeof terrain. If type is unregistered, returns unknown (-1).
@@ -308,28 +308,28 @@ public:
 
 	const Resource& getResource(int x, int y) const
 	{
-		return cases[coordToIndex(x, y)].resource;
+		return tiles[coordToIndex(x, y)].resource;
 	}
 
 	const Resource& getResource(size_t pos) const
 	{
-		return cases[pos].resource;
+		return tiles[pos].resource;
 	}
 
 	Resource& getResource(int x, int y)
 	{
-		return cases[coordToIndex(x, y)].resource;
+		return tiles[coordToIndex(x, y)].resource;
 	}
 	
 	Resource& getResource(size_t pos)
 	{
-		return cases[pos].resource;
+		return tiles[pos].resource;
 	}
 	
 	//Returns the combined forbidden and hidden forbidden masks
 	Uint32 getForbidden(int x, int y) const
 	{
-		return cases[coordToIndex(x, y)].forbidden;
+		return tiles[coordToIndex(x, y)].forbidden;
 	}
 	
 	Uint8 getExplored(int x, int y, int team) const
@@ -339,33 +339,33 @@ public:
 	
 	void setTerrain(int x, int y, Uint16 terrain)
 	{
-		cases[coordToIndex(x, y)].terrain = terrain;
+		tiles[coordToIndex(x, y)].terrain = terrain;
 	}
 	
 	void setForbidden(int x, int y, Uint32 forbidden)
 	{
-		cases[coordToIndex(x, y)].forbidden = forbidden;
+		tiles[coordToIndex(x, y)].forbidden = forbidden;
 	}
 	
 	void addForbidden(int x, int y, Uint32 teamNum)
 	{
-		cases[coordToIndex(x, y)].forbidden |=  Team::teamNumberToMask(teamNum);
+		tiles[coordToIndex(x, y)].forbidden |=  Team::teamNumberToMask(teamNum);
 	}
 
 	void removeForbidden(int x, int y, Uint32 teamNum)
 	{
-		Case& c=cases[coordToIndex(x, y)];
+		Tile& c=tiles[coordToIndex(x, y)];
 		c.forbidden ^= c.forbidden &  Team::teamNumberToMask(teamNum);
 	}
 	
 	void addClearArea(int x, int y, Uint32 teamNum)
 	{
-		cases[coordToIndex(x, y)].clearArea |=  Team::teamNumberToMask(teamNum);
+		tiles[coordToIndex(x, y)].clearArea |=  Team::teamNumberToMask(teamNum);
 	}
 	
 	void addGuardArea(int x, int y, Uint32 teamNum)
 	{
-		cases[coordToIndex(x, y)].guardArea |=  Team::teamNumberToMask(teamNum);
+		tiles[coordToIndex(x, y)].guardArea |=  Team::teamNumberToMask(teamNum);
 	}
 
 	
@@ -405,18 +405,18 @@ public:
 
 	bool isResource(int x, int y) const
 	{
-		return getCase(x, y).resource.type != NO_RES_TYPE;
+		return getTile(x, y).resource.type != NO_RES_TYPE;
 	}
 
 	bool isResourceTakeable(int x, int y, int resourceType) const
 	{
-		const Resource &resource = getCase(x, y).resource;
+		const Resource &resource = getTile(x, y).resource;
 		return (resource.type == resourceType && resource.amount > 0);
 	}
 
 	bool isResourceTakeable(int x, int y, bool resourceTypes[BASIC_COUNT]) const
 	{
-		const Resource &resource = getCase(x, y).resource;
+		const Resource &resource = getTile(x, y).resource;
 		return (resource.type != NO_RES_TYPE
 			&& resource.amount > 0
 			&& resource.type < BASIC_COUNT
@@ -425,7 +425,7 @@ public:
 
 	bool isResource(int x, int y, int *resourceType) const
 	{
-		const Resource &resource = getCase(x, y).resource;
+		const Resource &resource = getTile(x, y).resource;
 		if (resource.type == NO_RES_TYPE)
 			return false;
 		*resourceType = resource.type;
@@ -434,7 +434,7 @@ public:
 
 	bool canResourcesGrow(int x, int y) const
 	{
-		return getCase(x, y).canResourcesGrow;
+		return getTile(x, y).canResourcesGrow;
 	}
 
 	//! Decrement resource at position (x,y). Return true on success, false otherwise.
@@ -505,17 +505,17 @@ public:
 	Uint8 getImmobileUnit(int x, int y) const;
 
 	//! Return GID
-	Uint16 getGroundUnit(int x, int y) const { return cases[coordToIndex(x, y)].groundUnit; }
-	Uint16 getAirUnit(int x, int y) const { return cases[coordToIndex(x, y)].airUnit; }
-	Uint16 getBuilding(int x, int y) const { return cases[coordToIndex(x, y)].building; }
+	Uint16 getGroundUnit(int x, int y) const { return tiles[coordToIndex(x, y)].groundUnit; }
+	Uint16 getAirUnit(int x, int y) const { return tiles[coordToIndex(x, y)].airUnit; }
+	Uint16 getBuilding(int x, int y) const { return tiles[coordToIndex(x, y)].building; }
 	
-	void setGroundUnit(int x, int y, Uint16 guid) { cases[coordToIndex(x, y)].groundUnit = guid; }
-	void setAirUnit(int x, int y, Uint16 guid) { cases[coordToIndex(x, y)].airUnit = guid; }
+	void setGroundUnit(int x, int y, Uint16 guid) { tiles[coordToIndex(x, y)].groundUnit = guid; }
+	void setAirUnit(int x, int y, Uint16 guid) { tiles[coordToIndex(x, y)].airUnit = guid; }
 	void setBuilding(int x, int y, int w, int h, Uint16 gbid)
 	{
 		for (int yi=y; yi<y+h; yi++)
 			for (int xi=x; xi<x+w; xi++)
-				cases[coordToIndex(xi, yi)].building = gbid;
+				tiles[coordToIndex(xi, yi)].building = gbid;
 	}
 	
 	//! Return the sector index of the sector containing tile (x,y). The
@@ -541,7 +541,7 @@ public:
 	//! Removes every resource in the w by h area at (x, y) whose terrain no longer allows it,
 	//! used after the terrain under it changed
 	void removeUnallowedResources(int x, int y, int w, int h);
-	//! With l==0, it will add resource only on one case. (Aligned coordinates)
+	//! With l==0, it will add resource only on one tile. (Aligned coordinates)
 	void setResource(int x, int y, int type, int l);
 	bool isResourceAllowed(int x, int y, int type);
 	
@@ -676,7 +676,7 @@ public:
 public:
 	Game *game;
 public:
-	std::vector<Case> cases;
+	std::vector<Tile> tiles;
 	Sint32 w, h;
 	Sint32 wMask, hMask;
 	Sint32 wDec, hDec;
@@ -697,7 +697,7 @@ public:
 	std::vector<Uint32> fogOfWarB;
 	Uint32* fogOfWar = nullptr; // if valid, either points to &fogOfWarA[0] or &fogOfWarB[0]
 	//! Render-only overlay caches for the locally-displayed team's areas (forbidden /
-	//! guard / clear). These mirror the per-team bits in cases[].{forbidden,guardArea,
+	//! guard / clear). These mirror the per-team bits in tiles[].{forbidden,guardArea,
 	//! clearArea} but only for displayedTeam, so the renderer can query one tile cheaply.
 	//! They are NOT in checkSum() and must never be read from a sim path — doing so would
 	//! desync, because displayedTeam differs per client. true = bit set.

--- a/src/map/MapMisc.cpp
+++ b/src/map/MapMisc.cpp
@@ -17,7 +17,7 @@ Uint32 Map::checkSum(bool heavy)
 	Uint32 cs=size;
 	if (heavy)
 	{
-		for (const auto& c: cases)
+		for (const auto& c: tiles)
 		{
 			cs+=
 				c.terrain +

--- a/src/map/MapResources.cpp
+++ b/src/map/MapResources.cpp
@@ -14,7 +14,7 @@
 
 void Map::decResource(int x, int y)
 {
-	Resource &r = getCase(x, y).resource;
+	Resource &r = getTile(x, y).resource;
 	
 	if (r.type == NO_RES_TYPE || r.amount == 0)
 		return;
@@ -45,7 +45,7 @@ void Map::decResource(int x, int y, int resourceType)
 
 bool Map::incResource(int x, int y, int resourceType, int variety)
 {
-	Resource &r = getCase(x, y).resource;
+	Resource &r = getTile(x, y).resource;
 	const ResourceType *fulltype;
 	if (r.type == NO_RES_TYPE)
 	{
@@ -97,7 +97,7 @@ void Map::setNoResource(int x, int y, int l)
 	assert(l<h);
 	for (int dx=x-(l>>1); dx<x+(l>>1)+1; dx++)
 		for (int dy=y-(l>>1); dy<y+(l>>1)+1; dy++)
-			cases[coordToIndex(dx, dy)].resource.clear();
+			tiles[coordToIndex(dx, dy)].resource.clear();
 }
 
 void Map::removeUnallowedResources(int x, int y, int w, int h)
@@ -105,7 +105,7 @@ void Map::removeUnallowedResources(int x, int y, int w, int h)
 	for (int dx=x; dx<x+w; dx++)
 		for (int dy=y; dy<y+h; dy++)
 		{
-			Resource& r=cases[coordToIndex(dx, dy)].resource;
+			Resource& r=tiles[coordToIndex(dx, dy)].resource;
 			if (r.type!=NO_RES_TYPE && getTerrainType(dx, dy)!=globalContainer->resourcesTypes.get(r.type)->terrain)
 				r.clear();
 		}
@@ -120,7 +120,7 @@ void Map::setResource(int x, int y, int type, int l)
 		for (int dy=y-(l>>1); dy<y+(l>>1)+1; dy++)
 			if (isResourceAllowed(dx, dy, type))
 			{
-				Resource& rp=cases[coordToIndex(dx, dy)].resource;
+				Resource& rp=tiles[coordToIndex(dx, dy)].resource;
 				rp.type=type;
 				const ResourceType *rt=globalContainer->resourcesTypes.get(type);
 				rp.variety=syncRand()%rt->varietiesCount;
@@ -137,17 +137,17 @@ bool Map::isResourceAllowed(int x, int y, int type)
 
 bool Map::isPointSet(int n, int x, int y) const
 {
-	return getCase(x, y).scriptAreas & 1<<n;
+	return getTile(x, y).scriptAreas & 1<<n;
 }
 
 void Map::setPoint(int n, int x, int y)
 {
-	getCase(x, y).scriptAreas |= 1<<n;
+	getTile(x, y).scriptAreas |= 1<<n;
 }
 
 void Map::unsetPoint(int n, int x, int y)
 {
-	getCase(x, y).scriptAreas ^= getCase(x, y).scriptAreas & (1<<n);
+	getTile(x, y).scriptAreas ^= getTile(x, y).scriptAreas & (1<<n);
 }
 
 std::string Map::getAreaName(int n) const

--- a/src/map/MapStep.cpp
+++ b/src/map/MapStep.cpp
@@ -165,7 +165,7 @@ void Map::setMapDiscovered(int x, int y, int w, int h,  Uint32 sharedVision)
 
 void Map::setMapBuildingsDiscovered(int x, int y, Uint32 sharedVision, Team *teams[Team::MAX_COUNT])
 {
-	Uint16 bgid = cases[coordToIndex(x, y)].building;
+	Uint16 bgid = tiles[coordToIndex(x, y)].building;
 	if (bgid != NOGBID)
 	{
 		int id = Building::GIDtoID(bgid);
@@ -230,21 +230,21 @@ void Map::computeDisplayedForbidden(int teamNumber)
 {
 	Uint32 teamMask = Team::teamNumberToMask(teamNumber);
 	for (size_t i=0; i<size; i++)
-		displayedForbiddenView.set(i, (cases[i].forbidden & teamMask) != 0);
+		displayedForbiddenView.set(i, (tiles[i].forbidden & teamMask) != 0);
 }
 
 void Map::computeDisplayedGuardArea(int teamNumber)
 {
 	Uint32 teamMask = Team::teamNumberToMask(teamNumber);
 	for (size_t i=0; i<size; i++)
-		displayedGuardAreaView.set(i, (cases[i].guardArea & teamMask) != 0);
+		displayedGuardAreaView.set(i, (tiles[i].guardArea & teamMask) != 0);
 }
 
 void Map::computeDisplayedClearArea(int teamNumber)
 {
 	Uint32 teamMask = Team::teamNumberToMask(teamNumber);
 	for (size_t i=0; i<size; i++)
-		displayedClearAreaView.set(i, (cases[i].clearArea & teamMask) != 0);
+		displayedClearAreaView.set(i, (tiles[i].clearArea & teamMask) != 0);
 }
 
 

--- a/src/map/edit/MapEdit.h
+++ b/src/map/edit/MapEdit.h
@@ -730,10 +730,10 @@ private:
 	BrushAccumulator brushAccumulator;
 	///Handles brush click to place a zone
 	void handleBrushClick(int mx, int my);
-	///The pair of map fields a zone brush edits: the per-case team bitmask and the local (display-only) overlay
+	///The pair of map fields a zone brush edits: the per-tile team bitmask and the local (display-only) overlay
 	struct AreaBrushTarget
 	{
-		Uint32 Case::* caseMask;
+		Uint32 Tile::* tileMask;
 		Utilities::BitArray& view;
 	};
 	///Returns the map fields edited by the current brushType

--- a/src/map/edit/MapEditClicks.cpp
+++ b/src/map/edit/MapEditClicks.cpp
@@ -119,11 +119,11 @@ void MapEdit::handleBrushClick(int mx, int my)
 			for (int x=startX; x<startX+width; x++)
 				if (BrushTool::getBrushValue(fig, x-startX, y-startY, mapX, mapY, firstX, firstY))
 				{
-					Uint32& caseMask = game.map.getCase(x, y).*target.caseMask;
+					Uint32& tileMask = game.map.getTile(x, y).*target.tileMask;
 					if (add)
-						caseMask |= teamBit;
+						tileMask |= teamBit;
 					else
-						caseMask &= ~teamBit; // clears the team bit, same as the old `mask ^= mask & teamBit`
+						tileMask &= ~teamBit; // clears the team bit, same as the old `mask ^= mask & teamBit`
 					target.view.set(game.map.w*(y&game.map.hMask)+(x&game.map.wMask), add);
 				}
 	}
@@ -140,14 +140,14 @@ MapEdit::AreaBrushTarget MapEdit::areaBrushTarget()
 	switch (brushType)
 	{
 	case ForbiddenBrush:
-		return {&Case::forbidden, game.map.displayedForbiddenView};
+		return {&Tile::forbidden, game.map.displayedForbiddenView};
 	case GuardAreaBrush:
-		return {&Case::guardArea, game.map.displayedGuardAreaView};
+		return {&Tile::guardArea, game.map.displayedGuardAreaView};
 	case ClearAreaBrush:
-		return {&Case::clearArea, game.map.displayedClearAreaView};
+		return {&Tile::clearArea, game.map.displayedClearAreaView};
 	default:
 		assert(false);
-		return {&Case::forbidden, game.map.displayedForbiddenView};
+		return {&Tile::forbidden, game.map.displayedForbiddenView};
 	}
 }
 
@@ -341,7 +341,7 @@ void MapEdit::handleClick(int mx, int my, BrushTool::ClickType clickType)
 						game.map.setPoint(areaNumber->getIndex(), x, y);
 						break;
 					case BrushTool::CT_NO_RESOURCE_GROWTH:
-						game.map.getCase(x, y).canResourcesGrow=false;
+						game.map.getTile(x, y).canResourcesGrow=false;
 						break;
 					}
 				}
@@ -358,7 +358,7 @@ void MapEdit::handleClick(int mx, int my, BrushTool::ClickType clickType)
 						game.map.unsetPoint(areaNumber->getIndex(), x, y);
 						break;
 					case BrushTool::CT_NO_RESOURCE_GROWTH:
-						game.map.getCase(x, y).canResourcesGrow=true;
+						game.map.getTile(x, y).canResourcesGrow=true;
 						break;
 					default:break;
 					}

--- a/src/map/gradient/MapGradientArea.cpp
+++ b/src/map/gradient/MapGradientArea.cpp
@@ -57,7 +57,7 @@ void Map::updateForbiddenGradient(int teamNumber, int swimClass)
 	// all other blockers (resources, buildings, water, immobileUnits) are obstacles.
 	for (size_t i=0; i<size; i++)
 	{
-		const Case& c=cases[i];
+		const Tile& c=tiles[i];
 		if (c.resource.type!=NO_RES_TYPE)
 			gradient[i] = GRADIENT_FORBIDDEN;
 		else if (c.building!=NOGBID)
@@ -117,7 +117,7 @@ void Map::updateGuardAreasGradient(int teamNumber, int swimClass)
 	Uint32 teamMask = Team::teamNumberToMask(teamNumber);
 	for (size_t i=0; i<size; i++)
 	{
-		const Case& c=cases[i];
+		const Tile& c=tiles[i];
 		if (c.forbidden & teamMask)
 			gradient[i] = GRADIENT_FORBIDDEN;
 		else if(immobileUnits[i] != IMMOBILE_UNIT_NONE)
@@ -160,7 +160,7 @@ void Map::updateClearAreasGradient(int teamNumber, int swimClass)
 	Uint32 teamMask = Team::teamNumberToMask(teamNumber);
 	for (size_t i=0; i<size; i++)
 	{
-		const Case& c=cases[i];
+		const Tile& c=tiles[i];
 		if (c.forbidden & teamMask)
 			gradient[i] = GRADIENT_FORBIDDEN;
 		else if(c.clearArea & teamMask && c.resource.type != NO_RES_TYPE && globalContainer->resourcesTypes.get(c.resource.type)->clearable)

--- a/src/map/gradient/MapGradientBuilding.cpp
+++ b/src/map/gradient/MapGradientBuilding.cpp
@@ -65,7 +65,7 @@ void Map::updateGlobalGradient(Building *building, int swimClass)
 				if (yi2+(xi*xi)<=r2)
 				{
 					size_t addr = coordToIndex(posX+w+xi, posY+h+yi);
-					if(cases[addr].resource.type!=NO_RES_TYPE && building->clearingResources[cases[addr].resource.type])
+					if(tiles[addr].resource.type!=NO_RES_TYPE && building->clearingResources[tiles[addr].resource.type])
 					{
 						if(gradient[addr] == GRADIENT_UNREACHABLE)
 							gradient[addr] = GRADIENT_AT_GOAL;
@@ -82,7 +82,7 @@ void Map::updateGlobalGradient(Building *building, int swimClass)
 		for (int x=0; x<w; x++)
 		{
 			int wyx=wy+x;
-			const Case& c=cases[wyx];
+			const Tile& c=tiles[wyx];
 			if (c.building==NOGBID)
 			{
 				if (c.forbidden&teamMask)

--- a/src/map/gradient/MapGradientGlobal.cpp
+++ b/src/map/gradient/MapGradientGlobal.cpp
@@ -127,7 +127,7 @@ void Map::updateResourcesGradient(int teamNumber, Uint8 resourceType, int swimCl
 	assert(globalContainer);
 	for (size_t i=0; i<size; i++)
 	{
-		const Case& c=cases[i];
+		const Tile& c=tiles[i];
 		if (c.forbidden & teamMask)
 			gradient[i]=GRADIENT_FORBIDDEN;
 		else if(immobileUnits[i] != IMMOBILE_UNIT_NONE)

--- a/src/map/io/MapIO.cpp
+++ b/src/map/io/MapIO.cpp
@@ -57,7 +57,7 @@ try
 	displayedForbiddenView.resize(size, false);
 	displayedGuardAreaView.resize(size, false);
 	displayedClearAreaView.resize(size, false);
-	cases.resize(size);
+	tiles.resize(size);
 	undermap = new Uint8[size];
 	listedAddr = new Uint8*[size];
 	aStarPoints=new AStarAlgorithmPoint[size];
@@ -72,24 +72,24 @@ try
 		stream->readEnterSection(i);
 		mapDiscovered[i] = stream->readUint32("mapDiscovered");
 
-		cases[i].terrain = stream->readUint16("terrain");
-		cases[i].building = stream->readUint16("building");
-		if (cases[i].building != NOGBID && cases[i].building >= Building::MAX_COUNT * header.getNumberOfTeams())
+		tiles[i].terrain = stream->readUint16("terrain");
+		tiles[i].building = stream->readUint16("building");
+		if (tiles[i].building != NOGBID && tiles[i].building >= Building::MAX_COUNT * header.getNumberOfTeams())
 			return false;
 
-		stream->read(&(cases[i].resource), 4, "ressource");
-		cases[i].groundUnit = stream->readUint16("groundUnit");
-		cases[i].airUnit = stream->readUint16("airUnit");
-		cases[i].forbidden = stream->readUint32("forbidden");
+		stream->read(&(tiles[i].resource), 4, "ressource");
+		tiles[i].groundUnit = stream->readUint16("groundUnit");
+		tiles[i].airUnit = stream->readUint16("airUnit");
+		tiles[i].forbidden = stream->readUint32("forbidden");
 		if(versionMinor < 62)
 			stream->readUint32("hiddenForbidden");
-		cases[i].guardArea = stream->readUint32("guardArea");
-		cases[i].clearArea = stream->readUint32("clearArea");
-		cases[i].scriptAreas = stream->readUint16("scriptAreas");
-		cases[i].canResourcesGrow = stream->readUint8("canRessourcesGrow");
+		tiles[i].guardArea = stream->readUint32("guardArea");
+		tiles[i].clearArea = stream->readUint32("clearArea");
+		tiles[i].scriptAreas = stream->readUint16("scriptAreas");
+		tiles[i].canResourcesGrow = stream->readUint8("canRessourcesGrow");
 		if(versionMinor >= 63)
-			cases[i].fertility = stream->readUint16("fertility");
-		fertilityMaximum = std::max(fertilityMaximum, cases[i].fertility);
+			tiles[i].fertility = stream->readUint16("fertility");
+		fertilityMaximum = std::max(fertilityMaximum, tiles[i].fertility);
 
 		stream->readLeaveSection();
 	}
@@ -200,19 +200,19 @@ void Map::save(GAGCore::OutputStream *stream)
 		stream->writeEnterSection(i);
 		stream->writeUint32(mapDiscovered[i], "mapDiscovered");
 
-		stream->writeUint16(cases[i].terrain, "terrain");
-		stream->writeUint16(cases[i].building, "building");
+		stream->writeUint16(tiles[i].terrain, "terrain");
+		stream->writeUint16(tiles[i].building, "building");
 		
-		stream->write(&(cases[i].resource), 4, "ressource");
+		stream->write(&(tiles[i].resource), 4, "ressource");
 		
-		stream->writeUint16(cases[i].groundUnit, "groundUnit");
-		stream->writeUint16(cases[i].airUnit, "airUnit");
-		stream->writeUint32(cases[i].forbidden, "forbidden");
-		stream->writeUint32(cases[i].guardArea, "guardArea");
-		stream->writeUint32(cases[i].clearArea, "clearArea");
-		stream->writeUint16(cases[i].scriptAreas, "scriptAreas");
-		stream->writeUint8(cases[i].canResourcesGrow, "canRessourcesGrow");
-		stream->writeUint16(cases[i].fertility, "fertility");
+		stream->writeUint16(tiles[i].groundUnit, "groundUnit");
+		stream->writeUint16(tiles[i].airUnit, "airUnit");
+		stream->writeUint32(tiles[i].forbidden, "forbidden");
+		stream->writeUint32(tiles[i].guardArea, "guardArea");
+		stream->writeUint32(tiles[i].clearArea, "clearArea");
+		stream->writeUint16(tiles[i].scriptAreas, "scriptAreas");
+		stream->writeUint8(tiles[i].canResourcesGrow, "canRessourcesGrow");
+		stream->writeUint16(tiles[i].fertility, "fertility");
 		stream->writeLeaveSection();
 	}
 	stream->writeLeaveSection();

--- a/src/map/pathfind/MapPathfindBuilding.cpp
+++ b/src/map/pathfind/MapPathfindBuilding.cpp
@@ -74,7 +74,7 @@ bool Map::pathfindBuilding(Building *building, int swimClass, int x, int y, int 
 	assert(x>=0);
 	assert(y>=0);
 	Uint32 teamMask=building->owner->me;
-	if (((cases[coordToIndex(x, y)].forbidden) & teamMask)!=0)
+	if (((tiles[coordToIndex(x, y)].forbidden) & teamMask)!=0)
 		return pathfindForbidden(building->globalGradient[swimClass], building->owner->teamNumber, swimClass, x, y, dx, dy);
 
 	const Uint16 *gradient=buildingGradient(building, swimClass);
@@ -109,7 +109,7 @@ void Map::dirtyBuildingGradients(int x, int y, int wl, int hl, int teamNumber)
 	{
 		for (int wi=0; wi<wl; wi++)
 		{
-			int bgid=cases[coordToIndex(x + wi, y + hi)].building;
+			int bgid=tiles[coordToIndex(x + wi, y + hi)].building;
 			if (bgid!=NOGBID)
 				if (Building::GIDtoTeam(bgid)==teamNumber)
 				{

--- a/src/map/pathfind/MapPathfindRessource.cpp
+++ b/src/map/pathfind/MapPathfindRessource.cpp
@@ -40,7 +40,7 @@ void Map::pathfindRandom(Unit *unit)
 {
 	int x=unit->posX;
 	int y=unit->posY;
-	if ((cases[x+(y<<wDec)].forbidden)&unit->owner->me)
+	if ((tiles[x+(y<<wDec)].forbidden)&unit->owner->me)
 	{
 		if (pathfindForbidden(NULL, unit->owner->teamNumber, unit->swimClass(), x, y, &unit->dx, &unit->dy))
 		{

--- a/src/team/Team.h
+++ b/src/team/Team.h
@@ -92,7 +92,7 @@ public:
 	void setCorrectMasks(void);
 	void setCorrectColor(const GAGCore::Color& color);
 	void setCorrectColor(float value);
-	/// Bit for `team` in team-mask bitfields (allies, sharedVision*, Case::forbidden, ...).
+	/// Bit for `team` in team-mask bitfields (allies, sharedVision*, Tile::forbidden, ...).
 	/// Masks have MAX_COUNT_ON_DISK bits; `1<<31` on a signed int would be UB.
 	inline static Uint32 teamNumberToMask(int team) { return Uint32(1)<<team; }
 

--- a/src/unit/UnitMovement.cpp
+++ b/src/unit/UnitMovement.cpp
@@ -93,7 +93,7 @@ bool Unit::tryClaimClearingAreaForHarvesting()
 			{
 				int x = (posX + tdx) & map->wMask;
 				int y = (posY + tdy) & map->hMask;
-				Case mapCase = map->cases[(y << map->wDec) + x];
+				Tile mapCase = map->tiles[(y << map->wDec) + x];
 				if ((mapCase.clearArea & owner->me)
 					&& (mapCase.resource.type != NO_RES_TYPE)
 					&& globalContainer->resourcesTypes.get(mapCase.resource.type)->clearable

--- a/test/GradientTest.cpp
+++ b/test/GradientTest.cpp
@@ -33,7 +33,7 @@ namespace
 			wMask = w - 1;
 			hMask = h - 1;
 			size = static_cast<size_t>(w * h);
-			cases.assign(size, Case());
+			tiles.assign(size, Tile());
 		}
 		~GrassMap()
 		{
@@ -43,8 +43,8 @@ namespace
 			size = 0;
 		}
 		size_t cells() const { return size; }
-		void putWater(int x, int y) { cases[coordToIndex(x, y)].terrain = 256; }
-		void putGroundUnit(int x, int y) { cases[coordToIndex(x, y)].groundUnit = 0; }
+		void putWater(int x, int y) { tiles[coordToIndex(x, y)].terrain = 256; }
+		void putGroundUnit(int x, int y) { tiles[coordToIndex(x, y)].groundUnit = 0; }
 	};
 
 	// Shortest wrapped axis distance on a torus of extent n.

--- a/test/MapQueryTest.cpp
+++ b/test/MapQueryTest.cpp
@@ -31,7 +31,7 @@ namespace
 			wMask = w - 1;
 			hMask = h - 1;
 			size = static_cast<size_t>(w * h);
-			cases.assign(size, Case());   // Case() defaults: terrain=0 (grass), no building, no unit
+			tiles.assign(size, Tile());   // Tile() defaults: terrain=0 (grass), no building, no unit
 		}
 		~GrassMap()
 		{
@@ -43,15 +43,15 @@ namespace
 
 		void putBuilding(int x, int y, Uint16 gbid = 0)
 		{
-			cases[coordToIndex(x, y)].building = gbid;
+			tiles[coordToIndex(x, y)].building = gbid;
 		}
 		void putGroundUnit(int x, int y, Uint16 guid = 0)
 		{
-			cases[coordToIndex(x, y)].groundUnit = guid;
+			tiles[coordToIndex(x, y)].groundUnit = guid;
 		}
 		void putResource(int x, int y, int type = 0)
 		{
-			Resource &r = cases[coordToIndex(x, y)].resource;
+			Resource &r = tiles[coordToIndex(x, y)].resource;
 			r.type = type;
 			r.amount = 1;
 			r.variety = 0;
@@ -59,7 +59,7 @@ namespace
 		}
 		void setForbidden(int x, int y, Uint32 mask)
 		{
-			cases[coordToIndex(x, y)].forbidden = mask;
+			tiles[coordToIndex(x, y)].forbidden = mask;
 		}
 		// Terrain encoding (see Map.h:336-361):
 		//   grass : terrain <  16
@@ -67,11 +67,11 @@ namespace
 		//   water : 256..271
 		void makeWater(int x, int y)
 		{
-			cases[coordToIndex(x, y)].terrain = 256;
+			tiles[coordToIndex(x, y)].terrain = 256;
 		}
 		void makeSand(int x, int y)
 		{
-			cases[coordToIndex(x, y)].terrain = 128;
+			tiles[coordToIndex(x, y)].terrain = 128;
 		}
 	};
 

--- a/test/WinningConditionsHarness.cpp
+++ b/test/WinningConditionsHarness.cpp
@@ -156,14 +156,14 @@ void testAllies()
 void testPrestige()
 {
 	constexpr int N = 3;
-	struct Case
+	struct Tile
 	{
 		const char* tag;
 		int totalPrestige;
 		int prestigeToReach;
 		std::array<int, N> teamPrestige;
 	};
-	static const Case cases[] = {
+	static const Tile tiles[] = {
 		{"all-zero-belowGate",   0,   100, {0, 0, 0}},
 		{"all-zero-atGate",      100, 100, {0, 0, 0}},
 		{"belowGate-noTie",      50,  100, {10, 30, 10}},
@@ -174,7 +174,7 @@ void testPrestige()
 		{"aboveGate-tieAtTop",   200, 100, {100, 100, 25}},
 		{"negativePrestige",     100, 100, {-5, 0, -10}},
 	};
-	for (const auto& c : cases)
+	for (const auto& c : tiles)
 	{
 		clearAll();
 		setupTeams(N);


### PR DESCRIPTION
Replace the French map-cell name `Case` with `Tile`, rename `getCase` to `getTile` and the map's `cases` storage to `tiles`, and update the editor's member pointer and current test harnesses. This is the map terminology portion of Stéphane Magnenat's #85, adapted to current master.

All string literals remain unchanged, including the historical `cases` save section. No data layout, algorithms, or gameplay changes are intended.

Validation:
- Lexical comparison confirms only the documented identifier substitutions outside comments, with every string/character literal preserved.
- macOS release client and server builds pass with both replacement patches applied together to master 88934ecfb.
- All 16 existing test executables pass on that combined code, including TestsRunner's 170 tests and replay/network/text-serialization tests.
- G2, playground-8numbi, gd-archipelago, and gd-bigarena-long: 15,000 ticks each, before/after replay bytes and every per-tick checksum identical (60,000 ticks per version).
- Each PR also runs its own Linux/Windows CI; see checks below.

Companion PR: #200

This replaces part of #85. The complementary spelling/comment patch and Kyle's already-landed cb7856eaa cover the selected spelling cleanup; the original broad casing-only sweep is intentionally omitted.
