### PR TITLE
Traffic lanes: narrow passages become one-way from traffic history (draft)

### DIFF
--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -80,6 +80,7 @@ Map::Map()
 	sizeSector=0;
 	
 	immobileUnits=NULL;
+	trafficDirection=NULL;
 
 	areaNames.resize(9);
 	
@@ -129,6 +130,8 @@ void Map::clear()
 	aStarPoints = NULL;
 	delete[] immobileUnits;
 	immobileUnits = NULL;
+	delete[] trafficDirection;
+	trafficDirection = NULL;
 	arraysBuilt = false;
 
 	w=h=0;
@@ -194,6 +197,7 @@ void Map::setSize(int wDec, int hDec, TerrainType terrainType)
 
 	immobileUnits = new Uint8[w*h];
 	memset(immobileUnits, IMMOBILE_UNIT_NONE, w*h);
+	trafficDirection = new Uint8[(size_t)w*h*8]();
 
 	arraysBuilt=true;
 }

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -767,6 +767,22 @@ public:
 	/// square, and if so, what team number it is. In terms of the engine, these
 	/// are treated like forbidden areas
 	Uint8 *immobileUnits;
+
+	/// Traffic through each cell: how many units recently entered it heading in
+	/// each of the 8 directions, halved every TRAFFIC_DECAY_TICKS (about 40 s: a
+	/// lane is a slow structure, one unit crosses a given cell only every few
+	/// hundred ticks). The gradients charge an extra step cost for entering a
+	/// passage (a cell walled on both sides) against its prevailing direction,
+	/// so a one-wide gap settles into a one-way lane. Derived from the
+	/// simulation, not saved.
+	Uint8 *trafficDirection;
+	static constexpr int TRAFFIC_DECAY_TICKS = 1024;
+	void recordTraffic(int x, int y, int direction);
+	void decayTraffic();
+	//! Whether cell `index` is walled on both sides across one axis in this gradient.
+	bool isPassage(size_t index, const Uint16 *gradient) const;
+	//! Extra cost of entering the passage at `index` heading in `direction`.
+	int lanePenalty(size_t index, int direction) const;
 	
 protected:
 	//Used for scheduling computation time.

--- a/src/map/MapStep.cpp
+++ b/src/map/MapStep.cpp
@@ -82,6 +82,8 @@ void Map::growResources(void)
 void Map::syncStep(Uint32 stepCounter)
 {
 	growResources();
+	if (stepCounter % TRAFFIC_DECAY_TICKS == 0)
+		decayTraffic();
 	for (int i=0; i<sizeSector; i++)
 		sectors[i].step();
 	game->animations->step();

--- a/src/map/gradient/MapGradientField.cpp
+++ b/src/map/gradient/MapGradientField.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -35,9 +36,75 @@ namespace
 	// Seeds whose cost lies beyond the bucket window, sorted by (cost, cell);
 	// each enters its bucket once the sweep reaches its cost.
 	std::vector<std::pair<int, int>> deferredSeeds;
+
+	bool anyTraffic(const Uint8 *counts)
+	{
+		Uint64 all;
+		memcpy(&all, counts, sizeof all);
+		return all != 0;
+	}
 }
 
 static_assert(WATER_STEP[Map::SWIM_CLASS_EVEN] == GRADIENT_STEP);
