### PR TITLE
Recover remaining spelling and name-clarity fixes from #85

### DIFF
--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -180,7 +180,7 @@ namespace GAGCore
 		void _drawHorzLine(int x, int y, int l, const Color& color);
 		
 	protected:
-		//! Protectedconstructor, only called by GraphicContext
+		//! Protected constructor, only called by GraphicContext
 		DrawableSurface() { sdlsurface = NULL; }
 		//! allocate texture in GPU for this surface
 		void allocateTexture(void);
@@ -278,7 +278,7 @@ namespace GAGCore
 		virtual void drawCircle(int x, int y, int radius, Uint8 r, Uint8 g, Uint8 b, Uint8 a = Color::ALPHA_OPAQUE);
 		virtual void drawString(int x, int y, Font *font, int i);
 		
-		// This is for translation textshot code, it works by trapping calls to the getString function in the translation StringTables,
+		// This is for translation text shot code, it works by trapping calls to the getString function in the translation StringTables,
 		// then later in drawString, if we are drawing one of the found strings returned by StringTable, it will add it to the list of
 		// rectangles that represent found texts. Just before the next frame begins to draw, all of the rectangle pictures are flushed
 		// into bmp's. This is done because we want the translation pictures to be done when *all* of the screen is already drawn (when

--- a/libgag/include/StreamBackend.h
+++ b/libgag/include/StreamBackend.h
@@ -71,7 +71,7 @@ namespace GAGCore
 	class MemoryStreamBackend : public StreamBackend
 	{
 	private:
-		std::string datas;
+		std::string buffer;
 		size_t index;
 		
 	public:
@@ -90,6 +90,6 @@ namespace GAGCore
 		virtual size_t getPosition(void);
 		virtual bool isEndOfStream(void);
 		virtual bool isValid(void) { return true; }
-		virtual const char* getBuffer() { return datas.c_str(); }
+		virtual const char* getBuffer() { return buffer.c_str(); }
 	};
 }

--- a/libgag/src/DrawableSurface.cpp
+++ b/libgag/src/DrawableSurface.cpp
@@ -172,7 +172,7 @@ namespace GAGCore
 
 			// The next line causes a desynchronization between _doScissors and glIsEnabled(GL_SCISSOR_TEST),
 			// which causes the setClipRect() functions to not reset the clipping the way it should,  so many
-			// things don't get drawn properly and the game appears to "blink". Outcommenting it didn't cause
+			// things don't get drawn properly and the game appears to "blink". Commenting it out didn't cause
 			// any other problems.  If you think glState should be reset,  feel free to do so,  but also call
 			// functions like glDisable() as required.
 

--- a/libgag/src/DrawableSurfaceCompound.cpp
+++ b/libgag/src/DrawableSurfaceCompound.cpp
@@ -365,7 +365,7 @@ namespace GAGCore
 
 		font->drawString(this, x, y, w, output, alpha);
 
-		///////////// The following code is for translation textshots ////////////
+		///////////// The following code is for translation text shots ////////////
 		if(!translationPicturesDirectory.empty())
 		{
 			for(std::map<std::string, std::string>::iterator i=texts.begin(); i!=texts.end(); ++i)
@@ -395,7 +395,7 @@ namespace GAGCore
 		if(pos != std::string::npos)
 			output = output.substr(0, pos);
 
-		///////////// The following code is for translation textshots ////////////
+		///////////// The following code is for translation text shots ////////////
 		if(!translationPicturesDirectory.empty())
 		{
 			for(std::map<std::string, std::string>::iterator i=texts.begin(); i!=texts.end(); ++i)
@@ -442,7 +442,7 @@ namespace GAGCore
 		this->drawString(x, y, font, str.str());
 	}
 
-	//This code is for the textshot code
+	//This code is for the text shot code
 	std::map<std::string, std::string> DrawableSurface::texts;
 	std::set<std::string> DrawableSurface::wroteTexts;
 	std::vector<std::tuple<DrawableSurface::SRectangle, std::string, GAGCore::DrawableSurface*> > DrawableSurface::drawSquares;

--- a/libgag/src/DrawableSurfaceDraw.cpp
+++ b/libgag/src/DrawableSurfaceDraw.cpp
@@ -419,7 +419,7 @@ namespace GAGCore
 		px = x1;
 		py = y1;
 
-		// variable initialisation for bresenham algo
+		// variable initialisation for Bresenham algo
 		if (dx == 0)
 			return;
 		if (dy == 0)

--- a/libgag/src/StreamBackend.cpp
+++ b/libgag/src/StreamBackend.cpp
@@ -18,23 +18,23 @@ namespace GAGCore
 	void MemoryStreamBackend::write(const void *data, const size_t size)
 	{
 		const char *_data = static_cast<const char *>(data);
-		if ((index + size) > datas.size())
-			datas.resize(index + size);
-		std::copy(_data, _data+size, datas.begin()+index);
+		if ((index + size) > buffer.size())
+			buffer.resize(index + size);
+		std::copy(_data, _data+size, buffer.begin()+index);
 		index += size;
 	}
 	
 	void MemoryStreamBackend::read(void *data, size_t size)
 	{
 		char *_data = static_cast<char *>(data);
-		if (index+size > datas.size())
+		if (index+size > buffer.size())
 		{
 			// overread, read 0
 			std::fill(_data, _data+size, 0);
 		}
 		else
 		{
-			std::copy(datas.data() + index, datas.data() + index + size, _data);
+			std::copy(buffer.data() + index, buffer.data() + index + size, _data);
 			index += size;
 		}
 	}
@@ -55,19 +55,19 @@ namespace GAGCore
 	
 	void MemoryStreamBackend::seekFromStart(int displacement)
 	{
-		index = std::min(static_cast<size_t>(displacement), datas.size());
+		index = std::min(static_cast<size_t>(displacement), buffer.size());
 	}
 	
 	void MemoryStreamBackend::seekFromEnd(int displacement)
 	{
-		index = static_cast<size_t>(std::max(0, static_cast<int>(datas.size()) - displacement));
+		index = static_cast<size_t>(std::max(0, static_cast<int>(buffer.size()) - displacement));
 	}
 	
 	void MemoryStreamBackend::seekRelative(int displacement)
 	{
 		int newIndex = static_cast<int>(index) + displacement;
 		newIndex = std::max(newIndex, 0);
-		newIndex = std::min(newIndex, static_cast<int>(datas.size()));
+		newIndex = std::min(newIndex, static_cast<int>(buffer.size()));
 		index = static_cast<size_t>(newIndex);
 	}
 	
@@ -78,6 +78,6 @@ namespace GAGCore
 	
 	bool MemoryStreamBackend::isEndOfStream(void)
 	{
-		return index >= datas.size();
+		return index >= buffer.size();
 	}
 }

