### PR TITLE
Bump map, network and replay versions for the pathfinding change

### DIFF
--- a/src/ReplayReader.cpp
+++ b/src/ReplayReader.cpp
@@ -21,7 +21,6 @@ ReplayReader::ReplayReader()
 	ordersProcessed = 0;
 	numOrders = 0;
 	stepsUntilNextOrder = -1;
-	wideStepCounter = false;
 	versionMinor = VERSION_MINOR;
 	checksum = 0;
 }
@@ -87,9 +86,6 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 		return false;
 	}
 
-	// Replays written before version 87 store step counters as Uint16
-	wideStepCounter = (version_minor >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR);
-
 	versionMinor = version_minor;
 
 	// If there are no orders, this is also not a valid replay (there should be at least a NullOrder)
@@ -108,7 +104,7 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 	std::shared_ptr<Order> order;
 	numSteps = 0;
 	numOrders = 0;
-	stepsUntilNextOrder = readStepCounter();
+	stepsUntilNextOrder = stream->readUint32("replayStepCounter");
 	do
 	{
 		try
@@ -146,7 +142,7 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 		// If it was a real order, read and increase numSteps accordingly
 		if (order->getOrderType() != ORDER_NULL)
 		{
-			stepsUntilNextOrder = readStepCounter();
+			stepsUntilNextOrder = stream->readUint32("replayStepCounter");
 		}
 	}
 	while (order->getOrderType() != ORDER_NULL);
@@ -155,7 +151,7 @@ bool ReplayReader::loadReplay(GAGCore::InputStream *inputStream, bool skipToOrde
 	stream->seekFromStart(pos);
 	
 	// Read the number of steps until the first order
-	stepsUntilNextOrder = readStepCounter();
+	stepsUntilNextOrder = stream->readUint32("replayStepCounter");
 
 	// If we get to this point, the replay file should be valid
 	assert(isValid());
@@ -248,16 +244,8 @@ std::shared_ptr<Order> ReplayReader::retrieveOrder()
 	ordersProcessed++;
 
 	// Read the number of steps until the next order, if there is one
-	if (order->getOrderType() != ORDER_NULL) stepsUntilNextOrder = readStepCounter();
+	if (order->getOrderType() != ORDER_NULL) stepsUntilNextOrder = stream->readUint32("replayStepCounter");
 	else assert(ordersProcessed >= numOrders && currentStep >= numSteps);
 
 	return order;
-}
-
-Uint32 ReplayReader::readStepCounter()
-{
-	if (wideStepCounter)
-		return stream->readUint32("replayStepCounter");
-	else
-		return stream->readUint16("replayStepCounter");
 }

--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -22,13 +22,10 @@ class Order;
 static constexpr Uint32 REPLAY_MIN_VALID_ORDERS = 5;
 
 //! Oldest replay format (the VERSION_MINOR the replay was written with) that
-//! the reader still accepts. Replays older than this are rejected.
-static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 86;
-
-//! Replays written at this VERSION_MINOR or later store the inter-order step
-//! counter as Uint32. Older replays used Uint16, which silently wrapped after
-//! 65535 order-less steps (~44 minutes without an order).
-static constexpr Uint16 REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR = 87;
+//! the reader still accepts. Replays older than this are rejected: version 90
+//! changed the simulation (weighted pathfinding, diagonal timing), so earlier
+//! replays would diverge from what happened.
+static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 90;
 
 /// This class is used for reading replays.
 /// The replay stream is kept open and read every time you do retrieveOrder.
@@ -85,10 +82,6 @@ private:
 	/// You shouldn't use assignment on this class
 	void operator=(const ReplayReader &reader) { assert(false); };
 
-	/// Reads an inter-order step counter from the stream, honouring the
-	/// width used by the replay's format version (see wideStepCounter).
-	Uint32 readStepCounter();
-
 	/// The stream it reads the replay from
 	GAGCore::InputStream *stream;
 
