### PR TITLE
Follow the round-trip gradient for the resource-fetch target too

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -542,3 +542,10 @@ if not env['server']:
     regression_sources += local.Object('EnteringUnitSaveHarness.o', '#test/EnteringUnitSaveHarness.cpp')
     regression_test = local.Program('EnteringUnitSaveHarness', regression_sources)
     local.Alias('entering-unit-save-test', regression_test)
+
+# Real engine regression for resource-fetch target staleness, built only by its explicit target.
+if not env['server']:
+    regression_sources = [source for source in source_files if source != 'Glob2.cpp']
+    regression_sources += local.Object('ResourceFetchTargetHarness.o', '#test/ResourceFetchTargetHarness.cpp')
+    regression_test = local.Program('ResourceFetchTargetHarness', regression_sources)
+    local.Alias('resource-fetch-target-test', regression_test)

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -615,7 +615,12 @@ public:
 	//! on the AIs' Uint8 maps alike: the goal is the maximum of the element type.
 	template<typename T>
 	bool getGlobalGradientDestination(const T *gradient, int x, int y, Sint32 *targetX, Sint32 *targetY) const;
-	
+	//! Whether (x, y) is a local maximum of gradient: no neighbour holds a strictly higher
+	//! value. True at any tile getGlobalGradientDestination's ascent could end on, including
+	//! gradients like a round-trip field whose seeded goal is a finite cost, not the type's max.
+	template<typename T>
+	bool isGradientPeak(const T *gradient, int x, int y) const;
+
 	Uint16 getGradient(int teamNumber, Uint8 resourceType, int swimClass, int x, int y)
 	{
 		return getResourceGradient(teamNumber, resourceType, swimClass)[coordToIndex(x, y)];

--- a/src/map/MapResources.cpp
+++ b/src/map/MapResources.cpp
@@ -252,6 +252,26 @@ bool Map::getGlobalGradientDestination(const T *gradient, int x, int y, Sint32 *
 template bool Map::getGlobalGradientDestination<Uint8>(const Uint8 *gradient, int x, int y, Sint32 *targetX, Sint32 *targetY) const;
 template bool Map::getGlobalGradientDestination<Uint16>(const Uint16 *gradient, int x, int y, Sint32 *targetX, Sint32 *targetY) const;
 
+template<typename T>
+bool Map::isGradientPeak(const T *gradient, int x, int y) const
+{
+	// A round-trip gradient's goal is seeded at a finite cost, not the type's
+	// max the way GRADIENT_AT_GOAL is, so getGlobalGradientDestination's own
+	// "reached exact goal" check does not generalize to it. This is the
+	// weaker, gradient-agnostic property an ascent target actually needs:
+	// no neighbour holds a strictly higher value, so an ascent from anywhere
+	// nearby would still stop here.
+	size_t index = coordToIndex(x, y);
+	T here = gradient[index];
+	for (int d=0; d<8; d++)
+		if (gradient[coordToIndex(x+deltaOne[d][0], y+deltaOne[d][1])]>here)
+			return false;
+	return true;
+}
+
+template bool Map::isGradientPeak<Uint8>(const Uint8 *gradient, int x, int y) const;
+template bool Map::isGradientPeak<Uint16>(const Uint16 *gradient, int x, int y) const;
+
 
 /*
 This was the old way. I was much more complex but reliable with partially broken gradients. Let's keep it for now in case of such type of gradient reappears

--- a/src/unit/UnitMovement.cpp
+++ b/src/unit/UnitMovement.cpp
@@ -557,11 +557,27 @@ void Unit::handleMovementGoingToResource()
 {
 	Map *map=owner->map;
 	int teamNumber=owner->teamNumber;
+	int swim=swimClass();
 	bool stopWork;
-	if (map->pathfindResource(teamNumber, destinationPurpose, swimClass(), posX, posY, &dx, &dy, &stopWork, attachedBuilding))
+	if (map->pathfindResource(teamNumber, destinationPurpose, swim, posX, posY, &dx, &dy, &stopWork, attachedBuilding))
 	{
 		directionFromDxDy();
 		movement=MOV_GOING_DX_DY;
+		// targetX/Y (also the debug path line, hotkey T) were set once, by
+		// ascending a gradient, when the fetch task started. pathfindResource
+		// above re-reads whichever gradient actually governs the step fresh
+		// every action -- the round-trip field when attachedBuilding has one
+		// and it is valid here, the plain resource gradient otherwise -- and
+		// either field can be rebuilt, or the preference between them can
+		// flip, while the unit is still walking. Re-ascend from here whenever
+		// the stored target has stopped being a peak of that same gradient;
+		// isGradientPeak is a cheap check to run every action, the ascent
+		// itself only when it actually goes stale.
+		const Uint16 *roundTrip = attachedBuilding ? map->roundTripGradient(attachedBuilding, destinationPurpose, swim) : NULL;
+		const Uint16 *gradient = (roundTrip && roundTrip[map->coordToIndex(posX, posY)]>GRADIENT_UNREACHABLE)
+			? roundTrip : map->getResourceGradient(teamNumber, destinationPurpose, swim);
+		if (!map->isGradientPeak(gradient, targetX, targetY))
+			map->getGlobalGradientDestination(gradient, posX, posY, &targetX, &targetY);
 	}
 	else
 	{

--- a/test/ResourceFetchTargetHarness.cpp
+++ b/test/ResourceFetchTargetHarness.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-engine regression: a resource-fetch target must track whichever
+// gradient (round-trip or plain) a walking unit actually follows.
+#include "GlobalContainer.h"
+#include "Game.h"
+#include "GameGUI.h"
+#include "Unit.h"
+#include "Team.h"
+#include "Building.h"
+#include "MapInternal.h"
+#include "Race.h"
+#include "Ressource.h"
+#include "IntBuildingType.h"
+#include <cstdio>
+#include <cstdlib>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+	if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+// handleMovementGoingToResource() is protected; a subclass gets access the
+// same way test/README.md's Map subclass pattern does for Map predicates.
+struct TestUnit : Unit
+{
+	TestUnit(int x, int y, Uint16 gid, Sint32 typeNum, Team *team, int level)
+		: Unit(x, y, gid, typeNum, team, level) {}
+	void stepGoingToResource() { handleMovementGoingToResource(); }
+};
+
+// targetX/Y (also the debug path line, hotkey T) are set once, by ascending
+// a gradient, when a fetch task starts (Unit.cpp, UnitDisplacement.cpp).
+// pathfindResource (UnitMovement.cpp) re-reads whichever gradient actually
+// governs the unit's step fresh every action instead -- the building's
+// round-trip field when it minimises fetch-plus-carry, the plain resource
+// gradient otherwise -- and either field can be rebuilt, or the preference
+// between them can flip, while the unit is still walking.
+static void targetTracksTheGradientTheUnitActuallyFollows()
+{
+	GameGUI gui;
+	Game& game = gui.game;
+	game.map.setSize(5, 5, GRASS); // 32x32
+	game.map.setGame(&game);
+	// setSize leaves immobileUnits[] zeroed, not IMMOBILE_UNIT_NONE (255), so
+	// every cell reads as immobile-unit-occupied until cleared; a real game
+	// never observes this because something else sweeps it first.
+	for (int y = 0; y < game.map.getH(); ++y)
+		for (int x = 0; x < game.map.getW(); ++x)
+			game.map.clearImmobileUnit(x, y);
+	game.addTeam(0);
+	Team* team = game.teams[0];
+	const int teamNumber = team->teamNumber;
+	const int innType = globalContainer->buildingsTypes.getTypeNum("inn", 0, false);
+	require(innType >= 0, "inn type exists");
+	Building* inn = game.addBuilding(5, 5, innType, 0);
+	require(inn != nullptr, "inn placed");
+	game.map.setBuilding(5, 5, inn->type->width, inn->type->height, inn->gid);
+
+	const int unitX = 16, unitY = 16;
+	// A is close to the unit but a long carry from the building; B is a
+	// longer fetch but a short carry, so the round trip through B is
+	// cheaper even though A is the nearer tile to ascend to from the unit.
+	const int nearUnitX = 20, nearUnitY = 16;
+	const int nearBuildingX = 7, nearBuildingY = 7;
+	require(game.map.incResource(nearUnitX, nearUnitY, CORN, 0), "seed the tile near the unit");
+	require(game.map.incResource(nearBuildingX, nearBuildingY, CORN, 0), "seed the tile near the building");
+
+	TestUnit* unit = new TestUnit(unitX, unitY, 0, WORKER, team, 0);
+	team->myUnits[0] = unit;
+	game.map.setGroundUnit(unitX, unitY, unit->gid);
+	unit->attachedBuilding = inn;
+	unit->destinationPurpose = CORN;
+	unit->activity = Unit::ACT_FILLING;
+	unit->displacement = Unit::DIS_GOING_TO_RESOURCE;
+	unit->validTarget = true;
+	const int swimClass = unit->swimClass();
+
+	require(game.map.getGlobalGradientDestination(game.map.getResourceGradient(teamNumber, CORN, swimClass), unit->posX, unit->posY, &unit->targetX, &unit->targetY),
+		"sanity: ascending the plain gradient reaches an exact goal");
+	require(unit->targetX == nearUnitX && unit->targetY == nearUnitY,
+		"sanity: the plain gradient's nearest tile is the one close to the unit, not the building");
+
+	// One action: pathfindResource builds and prefers the round-trip field,
+	// so the unit steps toward the tile that is cheaper to fetch and carry,
+	// and the target must follow it, not the plain gradient's nearer tile.
+	unit->stepGoingToResource();
+	require(unit->targetX == nearBuildingX && unit->targetY == nearBuildingY,
+		"target follows the round-trip gradient's cheaper tile, not the nearest one to the unit");
+
+	// Another action while nothing changed: the target must hold steady.
+	unit->stepGoingToResource();
+	require(unit->targetX == nearBuildingX && unit->targetY == nearBuildingY,
+		"target holds steady while still valid");
+
+	// The near-building tile gets fully harvested by someone else. Neither
+	// the resource gradient nor the round-trip field notice by themselves.
+	game.map.getCase(nearBuildingX, nearBuildingY).resource.clear();
+	game.map.updateResourcesGradient(teamNumber, CORN, swimClass);
+	game.map.updateRoundTripGradient(inn, CORN, swimClass);
+
+	// Next action: only the near-unit tile is left on either gradient: the
+	// target must be refreshed to it.
+	unit->stepGoingToResource();
+	require(unit->targetX == nearUnitX && unit->targetY == nearUnitY,
+		"target is refreshed to the only remaining corn tile");
+
+	std::puts("PASS resource-fetch target tracks the round-trip gradient and refreshes when it is rebuilt");
+}
+
+int main()
+{
+	GlobalContainer globals;
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+	targetTracksTheGradientTheUnitActuallyFollows();
+	std::puts("Resource fetch target regressions passed");
+	return 0;
+}


### PR DESCRIPTION
Companion to #209 (the same class of bug, ported and extended for this branch's round-trip gradients).

targetX/Y for a fetch task (also the debug path line, hotkey T) are set once, by ascending the plain resource gradient, when the task starts. `pathfindResource` re-reads whichever gradient actually governs the per-tick step -- the round-trip field when `attachedBuilding` has one and it is valid here, the plain resource gradient otherwise -- and either field can be rebuilt, or the preference between them can flip, while the unit is still walking. The stored target never tracked either change, so the debug line and the range checks that read targetX/Y could point at the nearest tile to the unit while the unit actually walked toward the cheaper round trip through a farther one -- exactly the mismatch reported in channel.

Adds `Map::isGradientPeak`: whether a tile is a local maximum of a gradient, true anywhere `getGlobalGradientDestination`'s ascent could end, including a round-trip field whose seeded goal is a finite cost rather than the type's max the way `GRADIENT_AT_GOAL` is (so its own "reached exact goal" check does not generalize to it). `handleMovementGoingToResource` now resolves the same gradient `pathfindResource` prefers and re-ascends from the unit's position whenever the stored target stops being a peak of it -- a cheap check every action, the ascent itself only when it actually goes stale.

New `ResourceFetchTargetHarness` (wired as the `resource-fetch-target-test` scons alias) seeds a tile close to the unit but far from the building and one far from the unit but close to it, confirms the target follows the cheaper round trip rather than the nearer tile, and that it refreshes once that tile is harvested away. Confirmed it fails without the fix. Full `test/TestsRunner` suite (169 tests) passes; `scons release=1` and `scons release=1 server=1` build clean.

Sonnet helped authoring this commit.