### PR TITLE
Fix duplicate-env scons warning for team-stats-save-test

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -465,7 +465,9 @@ source_files.append("../libusl/src/libusl.a")
 p1 = local.Program("glob2", source_files)
 
 if not env['server']:
-    stats_sources = [source for source in source_files if source != 'Glob2.cpp']
+    # Compile with local, not stats_env, to avoid rebuilding shared objects under a second environment.
+    stats_sources = local.Object([source for source in source_files if source != 'Glob2.cpp' and source.endswith('.cpp')])
+    stats_sources += [source for source in source_files if not source.endswith('.cpp')]
     stats_sources += local.Object('TeamStatsSaveHarness.o', '#test/TeamStatsSaveHarness.cpp')
     stats_env = local.Clone()
     stats_env['LINKFLAGS'] = [flag for flag in local.Split(local['LINKFLAGS']) if flag != '-mwindows']


### PR DESCRIPTION
`stats_env` (a `.Clone()` of `local` with tweaked `LINKFLAGS`/`LIBS`) was being handed the raw `source_files` list for the TeamStatsSaveHarness build — the same anti-pattern #172 fixed for `savegame_env`. Since most of those objects are also built by `local.Program()` elsewhere in this file, scons registers two different `Environment` instances against the same target and warns `Two different environments were specified for target ...` once per shared file (e.g. `ai/castor/Control.o`, `GetOrder.o`, `Lifecycle.o`) on every build.

Fix: compile the shared sources through `local.Object()` first (same as the `savegame_env` fix in #172) and only apply `stats_env` at the link step, where the LINKFLAGS/LIBS override actually matters.

Verified locally: clean `scons release=1 -j20` and `scons release=1 -j20 team-stats-save-test` both build with zero `Two different environments` warnings.