@@ -106,10 +99,6 @@ private:
 
 	/// The number of steps until the next order
 	Uint32 stepsUntilNextOrder;
-
-	/// True if the loaded replay stores step counters as Uint32
-	/// (format version >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR)
-	bool wideStepCounter;
 
 	/// Format version from the replay header, used to decode orders.
 	Uint32 versionMinor;

--- a/src/Version.h
+++ b/src/Version.h
@@ -6,7 +6,7 @@
 // This is the version of map and savegame format, and all of the recorded data on the server
 #define VERSION_MAJOR 0
 #define MINIMUM_VERSION_MINOR 58
-#define VERSION_MINOR 89
+#define VERSION_MINOR 90
 // version 10 adds script saved in game
 // version 11 the gamesfiles do saves which building has been seen under fog of war.
 // version 12 saves map name into SessionGame instead of BaseMap.
@@ -91,12 +91,14 @@
 // version 87 widened the replay inter-order step counter from Uint16 to Uint32
 // version 88 added the per-team Map::exploredArea to saved games
 // version 89 preserves live team statistics and their sampling cadence
+// version 90 marks the weighted per-swim-class pathfinding and sqrt(2) diagonal timing (#184):
+//            the simulation changed, so replays recorded before it diverge and are refused
 
 //This must be updated when there are changes to YOG, MapHeader, GameHeader, BasePlayer, BaseTeam,
 //NetMessage, and the likes, in parallel to change of the VERSION_MINOR above
-#define NET_PROTOCOL_VERSION 28
+#define NET_PROTOCOL_VERSION 29
 //Clients with older versions than this will be rejected
-#define YOG_MIN_CLIENT_NET_PROTOCOL_VERSION 27
+#define YOG_MIN_CLIENT_NET_PROTOCOL_VERSION 29
 // version 21 changed OrderModifyWarFlag to more generic OrderModifyMinLevelToFlag
 // version 22 added ConfigCheckSum to check if all use has the same file config.
 // version 23 updated to allow custom prestige settings
@@ -105,4 +107,5 @@
 // version 26 changed heavy updates to YOG in general
 // version 27 reordered the NetMessages so that reverse compatibility with future game versions can be done, added random seed in GameHeader
 // version 28 Nicowar's behavior was changed
+// version 29 the pathfinding simulation changed (#184); older clients would desync, so they are refused
 

--- a/test/ReplayStepCounterTest.cpp
+++ b/test/ReplayStepCounterTest.cpp
@@ -5,17 +5,16 @@
 // writeUint16, so after 65535 order-less ticks (~44 minutes at 25 Hz — routine
 // in sparse AI runs and the 90000-tick trainer games) the counter silently
 // wrapped, corrupting the tick-to-order alignment on read-back. Post-fix the
-// counter is Uint32 on both sides, gated on the replay's VERSION_MINOR:
-// replays written at REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR (87) or later
-// read Uint32, older ones still read Uint16.
+// counter is Uint32 on both sides. (Replays from before that fix are below
+// REPLAY_MINIMUM_VERSION_MINOR and no longer load at all.)
 //
 // Covered here:
 //   1. writer/reader round-trip with >65535 quiet steps between orders — the
 //      read-back step delta is exact (would have wrapped to delta % 65536)
-//   2. a hand-written pre-87 (version 86) stream with Uint16 counters still
-//      parses correctly through the gated read
-//   3. version floor/ceiling: replays older than REPLAY_MINIMUM_VERSION_MINOR
+//   2. version floor/ceiling: replays older than REPLAY_MINIMUM_VERSION_MINOR
 //      or newer than the running build are rejected
+//   3. the replay header version, not VERSION_MINOR, is what orders are
+//      decoded against
 //
 // GameGUI and the Order hierarchy are stubbed (same trick as
 // NetSendOrderDecodeTest.cpp) so only ReplayWriter/ReplayReader plus