+
+namespace
+{
+	// Full lane penalty, in gradient units (GRADIENT_STEP = one land step),
+	// reached when this many more units recently entered the passage against
+	// us than our way. Anything less pays in proportion, so a slight imbalance
+	// already tips the next units toward another gap and the lane reinforces
+	// itself.
+	constexpr int LANE_PENALTY = 30;
+	constexpr int LANE_FULL_EXCESS = 16;
+}
+
+void Map::recordTraffic(int x, int y, int direction)
+{
+	assert(direction >= 0 && direction < 8);
+	Uint8 &count = trafficDirection[coordToIndex(x, y) * 8 + direction];
+	if (count < 255)
+		count++;
+}
+
+void Map::decayTraffic()
+{
+	for (size_t i = 0; i < size * 8; i++)
+		trafficDirection[i] >>= 1;
+}
+
+bool Map::isPassage(size_t index, const Uint16 *gradient) const
+{
+	// A cell in a channel at most two cells wide across one axis: walls on both
+	// sides, or a wall on one side and a wall right behind the free cell on the
+	// other. Each column of a 2-wide channel is its own passage, so the two can
+	// take opposite directions.
+	size_t x = index & wMask;
+	size_t y = index >> wDec;
+	for (int side = 1; side < 4; side += 2) // N and S, then E and W
+	{
+		const int sx = tabClose[side][0], sy = tabClose[side][1];
+		const bool wallA = gradient[coordToIndex(x + sx, y + sy)] == GRADIENT_FORBIDDEN;
+		const bool wallB = gradient[coordToIndex(x - sx, y - sy)] == GRADIENT_FORBIDDEN;
+		if (wallA && wallB)
+			return true;
+		if (wallA && gradient[coordToIndex(x - 2 * sx, y - 2 * sy)] == GRADIENT_FORBIDDEN)
+			return true;
+		if (wallB && gradient[coordToIndex(x + 2 * sx, y + 2 * sy)] == GRADIENT_FORBIDDEN)
+			return true;
+	}
+	return false;
+}
+
+int Map::lanePenalty(size_t index, int direction) const
+{
+	const Uint8 *counts = trafficDirection + index * 8;
+	// Units that headed within 45 degrees of our way, and of the opposite way.
+	int same = counts[direction] + counts[(direction + 1) & 7] + counts[(direction + 7) & 7];
+	int opposing = counts[(direction + 4) & 7] + counts[(direction + 3) & 7] + counts[(direction + 5) & 7];
+	if (opposing <= same)
+		return 0;
+	return std::min(LANE_PENALTY, (opposing - same) * LANE_PENALTY / LANE_FULL_EXCESS);
+}
 
 int Map::swimClass(int walkSpeed, int swimSpeed)
 {
@@ -123,29 +190,40 @@ void Map::propagateGradient(Uint16 *gradient, int swimClass, int maxCost)
 			const size_t above = ((y - 1) & hMask) << wDec;
 			const size_t row = y << wDec;
 			const size_t below = ((y + 1) & hMask) << wDec;
-			// All reverse edges enter i, so they share its two terrain costs.
+			// All reverse edges enter i, so they share its two terrain costs. In a
+			// passage with traffic history, entering against the lane costs extra,
+			// per direction (the step from n to i heads the opposite way of d).
+			const bool lane = trafficDirection != NULL && anyTraffic(trafficDirection + (size_t)i * 8) && isPassage((size_t)i, gradient);
 			const int cardinalCost = cur + stepCost(1, 0, (size_t)i, swimClass);
 			const int diagonalCost = cur + stepCost(1, 1, (size_t)i, swimClass);
 			auto& cardinalBucket = buckets[cardinalCost % BUCKETS];
 			auto& diagonalBucket = buckets[diagonalCost % BUCKETS];
-			auto relax = [&](size_t n, int cost, std::vector<int>& destination)
+			auto relax = [&](size_t n, int cost, std::vector<int>& destination, int d)
 			{
-				if (gradient[n] != GRADIENT_FORBIDDEN && cost <= limit && cost < GRADIENT_AT_GOAL - gradient[n])
+				if (gradient[n] == GRADIENT_FORBIDDEN)
+					return;
+				std::vector<int>* dest = &destination;
+				if (lane)
+				{
+					cost += lanePenalty((size_t)i, (d + 4) & 7);
+					dest = &buckets[cost % BUCKETS];
+				}
+				if (cost <= limit && cost < GRADIENT_AT_GOAL - gradient[n])
 				{
 					gradient[n] = (Uint16)(GRADIENT_AT_GOAL - cost);
-					destination.push_back((int)n);
+					dest->push_back((int)n);
 					pending++;
 				}
 			};
 			// Preserve tabClose order: NW, N, NE, E, SE, S, SW, W.
-			relax(above | left, diagonalCost, diagonalBucket);
-			relax(above | x, cardinalCost, cardinalBucket);
-			relax(above | right, diagonalCost, diagonalBucket);
-			relax(row | right, cardinalCost, cardinalBucket);
-			relax(below | right, diagonalCost, diagonalBucket);
-			relax(below | x, cardinalCost, cardinalBucket);
-			relax(below | left, diagonalCost, diagonalBucket);
-			relax(row | left, cardinalCost, cardinalBucket);
+			relax(above | left, diagonalCost, diagonalBucket, 0);
+			relax(above | x, cardinalCost, cardinalBucket, 1);
+			relax(above | right, diagonalCost, diagonalBucket, 2);
+			relax(row | right, cardinalCost, cardinalBucket, 3);
+			relax(below | right, diagonalCost, diagonalBucket, 4);
+			relax(below | x, cardinalCost, cardinalBucket, 5);
+			relax(below | left, diagonalCost, diagonalBucket, 6);
+			relax(row | left, cardinalCost, cardinalBucket, 7);
 		}
 		bucket.clear();
 	}