--- a/libgag/src/StringTable.cpp
+++ b/libgag/src/StringTable.cpp
@@ -163,14 +163,14 @@ namespace GAGCore
 		for (std::map<std::string, size_t>::iterator it=stringAccess.begin(); it!=stringAccess.end(); ++it)
 		{
 			// For each entry...
-			bool lcwp=false;
+			bool lastCharWasPct=false;
 			int baseCount=0;
 			const std::string &s = it->first;
 			// we check that we only have valid format (from a FormattableString point of view)...
 			for (size_t j=0; j<s.length(); j++)
 			{
 				char c = s[j];
-				if (lcwp && c!=' ' && c!='%')
+				if (lastCharWasPct && c!=' ' && c!='%')
 				{
 					if (isdigit(c))
 						baseCount++;
@@ -181,18 +181,18 @@ namespace GAGCore
 						return false;
 					}
 				}
-				lcwp=(c=='%');
+				lastCharWasPct=(c=='%');
 			}
 			// then we are sure that format are correct in all translation
 			for (size_t i=0; i<strings[it->second]->data.size(); i++)
 			{
 				const std::string &s = strings[it->second]->data[i];
-				bool lcwp=false;
+				bool lastCharWasPct=false;
 				int count=0;
 				for (size_t j=0; j<s.length(); j++)
 				{
 					char c=s[j];
-					if (lcwp && c!=' ' && c!='%')
+					if (lastCharWasPct && c!=' ' && c!='%')
 					{
 						if (isdigit(c))
 							count++;
@@ -203,7 +203,7 @@ namespace GAGCore
 							return false;
 						}
 					}
-					lcwp=(c=='%');
+					lastCharWasPct=(c=='%');
 				}
 				// if not, issue an error message
 				if (baseCount!=count && s!="")