@@ -192,11 +191,11 @@ void testWideRoundTrip()
 }
 
 // Hand-write a replay body (no game header) at the given version, with the
-// step counters written at the given width. Returns an input stream over a
+// Uint32 step counters. Returns an input stream over a
 // copy of the written bytes (BinaryOutputStream deletes its backend on
 // destruction, so the copy is taken while it is still alive); the caller
 // passes ownership to ReplayReader::loadReplay.
-BinaryInputStream* writeReplayBody(Uint16 versionMinor, bool wideCounters, Uint32 firstCounter)
+BinaryInputStream* writeReplayBody(Uint16 versionMinor, Uint32 firstCounter)
 {
 	MemoryStreamBackend* writeBackend = new MemoryStreamBackend;
 	MemoryStreamBackend* readBackend = nullptr;
@@ -204,15 +203,9 @@ BinaryInputStream* writeReplayBody(Uint16 versionMinor, bool wideCounters, Uint3
 		BinaryOutputStream ostream(writeBackend);
 		ostream.writeUint16(VERSION_MAJOR, "versionMajor");
 		ostream.writeUint16(versionMinor, "versionMinor");
-		if (wideCounters)
-			ostream.writeUint32(firstCounter, "replayStepsSinceLastOrder");
-		else
-			ostream.writeUint16(firstCounter, "replayStepsSinceLastOrder");
+		ostream.writeUint32(firstCounter, "replayStepsSinceLastOrder");
 		writeOrderEnvelope(&ostream, std::shared_ptr<Order>(new StepTestOrder()));
-		if (wideCounters)
-			ostream.writeUint32(0, "replayStepsSinceLastOrder");
-		else
-			ostream.writeUint16(0, "replayStepsSinceLastOrder");
+		ostream.writeUint32(0, "replayStepsSinceLastOrder");
 		writeOrderEnvelope(&ostream, std::shared_ptr<Order>(new NullOrder()));
 		readBackend = new MemoryStreamBackend(*writeBackend);
 	}
@@ -221,61 +214,38 @@ BinaryInputStream* writeReplayBody(Uint16 versionMinor, bool wideCounters, Uint3
 	return new BinaryInputStream(readBackend);
 }
 
-// 2. A pre-87 stream with Uint16 counters still parses through the gate.
-void testOldFormatUint16()
-{
-	ReplayReader reader;
-	bool loaded = reader.loadReplay(
-		writeReplayBody(REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR - 1, false, 123), false);
-	check(loaded, "oldFormat: version-86 replay still loads");
-	if (!loaded)
-		return;
-
-	check(reader.getNumStepsTotal() == 123, "oldFormat: Uint16 counter read at the right width");
-
-	for (Uint32 i = 0; i < 123; i++)
-		reader.advanceStep();
-	check(reader.hasMoreOrdersThisStep(), "oldFormat: order due at step 123");
-	std::shared_ptr<Order> order = reader.retrieveOrder();
-	check(order && order->getOrderType() == ORDER_DELETE, "oldFormat: order read back");
-	std::shared_ptr<Order> terminator = reader.retrieveOrder();
-	check(terminator && terminator->getOrderType() == ORDER_NULL, "oldFormat: NullOrder terminator");
-}
-
-// 3. Version floor and ceiling.
+// 2. Version floor and ceiling.
 void testVersionBounds()
 {
 	{
 		ReplayReader reader;
-		check(!reader.loadReplay(writeReplayBody(REPLAY_MINIMUM_VERSION_MINOR - 1, false, 1), false),
+		check(!reader.loadReplay(writeReplayBody(REPLAY_MINIMUM_VERSION_MINOR - 1, 1), false),
 		      "versionBounds: replay older than the supported floor is rejected");
 	}
 	{
 		ReplayReader reader;
-		check(!reader.loadReplay(writeReplayBody(VERSION_MINOR + 1, true, 1), false),
+		check(!reader.loadReplay(writeReplayBody(VERSION_MINOR + 1, 1), false),
 		      "versionBounds: replay newer than this build is rejected");
 	}
 	{
 		ReplayReader reader;
-		check(reader.loadReplay(writeReplayBody(VERSION_MINOR, true, 1), false),
+		check(reader.loadReplay(writeReplayBody(VERSION_MINOR, 1), false),
 		      "versionBounds: current-version replay accepted");
 	}
 }
 
-// 4. Both the initial scan and playback use the replay header version.
+// 3. Both the initial scan and playback use the replay header version.
 void testDecodeVersionPlumbing()
 {
+	// The oldest version the reader accepts. When the floor equals the current
+	// build (as right after a floor bump) this still checks that the header
+	// value is what reaches the decoder.
 	const Uint16 oldVersion = REPLAY_MINIMUM_VERSION_MINOR;
 
-	// Require an older version so a hardcoded VERSION_MINOR cannot pass.
-	check(oldVersion != VERSION_MINOR,
-	      "decodeVersion: replay floor is below the current build version");
-
 	ReplayReader reader;
-	const bool wideCounters = oldVersion >= REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR;
 	lastDecodeVersionMinor = 0;
-	bool loaded = reader.loadReplay(writeReplayBody(oldVersion, wideCounters, 7), false);
-	check(loaded, "decodeVersion: old-but-supported replay loads");
+	bool loaded = reader.loadReplay(writeReplayBody(oldVersion, 7), false);
+	check(loaded, "decodeVersion: oldest supported replay loads");
 	if (!loaded)
 		return;
 
@@ -298,7 +268,6 @@ void testDecodeVersionPlumbing()
 int main(int /*argc*/, char* /*argv*/[])
 {
 	testWideRoundTrip();
-	testOldFormatUint16();
 	testVersionBounds();
 	testDecodeVersionPlumbing();
 	std::printf(failures == 0 ? "ALL PASS\n" : "FAILURES: %d\n", failures);


### PR DESCRIPTION
Follow-up to #184, prompted by @stephanemagnenat's review comment there.

#184 changed no saved byte (gradients are never written to disk; saves and maps from before it load fine), but it changed the simulation: units path and time their steps differently. Any recorded order stream from before it therefore diverges from what happened, and nothing refused those streams:

- `ReplayReader` accepted replays from format 86 up to the current version, so a pre-#184 replay played back with the new pathfinder. With checksums it aborts on the first order ("checksums don't match"); without them it drifts silently.
- The network compared only `NET_PROTOCOL_VERSION` (28), so a client built before the merge could join a game hosted by one built after and desync from the first tick.

This PR makes the incompatibility explicit:

- `VERSION_MINOR` 89 → 90, documented in `Version.h` as the version that marks the pathfinding change. (#169 bumped to 89 for the team statistics thirteen hours after #184 merged; no release sits between the two, but a dedicated number keeps the meaning of each bump clear.)
- `NET_PROTOCOL_VERSION` 28 → 29 and `YOG_MIN_CLIENT_NET_PROTOCOL_VERSION` 27 → 29, so mixed clients are refused before the game starts instead of desyncing in it.
- `REPLAY_MINIMUM_VERSION_MINOR` 86 → 90. With that floor the Uint16 step-counter path for pre-87 replays is dead, so it goes: `wideStepCounter`, `readStepCounter()` and `REPLAY_UINT32_STEP_COUNTER_VERSION_MINOR` are removed and the reader reads Uint32 directly. `ReplayStepCounterTest` loses its version-86 case and keeps the round-trip, floor/ceiling and decode-version-plumbing cases; the last one no longer requires the floor to be below the current version, since right after a floor bump they are equal.

Tested: release build; `ReplayStepCounterTest` and the other `test/` harnesses; the CI test targets.