@@ -179,6 +257,8 @@ bool Map::directionByGradient(Uint32 teamMask, int swimClass, int x, int y, cons
 		{
 			// Worth of going through n: its value less the step to get there.
 			int score = g - stepCost(ddx, ddy, n, swimClass);
+			if (trafficDirection != NULL && isPassage(n, gradient))
+				score -= lanePenalty(n, d);
 			if (score > best)
 			{
 				best = score;

--- a/src/map/io/MapIO.cpp
+++ b/src/map/io/MapIO.cpp
@@ -66,6 +66,7 @@ try
 	aStarPoints=new AStarAlgorithmPoint[size];
 	immobileUnits = new Uint8[size];
 	memset(immobileUnits, 255, size*sizeof(Uint8));
+	trafficDirection = new Uint8[size*8]();
 
 	// We read what's inside the map:
 	stream->read(undermap, size, "undermap");

--- a/src/unit/UnitAction.cpp
+++ b/src/unit/UnitAction.cpp
@@ -89,6 +89,8 @@ void Unit::handleActionGoingTarget()
 
 	if(dx == 0 && dy == 0)
 		owner->map->markImmobileUnit(posX, posY, owner->teamNumber);
+	else
+		owner->map->recordTraffic(posX+dx, posY+dy, direction);
 
 	selectPreferredGroundMovement();
 	speed=performance[action];
@@ -122,6 +124,8 @@ void Unit::handleActionGoingDxDy()
 
 	if(dx == 0 && dy == 0)
 		owner->map->markImmobileUnit(posX, posY, owner->teamNumber);
+	else if (!performance[FLY])
+		owner->map->recordTraffic(posX+dx, posY+dy, direction);
 
 	selectPreferredMovement();
 	speed=performance[action];

--- a/test/GradientTest.cpp
+++ b/test/GradientTest.cpp
@@ -43,6 +43,7 @@ namespace
 			size = 0;
 		}
 		size_t cells() const { return size; }
+		void trackTraffic() { trafficDirection = new Uint8[size * 8](); }
 		void putWater(int x, int y) { tiles[coordToIndex(x, y)].terrain = 256; }
 		void putGroundUnit(int x, int y) { tiles[coordToIndex(x, y)].groundUnit = 0; }
 	};
@@ -195,6 +196,65 @@ void GradientTest::testSeedsBeyondBucketWindow()
 	// (7,7): four diagonals from the goal beat 88 through the seed.
 	CPPUNIT_ASSERT_EQUAL(56, cost(g, map, 7, 7));
 	CPPUNIT_ASSERT_EQUAL((int)GRADIENT_FORBIDDEN, (int)g[map.coordToIndex(2, 5)]);
+}
+
+void GradientTest::testTrafficMakesNarrowCellsOneWay()
+{
+	// Wall at x=4 with a one-wide gap at (4,3); goal at (3,3). From (5,3) the
+	// way is two steps west through the gap, or six steps east around the torus.
+	GrassMap map;
+	map.trackTraffic();
+	auto walled = [&map]()
+	{
+		std::vector<Uint16> g = blank(map);
+		for (int y = 0; y < 8; y++)
+			if (y != 3)
+				g[map.coordToIndex(4, y)] = GRADIENT_FORBIDDEN;
+		return g;
+	};
+	std::vector<Uint16> g = walled();
+	g[map.coordToIndex(3, 3)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(g.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(20, cost(g, map, 5, 3));
+
+	// Sixteen units recently crossed the gap eastward (tabClose[3] = east): a
+	// westbound step into it now pays the full lane penalty, three tiles.
+	map.trafficDirection[map.coordToIndex(4, 3) * 8 + 3] = 16;
+	std::vector<Uint16> lane = walled();
+	lane[map.coordToIndex(3, 3)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(lane.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(50, cost(lane, map, 5, 3));
+	// Following the flow costs nothing extra: eastbound from (3,3) to (5,3).
+	std::vector<Uint16> along = walled();
+	along[map.coordToIndex(5, 3)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(along.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(20, cost(along, map, 3, 3));
+	// Eight units the other way make it a partial penalty: 8 of 16.
+	map.trafficDirection[map.coordToIndex(4, 3) * 8 + 7] = 8;
+	std::vector<Uint16> partial = walled();
+	partial[map.coordToIndex(3, 3)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(partial.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(20 + 15, cost(partial, map, 5, 3));
+	// A unit at (5,3) sees the same cost and still takes the gap (around is 60).
+	int dx = 0, dy = 0;
+	CPPUNIT_ASSERT(map.directionByGradient(1, 0, 5, 3, partial.data(), &dx, &dy, true));
+	CPPUNIT_ASSERT_EQUAL(-1, dx);
+	CPPUNIT_ASSERT_EQUAL(0, dy);
+
+	// The same opposing traffic is free on open ground and beside a single wall.
+	map.trafficDirection[map.coordToIndex(2, 3) * 8 + 3] = 16;
+	map.trafficDirection[map.coordToIndex(2, 7) * 8 + 3] = 16;
+	std::vector<Uint16> open = blank(map);
+	open[map.coordToIndex(1, 6)] = GRADIENT_FORBIDDEN; // (2,7) has a wall on one side only
+	open[map.coordToIndex(0, 3)] = GRADIENT_AT_GOAL;
+	open[map.coordToIndex(0, 7)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(open.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(30, cost(open, map, 3, 3));
+	CPPUNIT_ASSERT_EQUAL(30, cost(open, map, 3, 7));
+
+	// Decay halves the counts.
+	map.decayTraffic();
+	CPPUNIT_ASSERT_EQUAL(8, (int)map.trafficDirection[map.coordToIndex(4, 3) * 8 + 3]);
 }
 
 void GradientTest::testMaxCostStopsPropagation()

--- a/test/GradientTest.h
+++ b/test/GradientTest.h
@@ -6,7 +6,8 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 // Tests for the pathfinding gradients (Map::propagateGradient,
-// Map::directionByGradient, Map::swimClass) on a small toroidal grass map.
+// Map::directionByGradient, Map::swimClass, Map::lanePenalty) on a small
+// toroidal grass map.
 class GradientTest: public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE( GradientTest );
@@ -17,6 +18,7 @@ class GradientTest: public CppUnit::TestFixture
 		CPPUNIT_TEST( testSeedBelowGoalPropagates );
 		CPPUNIT_TEST( testSeedsBeyondBucketWindow );
 		CPPUNIT_TEST( testMaxCostStopsPropagation );
+		CPPUNIT_TEST( testTrafficMakesNarrowCellsOneWay );
 		CPPUNIT_TEST( testDirectionPrefersCheapestTotal );
 		CPPUNIT_TEST( testDirectionBlockedNeighbour );
 		CPPUNIT_TEST( testSwimClassFromSpeeds );
@@ -31,6 +33,7 @@ public:
 	void testSeedBelowGoalPropagates();
 	void testSeedsBeyondBucketWindow();
 	void testMaxCostStopsPropagation();
+	void testTrafficMakesNarrowCellsOneWay();
 	void testDirectionPrefersCheapestTotal();
 	void testDirectionBlockedNeighbour();
 	void testSwimClassFromSpeeds();


### PR DESCRIPTION
Stacked on #193 (round trip); one commit. Split out of the old #193 so it can be judged on its own evidence.

**What it does.** Units record the direction they step in, per cell (one Uint8 per cell and direction, halved every 1024 ticks). Building a gradient charges an extra cost, per edge, for entering a *passage* against its prevailing direction, in proportion to the excess of opposing over same-way units (full penalty at 16 units of excess, worth three tiles); `directionByGradient` sees the same cost. The first units through a gap set its direction and later units heading the other way take another gap; on open ground and beside a single wall nothing changes. Derived state, not saved; one shared traffic layer for all teams.

A passage is a cell in a channel at most two cells wide across one axis: walls on both sides, or a wall on one side and a wall right behind the free cell on the other (new since the old #193, which only knew 1-wide gaps). Each column of a 2-wide channel is its own passage, so the two take opposite directions on their own. That is the typical human layout: paired buildings that will merge after an upgrade leave 2-wide channels between them until then, and inns north of other buildings leave 1-wide ones.

**Evidence.** Nicowar never builds such layouts, so Nicowar-vs-Nicowar games cannot show the effect (they were flat within noise in the old #193, and are unchanged here). The fixture is a mid-game save of exactly such a base by @Giszmo (`FourSquares1_testing.game`, team 0 human with a base of 2-wide channels, teams 1 and 2 Nicowar), run headlessly for about 16 000 ticks after the save point with the human team working its existing orders. A loaded game is deterministic, so the synchronous random generator was reseeded after loading with 12 different seeds per build (different sidestep and AI dice, same layout and state); means ± standard error over the 12, per 1000 ticks of play. "Blocked" counts non-strict `directionByGradient` calls that found no step at all.

| team | metric | master | #193 (round trip) | #193 + lanes | lanes vs master | lanes vs #193 |
|---|---|---:|---:|---:|---:|---:|
| 0 (human) | deliveries / 1000 ticks | 64.6 ± 0.9 | 61.8 ± 1.1 | 64.1 ± 1.1 | −0.6 % (t=−0.3) | +3.8 % (t=+1.5) |
| 0 (human) | tiles per round trip | 20.22 ± 0.14 | 20.71 ± 0.17 | 20.25 ± 0.25 | +0.1 % (t=+0.1) | −2.3 % (t=−1.6) |
| 0 (human) | blocked ticks / 1000 ticks | 78.1 ± 2.1 | 70.5 ± 2.1 | 51.6 ± 1.5 | **−34 % (t=−10.5)** | **−27 % (t=−7.4)** |
| 1 (Nicowar) | deliveries / 1000 ticks | 91.3 ± 2.3 | 102.1 ± 3.2 | 99.6 ± 2.5 | +9.1 % (t=+2.4) | −2.5 % (t=−0.6) |
| 1 (Nicowar) | tiles per round trip | 22.46 ± 0.33 | 21.36 ± 0.19 | 20.65 ± 0.28 | −8.0 % (t=−4.2) | −3.3 % (t=−2.1) |
| 1 (Nicowar) | blocked ticks / 1000 ticks | 85.0 ± 7.9 | 94.5 ± 6.3 | 73.0 ± 4.3 | −14 % (t=−1.3) | −23 % (t=−2.8) |
| 2 (Nicowar) | deliveries / 1000 ticks | 104.8 ± 3.1 | 107.5 ± 1.7 | 106.3 ± 3.1 | +1.5 % (t=+0.3) | −1.1 % (t=−0.3) |
| 2 (Nicowar) | tiles per round trip | 21.74 ± 0.34 | 21.06 ± 0.27 | 20.78 ± 0.20 | −4.4 % (t=−2.4) | −1.3 % (t=−0.8) |
| 2 (Nicowar) | blocked ticks / 1000 ticks | 84.6 ± 6.3 | 94.3 ± 7.5 | 65.1 ± 4.9 | −23 % (t=−2.4) | −31 % (t=−3.2) |

Reading: on the human base the lanes cut blocked ticks by a third against master (and by a quarter against #193), with trips and deliveries unchanged; on the two AI teams blocking drops by a quarter to a third and trips get a few percent shorter. Output does not move: the units were blocked for a fraction of a tick per trip, so unblocking them shows in smoothness, not in deliveries. The old scripted choke fixture (3-thick wall, 1/2/4 one-wide gaps) from the previous #193 description still applies: two gaps, blocked ticks −64 %, deliveries +4.5 %; one or four gaps, no change.

**Cost, and why this is a draft.** Whole-game wall time on top of #193 (bash `time`, alternated runs): 128² Mazury, 2 Nicowars, 15360 ticks: 3.97 s → 4.39 s (+11 %); 512² Mazury tiled 4x4, 8 Nicowars, 9216 ticks: 46.9 s → 57.4 s (+22 %). That is far more than the 3 to 5 % measured before #184's optimised propagation loop, because the lane check now runs per popped cell inside that loop (`anyTraffic` load plus up to eight gradient lookups in `isPassage`) for every field of every tick, and the traffic layer is 8 bytes per cell (2 MB on 512²) that the loop touches. Plan before asking for review: keep a passage bitmap per map, maintained incrementally where cases change (buildings, resources), so the loop tests one bit and one 8-byte load, and touch the traffic counters only for passage cells. If that does not bring the cost under a few percent on 512², this stays a draft.

**Known limits.** One traffic layer for all teams (an enemy's traffic through a gap counts). The three constants (half-life 1024 ticks, full penalty at 16 excess units, three tiles) are first values. Traffic is not saved, so a loaded game starts with no lanes and re-learns them within a few hundred ticks.

Determinism: two runs of the same seed give identical checksum sidecars (the traffic counters are simulation state derived from unit steps, so they are the same on every peer). Tests: the three GradientTest cases from the old #193 (seeds beyond the bucket window, cost bound, lane penalty) plus the existing suites and harnesses.