--- a/src/BaseTeam.cpp
+++ b/src/BaseTeam.cpp
@@ -25,7 +25,7 @@ BaseTeam::BaseTeam()
 
 bool BaseTeam::load(GAGCore::InputStream *stream, Sint32 versionMinor)
 {
-	// loading baseteam
+	// loading base team
 	stream->readEnterSection("BaseTeam");
 	type = (TeamType)stream->readUint32("type");
 	teamNumber = stream->readSint32("teamNumber");
@@ -55,7 +55,7 @@ bool BaseTeam::load(GAGCore::InputStream *stream, Sint32 versionMinor)
 
 void BaseTeam::save(GAGCore::OutputStream *stream) const
 {
-	// saving baseteam
+	// saving base team
 	stream->writeEnterSection("BaseTeam");
 	stream->writeUint32((Uint32)type, "type");
 	stream->writeSint32(teamNumber, "teamNumber");

--- a/src/Brush.cpp
+++ b/src/Brush.cpp
@@ -92,7 +92,7 @@ void BrushTool::drawBrush(int x, int y, GAGCore::Color c, int viewportX, int vie
 	{
 		for (int cy = 0; cy < h; cy++)
 		{
-			// TODO: the brush is wrong, but without lookuping viewport in game gui, there is no way to know this
+			// TODO: the brush is wrong, but without looking up viewport in game gui, there is no way to know this
 			if (getBrushValue(figure, cx, cy, viewportX + (x / cell_size), viewportY + (y / cell_size), originalX, originalY))
 			{
 				globalContainer->gfx->drawRect(x + (cell_size * cx) + inset, y + (cell_size * cy) + inset, cell_size - inset, cell_size - inset, c);

--- a/src/CampaignMenuScreen.h
+++ b/src/CampaignMenuScreen.h
@@ -30,7 +30,7 @@ private:
 
 	/// Title of the screen
 	Text* title;
-	/// The exit to menuscreen button
+	/// The exit to menu screen button
 	Button* exitButton;
 	/// The "start mission" button
 	Button* startMission;

--- a/src/EndGameScreen.cpp
+++ b/src/EndGameScreen.cpp
@@ -74,7 +74,7 @@ void EndGameStat::paint(void)
 		for (pos=0; pos<game->teams[team]->stats.endOfGameStats.size(); pos++)
 			maxValue = std::max(maxValue, game->teams[team]->stats.endOfGameStats[pos].value[type]);
 
-	///You can't draw anything if the game ended so quickly that there wheren't two recorded values to draw a line between
+	///You can't draw anything if the game ended so quickly that there weren't two recorded values to draw a line between
 	if(game->teams[0]->stats.endOfGameStats.size() >= 2)
 	{
 		//Calculate the number of digits used by the max value when rounded up to the nearest 10

--- a/src/Glob2.cpp
+++ b/src/Glob2.cpp
@@ -630,7 +630,7 @@ int Glob2::run(int argc, char *argv[])
 		}
 	}
 
-	// This is for the textshot code
+	// This is for the text shot code
 	GAGCore::DrawableSurface::printFinishingText();
 	delete globalContainer;
 

--- a/src/Glob2Style.cpp
+++ b/src/Glob2Style.cpp
@@ -106,7 +106,7 @@ void Glob2Style::drawFrame(DrawableSurface *target, int x, int y, int w, int h, 
 		Height of sprites 17, 18 and 19 must be the same
 	*/
 	
-	// save cliprect
+	// save clip rect
 	int ocrX, ocrY, ocrW, ocrH;
 	target->getClipRect(&ocrX, &ocrY, &ocrW, &ocrH);
 	
@@ -130,7 +130,7 @@ void Glob2Style::drawFrame(DrawableSurface *target, int x, int y, int w, int h, 
 		target->drawSprite(x + w - sprite->getW(16), contentY + i, sprite, 16);
 	}
 	
-	// reset cliprect
+	// reset clip rect
 	target->setClipRect(ocrX, ocrY, ocrW, ocrH);
 	
 	// corners
@@ -149,7 +149,7 @@ void Glob2Style::drawScrollBar(GAGCore::DrawableSurface *target, int x, int y, i
 	target->drawSprite(x, y, sprite, 20);
 	target->drawSprite(x, y + h - sprite->getH(22), sprite, 22);
 	
-	// save cliprect
+	// save clip rect
 	int ocrX, ocrY, ocrW, ocrH;
 	target->getClipRect(&ocrX, &ocrY, &ocrW, &ocrH);
 	
@@ -167,7 +167,7 @@ void Glob2Style::drawScrollBar(GAGCore::DrawableSurface *target, int x, int y, i
 	for (int i = 0; i < barForegroundHeight; i += sprite->getH(23))
 		target->drawSprite(x + (sprite->getW(21) - sprite->getW(23)) / 2, barForegroundY + i, sprite, 23);
 	
-	// reset cliprect
+	// reset clip rect
 	target->setClipRect(ocrX, ocrY, ocrW, ocrH);
 }
 
@@ -184,14 +184,14 @@ void Glob2Style::drawProgressBar(GAGCore::DrawableSurface *target, int x, int y,
 	
 	target->drawFilledRect(x, y, w, h, Color(168, 150, 90));
 	
-	// save cliprect
+	// save clip rect
 	int ocrX, ocrY, ocrW, ocrH;
 	target->getClipRect(&ocrX, &ocrY, &ocrW, &ocrH);
 	target->setClipRect(x, y, len, h);
 	for (int i = 0; i < len; i += sprite->getW(24))
 		target->drawSprite(x + i, y, sprite, 24);
 	
-	// reset cliprect
+	// reset clip rect
 	target->setClipRect(ocrX, ocrY, ocrW, ocrH);
 }
 

--- a/src/GlobalContainerArgs.cpp
+++ b/src/GlobalContainerArgs.cpp
@@ -304,8 +304,8 @@ void GlobalContainer::parseArgs(int argc, char *argv[])
 				i++;
 				const char *resStr=&(argv[i][0]);
 				int ix, iy;
-				int nscaned = sscanf(resStr, "%dx%dx", &ix, &iy);
-				if (nscaned == 2)
+				int nScanned = sscanf(resStr, "%dx%dx", &ix, &iy);
+				if (nScanned == 2)
 				{
 					if (ix!=0 && iy!=0)
 					{

--- a/src/MapScript.h
+++ b/src/MapScript.h
@@ -42,7 +42,7 @@ public:
 	///This returns the string representing the mapscript
 	const std::string& getMapScript() const;
 	
-	///This sets the string representing the mapscript
+	///This sets the string representing the map script
 	void setMapScript(const std::string& newScript);
 	
 	///This returns the current map script mode

--- a/src/Order.h
+++ b/src/Order.h
@@ -525,7 +525,7 @@ class MessageOrder:public MiscOrder
 {
 public:
 	MessageOrder() = default;
-	MessageOrder(Uint32 recepientsMask, Uint32 messageOrderType, const char * text);
+	MessageOrder(Uint32 recipientsMask, Uint32 messageOrderType, const char * text);
 	virtual ~MessageOrder(void);
 
 	//! See OrderModifyBuilding::deserialize.
@@ -537,7 +537,7 @@ public:
 	char *getText(void) { return (char *)(data+9); }
 	Uint8 getOrderType(void) { return ORDER_TEXT_MESSAGE; }
 
-	Uint32 recepientsMask;
+	Uint32 recipientsMask;
 	enum MessageOrderType
 	{
 		BAD_MESSAGE_TYPE=0,
@@ -557,7 +557,7 @@ class OrderVoiceData:public MiscOrder
 {
 public:
 	OrderVoiceData() = default;
-	OrderVoiceData(Uint32 recepientsMask, size_t framesDataLength, Uint8 frameCount, const Uint8 *framesData);
+	OrderVoiceData(Uint32 recipientsMask, size_t framesDataLength, Uint8 frameCount, const Uint8 *framesData);
 	virtual ~OrderVoiceData(void);
 
 	//! See OrderModifyBuilding::deserialize.
@@ -570,7 +570,7 @@ public:
 	Uint8 getOrderType(void) { return ORDER_VOICE_DATA; }
 	Uint8 *getFramesData(void) { return data+5; }
 
-	Uint32 recepientsMask;
+	Uint32 recipientsMask;
 	size_t framesDataLength = 0;
 	Uint8 frameCount = 0;
 	Uint8 *data = nullptr;

--- a/src/OrderMisc.cpp
+++ b/src/OrderMisc.cpp
@@ -31,16 +31,16 @@ std::shared_ptr<MessageOrder> MessageOrder::deserialize(const Uint8 *data, int d
 	return order;
 }
 
-MessageOrder::MessageOrder(Uint32 recepientsMask, Uint32 messageOrderType, const char * text)
+MessageOrder::MessageOrder(Uint32 recipientsMask, Uint32 messageOrderType, const char * text)
 {
 	length=Utilities::strmlen(text, ORDER_TEXT_MESSAGE_MAX_LEN)+9;
 	data=(Uint8 *)malloc(length);
 	memcpy(data+9, text, length-9);
 	data[length-1]=0;
-	addUint32(data, recepientsMask, 0);
+	addUint32(data, recipientsMask, 0);
 	addUint32(data, messageOrderType, 4);
 	addUint8(data, (Uint8)(length-9), 8);
-	this->recepientsMask=recepientsMask;
+	this->recipientsMask=recipientsMask;
 	this->messageOrderType=messageOrderType;
 }
 
@@ -60,7 +60,7 @@ bool MessageOrder::setData(const Uint8 *data, int dataLength, Uint32 versionMino
 	if (dataLength<9)
 		return false;
 	this->length=dataLength;
-	this->recepientsMask=getUint32(data, 0);
+	this->recipientsMask=getUint32(data, 0);
 	this->messageOrderType=getUint32(data, 4);
 	Uint8 textLength=getUint8(data, 8);
 	if (this->data!=NULL)
@@ -86,9 +86,9 @@ std::shared_ptr<OrderVoiceData> OrderVoiceData::deserialize(const Uint8 *data, i
 	return order;
 }
 
-OrderVoiceData::OrderVoiceData(Uint32 recepientsMask, size_t framesDataLength, Uint8 frameCount, const Uint8 *framesData)
+OrderVoiceData::OrderVoiceData(Uint32 recipientsMask, size_t framesDataLength, Uint8 frameCount, const Uint8 *framesData)
 {
-	this->recepientsMask = recepientsMask;
+	this->recipientsMask = recipientsMask;
 	this->framesDataLength = framesDataLength;
 	this->frameCount = frameCount;
 
@@ -105,7 +105,7 @@ OrderVoiceData::~OrderVoiceData()
 
 Uint8 *OrderVoiceData::getData(void)
 {
-	addUint32(data, recepientsMask, 0);
+	addUint32(data, recipientsMask, 0);
 	addUint8(data, frameCount, 4);
 	return data;
 }
@@ -116,7 +116,7 @@ bool OrderVoiceData::setData(const Uint8 *data, int dataLength, Uint32 versionMi
 		return false;
 
 	this->framesDataLength = (size_t)dataLength - 5;
-	this->recepientsMask = getUint32(data, 0);
+	this->recipientsMask = getUint32(data, 0);
 	this->frameCount = getUint8(data, 4);
 
 	if (this->data != NULL)

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -32,7 +32,7 @@ public:
 
 	/**
 	 * Sets the password in the Settings object.
-	 * Provided an arbitrary string the password in the settingsobject is set
+	 * Provided an arbitrary string the password in the settings object is set
 	 * to the given value.
 	 * @param s The new password to use.
 	 */

--- a/src/TeamStat.cpp
+++ b/src/TeamStat.cpp
@@ -453,7 +453,7 @@ void TeamStats::drawStat(int posx, int posy)
 		int nbOk, nbNeedFood, nbNeedFoodCritical, nbNeedHeal;
 		if (stats[index].totalUnit)
 		{
-			// to avoid some roundoff errors
+			// to avoid some round-off errors
 			if (stats[index].needNothing>0)
 			{
 				nbNeedHeal=(stats[index].needHeal*64)/stats[index].totalUnit;

--- a/src/ai/AINicowar.h
+++ b/src/ai/AINicowar.h
@@ -140,29 +140,29 @@ public:
 	int upgrading_phase_1_inn_chance = 0;
 	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an hospital
 	int upgrading_phase_1_hospital_chance = 0;
-	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an racetrack
+	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose a racetrack
 	int upgrading_phase_1_racetrack_chance = 0;
 	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an swimming pool
 	int upgrading_phase_1_swimmingpool_chance = 0;
-	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an barracks
+	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose a barracks
 	int upgrading_phase_1_barracks_chance = 0;
-	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an school
+	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose a school
 	int upgrading_phase_1_school_chance = 0;
-	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose an tower
+	///The random chance that, when selecting the type of level 1 building to upgrade, it will choose a tower
 	int upgrading_phase_1_tower_chance = 0;
 	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an inn
 	int upgrading_phase_2_inn_chance = 0;
 	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an hospital
 	int upgrading_phase_2_hospital_chance = 0;
-	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an racetrack
+	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose a racetrack
 	int upgrading_phase_2_racetrack_chance = 0;
 	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an swimming pool
 	int upgrading_phase_2_swimmingpool_chance = 0;
-	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an barracks
+	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose a barracks
 	int upgrading_phase_2_barracks_chance = 0;
-	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an school
+	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose a school
 	int upgrading_phase_2_school_chance = 0;
-	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose an tower
+	///The random chance that, when selecting the type of level 2 building to upgrade, it will choose a tower
 	int upgrading_phase_2_tower_chance = 0;
 	///The number of units to assign to an upgrade for upgrading phase level 1
 	int upgrading_phase_1_units_assigned = 0;

--- a/src/ai/echo/Conditions.h
+++ b/src/ai/echo/Conditions.h
@@ -30,7 +30,7 @@ namespace AIEcho
 
 	///These are all conditions on a particular Building. They are used in several places, such as when counting numbers of buildings, or
 	///for setting a condition on an order to change the number of units assigned, making them very useful. Its important to note that
-	///none of the conditions work on enemies buildings, they only work on buildings on you're own team.
+	///none of the conditions work on enemy buildings, they only work on buildings on your own team.
 	namespace Conditions
 	{
 		///This is used for loading and saving purposes only.
@@ -238,7 +238,7 @@ namespace AIEcho
 		};
 
 		///Similar to BeingUpgraded, but this also takes a level, in which the building is being upgraded
-		///to a particular level. When possible, use this instead od combining BeingUpgraded and BuildingLevel
+		///to a particular level. When possible, use this instead of combining BeingUpgraded and BuildingLevel
 		class BeingUpgradedTo : public BuildingCondition
 		{
 		public:

--- a/src/ai/echo/Construction.h
+++ b/src/ai/echo/Construction.h
@@ -202,7 +202,7 @@ namespace AIEcho
 		};
 
 
-		///This constraint, againt unlike the others, does not use gradients. It only allows the given
+		///This constraint, again unlike the others, does not use gradients. It only allows the given
 		///position to be allowed. The resulting building will *not* be centered on it except if it is
 		///a 1x1 building
 		class SinglePosition : public Constraint

--- a/src/ai/echo/Gradients.h
+++ b/src/ai/echo/Gradients.h
@@ -258,7 +258,7 @@ namespace AIEcho
 
 		///A generic, all purpose gradient. The gradient is referenced by its GradientInfo, which it uses continually in its computation.
 		///Echo gradients are probably the slowest gradients in the game. However, they have one key difference compared to other gradients,
-		///they can be shared, and they are generic, even more so than Nicowar gradients (which where decently generic, but not entirely).
+		///they can be shared, and they are generic, even more so than Nicowar gradients (which were decently generic, but not entirely).
 		class Gradient
 		{
 		public:

--- a/src/ai/echo/Management.h
+++ b/src/ai/echo/Management.h
@@ -59,7 +59,7 @@ namespace AIEcho
 			///checks for the conditions for the management order to execute at all. indeterminate means
 			///that its impossible to execute, false means wait some more and true means ready to execute
 			///For example, the ChangeFlagSize order requires that the building be in existence, and
-			///that its a flag.
+			///that it's a flag.
 			virtual boost::logic::tribool wait(Echo& echo)=0;
 
 			virtual bool load(GAGCore::InputStream *stream, Player *player, Sint32 versionMinor);

--- a/src/ai/nicowar/Buildings.cpp
+++ b/src/ai/nicowar/Buildings.cpp
@@ -326,7 +326,7 @@ int NewNicowar::order_regular_inn(Echo& echo)
 	//Constraints about the distance to water.
 	AIEcho::Gradients::GradientInfo gi_water;
 	gi_water.add_source(new AIEcho::Gradients::Entities::Water);
-	//You dont want to be too close to water, so that farm can develop between it and water
+	//You don't want to be too close to water, so that farm can develop between it and water
 	bo->add_constraint(new AIEcho::Construction::MinimumDistance(gi_water, AI_NICOWAR_INN_WATER_MIN_DIST));
 
 	//Constraints around nearby settlement
@@ -395,7 +395,7 @@ int NewNicowar::order_regular_swarm(Echo& echo)
 	//Constraints about the distance to water.
 	AIEcho::Gradients::GradientInfo gi_water;
 	gi_water.add_source(new AIEcho::Gradients::Entities::Water);
-	//You dont want to be too close to water, so that farm can develop between it and water
+	//You don't want to be too close to water, so that farm can develop between it and water
 	bo->add_constraint(new AIEcho::Construction::MinimumDistance(gi_water, AI_NICOWAR_SWARM_WATER_MIN_DIST));
 
 	//Constraints around nearby settlement

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -169,7 +169,7 @@ public:
 	///of buildings in Team that need units for work, or can have units "inside"
 	void updateCallLists(void);
 	///When a building is waiting for room, this will make sure that the building is in the
-	///Team::buildingsTryToBuildingSiteRoom list. It will also check for hardspace, etc if
+	///Team::buildingsTryToBuildingSiteRoom list. It will also check for hard space, etc if
 	///resources grow into the space or a building is placed, it becomes impossible
 	///to upgrade and the construction is cancelled.
 	void updateConstructionState(void);
@@ -206,7 +206,7 @@ public:
 	///It is considered greedy, hiring as many units as it needs in order of its preference
 	///Returns true if a unit was hired
 	bool subscribeToBringResourcesStep(void);
-	///This function subscribes any flag that needs units for a with units.
+	///This function subscribes any flag that needs units.
 	///It is considered greedy, hiring as many units as it needs in order of its preference
 	///Returns true if a unit was hired
 	bool subscribeForFlagingStep();

--- a/src/building/Update.cpp
+++ b/src/building/Update.cpp
@@ -407,17 +407,17 @@ bool Building::isHardSpaceForBuildingSite(void)
 
 bool Building::isHardSpaceForBuildingSite(ConstructionResultState requestedState)
 {
-	int tltn=BUILDING_LEVEL_NONE;
+	int futureBuildingTypeId=BUILDING_LEVEL_NONE;
 	if (requestedState==UPGRADE)
-		tltn=type->nextLevel;
+		futureBuildingTypeId=type->nextLevel;
 	else if (requestedState==REPAIR)
-		tltn=type->prevLevel;
+		futureBuildingTypeId=type->prevLevel;
 	else
 		assert(false);
 
-	if (tltn==BUILDING_LEVEL_NONE)
+	if (futureBuildingTypeId==BUILDING_LEVEL_NONE)
 		return true;
-	BuildingType *bt=globalContainer->buildingsTypes.get(tltn);
+	BuildingType *bt=globalContainer->buildingsTypes.get(futureBuildingTypeId);
 	int x=posX+bt->decLeft-type->decLeft;
 	int y=posY+bt->decTop -type->decTop ;
 	int w=bt->width;

--- a/src/gui/GameGUIInternal.h
+++ b/src/gui/GameGUIInternal.h
@@ -20,7 +20,7 @@ using namespace GAGGUI;
 #define TYPING_INPUT_BASE_INC 7
 #define TYPING_INPUT_MAX_POS 46
 
-// these values are manually layouted for cuteste perception
+// These values are manually laid out for readability.
 #define YPOS_BASE_DEFAULT 180
 #define YPOS_BASE_CONSTRUCTION (YPOS_BASE_DEFAULT + 5)
 #define YPOS_BASE_FLAG (YPOS_BASE_DEFAULT + 5)

--- a/src/gui/GameGUIOrders.cpp
+++ b/src/gui/GameGUIOrders.cpp
@@ -132,12 +132,12 @@ void GameGUI::executeOrder(std::shared_ptr<Order> order)
 
 			if (messageOrderType==MessageOrder::NORMAL_MESSAGE_TYPE)
 			{
-				if (mo->recepientsMask &(1<<localPlayer))
+				if (mo->recipientsMask &(1<<localPlayer))
 					addMessage(Color(230, 230, 230), FormattableString("%0 : %1").arg(game.players[sp]->name).arg(mo->getText()), true);
 			}
 			else if (messageOrderType==MessageOrder::PRIVATE_MESSAGE_TYPE)
 			{
-				if (mo->recepientsMask &(1<<localPlayer))
+				if (mo->recipientsMask &(1<<localPlayer))
 					addMessage(Color(99, 255, 242), FormattableString("<%0%1> %2").arg(Toolkit::getStringTable()->getString("[from:]")).arg(game.players[sp]->name).arg(mo->getText()), true);
 				else if (sp==localPlayer)
 				{
@@ -145,7 +145,7 @@ void GameGUI::executeOrder(std::shared_ptr<Order> order)
 					// mask can carry several recipients, so iterate every set
 					// bit; messageRecipientPlayers drops any bit outside the
 					// live player range instead of indexing an empty slot.
-					for (int k : messageRecipientPlayers(mo->recepientsMask, game.gameHeader.getNumberOfPlayers()))
+					for (int k : messageRecipientPlayers(mo->recipientsMask, game.gameHeader.getNumberOfPlayers()))
 						addMessage(Color(99, 255, 242), FormattableString("<%0%1> %2").arg(Toolkit::getStringTable()->getString("[to:]")).arg(game.players[k]->name).arg(mo->getText()), true);
 				}
 			}
@@ -158,7 +158,7 @@ void GameGUI::executeOrder(std::shared_ptr<Order> order)
 		case ORDER_VOICE_DATA:
 		{
 			std::shared_ptr<OrderVoiceData> ov = static_pointer_cast<OrderVoiceData>(order);
-			if (ov->recepientsMask & (1<<localPlayer))
+			if (ov->recipientsMask & (1<<localPlayer))
 				globalContainer->mix->addVoiceData(ov);
 			game.executeOrder(order, localPlayer);
 		}

--- a/src/gui/GameGUIStep.cpp
+++ b/src/gui/GameGUIStep.cpp
@@ -113,7 +113,7 @@ void GameGUI::step(void)
 	bool wasMouseMotion=false;
 	bool wasWindowEvent=false;
 	int oldMouseMapX = -1, oldMouseMapY = -1; // hopefully the values here will never matter
-	// we get all pending events but for mousemotion we only keep the last one
+	// we get all pending events but for mouse motion we only keep the last one
 	while (SDL_PollEvent(&event))
 	{
 		GAGCore::GraphicContext::translateMouseEvent(&event);
@@ -245,7 +245,7 @@ void GameGUI::step(void)
 	std::shared_ptr<OrderVoiceData> orderVoiceData;
 	while ((orderVoiceData = globalContainer->voiceRecorder->getNextOrder()) != NULL)
 	{
-		orderVoiceData->recepientsMask = chatMask ^ (chatMask & (1<<localPlayer));
+		orderVoiceData->recipientsMask = chatMask ^ (chatMask & (1<<localPlayer));
 		orderQueue.push_back(orderVoiceData);
 	}
 

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -566,7 +566,7 @@ public:
 	void mapCaseToPixelCase(int mx, int my, int *px, int *py) const { *px=(mx<<5); *py=(my<<5); }
 	//! Transform coordinate from map (mx,my) to screen (px,py). Use this one to display a building or an unit to the screen.
 	void mapCaseToDisplayable(int mx, int my, int *px, int *py, int viewportX, int viewportY) const;
-	//! Transform coordinate from map (mx,my) to screen (px,py). Use this one to display a pathline to the screen.
+	//! Transform coordinate from map (mx,my) to screen (px,py). Use this one to display a path line to the screen.
 	void mapCaseToDisplayableVector(int mx, int my, int *px, int *py, int viewportX, int viewportY, int screenW, int screenH) const;
 	//! Transform coordinate from screen (mx,my) to map (px,py) for standard grid aligned object (buildings, resources, units)
 	void displayToMapCaseAligned(int mx, int my, int *px, int *py, int viewportX, int viewportY) const;

--- a/src/map/edit/MapEditIO.cpp
+++ b/src/map/edit/MapEditIO.cpp
@@ -137,7 +137,7 @@ int MapEdit::run(void)
 	{
 		startTick=SDL_GetTicks64();
 	
-		// we get all pending events but for mousemotion we only keep the last one
+		// we get all pending events but for mouse motion we only keep the last one
 		SDL_Event event;
 		while (SDL_PollEvent(&event))
 		{

--- a/src/map/generator/MapRandom.cpp
+++ b/src/map/generator/MapRandom.cpp
@@ -11,7 +11,7 @@
 #include "MapGenerationDescriptor.h"
 #include "Map.h"
 
-/// This random map generator generates a heightfield and then choses levels at which to draw the line between water, sand, gras and sand again (desert)
+/// This random map generator generates a height field and then chooses levels separating water, sand, grass, and desert.
 bool Map::makeRandomMap(MapGenerationDescriptor &descriptor)
 {
 	/// all under waterLevel is water, under sandLevel is beach, under grassLevel is grass and above grasslevel is desert
@@ -249,7 +249,7 @@ bool Map::makeRandomMap(MapGenerationDescriptor &descriptor)
 	//TODO: count of groves(=descriptor.fruitRatio) does not scale with mapsize.
 	//so it has to be adjusted higher on bigger maps now.
 
-	// in mapgeneration syncRand is not needed. In earlier versions we assumed
+	// in map generation syncRand is not needed. In earlier versions we assumed
 	// to profit from sharing only the generation seeds for common random maps.
 	// this assumption was dropped in favour of easier code.
 

--- a/src/map/gradient/MapGradientBuilding.cpp
+++ b/src/map/gradient/MapGradientBuilding.cpp
@@ -100,7 +100,7 @@ void Map::updateGlobalGradient(Building *building, int swimClass)
 			{
 				if (c.building==bgid)
 					gradient[wyx] = GRADIENT_AT_GOAL;
-				//Warflags don't consider enemy buildings an obstacle
+				//War flags don't consider enemy buildings an obstacle
 				else if(!isWarFlag || (1<<Building::GIDtoTeam(c.building)) & (building->owner->allies))
 					gradient[wyx] = GRADIENT_FORBIDDEN;
 				else if(gradient[wyx]!=GRADIENT_AT_GOAL)

--- a/src/net/irc/IRC.h
+++ b/src/net/irc/IRC.h
@@ -105,7 +105,7 @@ public:
 	// CONNECTION
 	//! Connect to YOG server (IRC network), return true on success
 	bool connect(const std::string &serverName, int serverPort, const std::string &nick);
-	//! Try to disconnect from server in a cleany way
+	//! Try to disconnect from the server cleanly
 	bool disconnect(void);
 
 	// RUN

--- a/src/net/message/MessageRecipients.cpp
+++ b/src/net/message/MessageRecipients.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "MessageRecipients.h"
 
-std::vector<int> messageRecipientPlayers(std::uint32_t recepientsMask, int numberOfPlayers)
+std::vector<int> messageRecipientPlayers(std::uint32_t recipientsMask, int numberOfPlayers)
 {
 	std::vector<int> recipients;
 	if (numberOfPlayers <= 0)
@@ -10,7 +10,7 @@ std::vector<int> messageRecipientPlayers(std::uint32_t recepientsMask, int numbe
 	// The mask is 32 bits wide, so no bit beyond position 31 can ever be set.
 	const int slotCount = numberOfPlayers < 32 ? numberOfPlayers : 32;
 	for (int player = 0; player < slotCount; ++player)
-		if (recepientsMask & (std::uint32_t(1) << player))
+		if (recipientsMask & (std::uint32_t(1) << player))
 			recipients.push_back(player);
 
 	return recipients;

--- a/src/net/message/MessageRecipients.h
+++ b/src/net/message/MessageRecipients.h
@@ -7,7 +7,7 @@
 /// Expands a player-indexed recipient bitmask into the list of targeted player
 /// indices, in strictly ascending order.
 ///
-/// Bit `p` set in `recepientsMask` means "player `p` is a recipient". The mask
+/// Bit `p` set in `recipientsMask` means "player `p` is a recipient". The mask
 /// arrives unvalidated over the network (see MessageOrder), so any bit at or
 /// beyond `numberOfPlayers` is silently dropped rather than trusted — every
 /// returned index is a live slot the caller can safely use to index the
@@ -17,4 +17,4 @@
 /// `numberOfPlayers` is the count of live player slots
 /// (GameHeader::getNumberOfPlayers()); values <= 0 yield an empty result, and
 /// values above 32 are capped since the mask only carries 32 bits.
-std::vector<int> messageRecipientPlayers(std::uint32_t recepientsMask, int numberOfPlayers);
+std::vector<int> messageRecipientPlayers(std::uint32_t recipientsMask, int numberOfPlayers);

--- a/src/render/GameRenderOverlay.cpp
+++ b/src/render/GameRenderOverlay.cpp
@@ -117,7 +117,7 @@ void Game::drawMapFogOfWar(int left, int top, int right, int bot, int sw, int sh
 {
 	if ((drawOptions & DRAW_WHOLE_MAP) == 0)
 	{
-		// we have decrease on because we do unalign lookup
+		// we have decrease on because we do unaligned lookup
 		for (int y=top-1; y<=bot; y++)
 			for (int x=left-1; x<=right; x++)
 			{

--- a/src/team/TeamSerialization.cpp
+++ b/src/team/TeamSerialization.cpp
@@ -14,7 +14,7 @@ bool Team::load(GAGCore::InputStream *stream, BuildingsTypes *buildingstypes, Si
 	assert(buildingsToBeDestroyed.size()==0);
 	buildingsTryToBuildingSiteRoom.clear();
 
-	// loading baseteam
+	// loading base team
 	if(!BaseTeam::load(stream, versionMinor))
 		return false;
 
@@ -153,7 +153,7 @@ bool Team::load(GAGCore::InputStream *stream, BuildingsTypes *buildingstypes, Si
 
 void Team::save(GAGCore::OutputStream *stream)
 {
-	// saving baseteam
+	// saving base team
 	BaseTeam::save(stream);
 
 	stream->writeEnterSection("Team");

--- a/src/yog/YOGServerChatChannelManager.h
+++ b/src/yog/YOGServerChatChannelManager.h
@@ -9,7 +9,7 @@
 
 class YOGServerChatChannel;
 
-///This does serverside management of YOG chat channels
+///This does server-side management of YOG chat channels
 class YOGServerChatChannelManager
 {
 public:


### PR DESCRIPTION
Correct the remaining `recepientsMask` and `nscaned` spellings, give the placeholder-parser flag and future building type descriptive names, name the memory stream's storage `buffer`, and recover comment corrections from Stéphane Magnenat's #85 against the reorganized source tree.

The buffer name avoids shadowing existing `data` parameters. All string literals, serialized keys/section names, translation keys, script names, and filenames remain unchanged. No gameplay or serialization changes are intended.

Validation:
- Lexical comparison confirms only the documented identifier substitutions outside comments, with every string/character literal preserved.
- macOS release client and server builds pass with both replacement patches applied together to master 88934ecfb.
- All 16 existing test executables pass on that combined code, including TestsRunner's 170 tests and replay/network/text-serialization tests.
- G2, playground-8numbi, gd-archipelago, and gd-bigarena-long: 15,000 ticks each, before/after replay bytes and every per-tick checksum identical (60,000 ticks per version).
- Each PR also runs its own Linux/Windows CI; see checks below.

Companion PR: #199

This complements the map terminology patch and Kyle's already-landed cb7856eaa. The original broad casing-only sweep is intentionally omitted. Recovered changes credit Stéphane as co-author.
