### PR TITLE
Fix resource-fetch test after Tile accessor rename

### DIFF
--- a/test/ResourceFetchTargetHarness.cpp
+++ b/test/ResourceFetchTargetHarness.cpp
@@ -79,7 +79,7 @@ static void staleTargetIsRefreshedAfterGradientRebuild(int expectedClass, int sw
 	// Another unit fully harvests the near tile. This mutates the resource
 	// layer directly, the same way Map::decResource does; the cached
 	// gradient is untouched until something rebuilds it.
-	game.map.getCase(nearX, nearY).resource.clear();
+	game.map.getTile(nearX, nearY).resource.clear();
 	require(game.map.getGradient(teamNumber, CORN, swimClass, nearX, nearY) == GRADIENT_AT_GOAL,
 		"the cached gradient does not notice the depletion by itself");
 


### PR DESCRIPTION
The resource-fetch regression still calls `Map::getCase`, so current master fails to compile that CI target after #199 renamed the accessor to `getTile`. Update the single call in the test; production code is unchanged.

The failure reproduced in Ubuntu 24.04 CI while integrating master into #192 and #181 (runs 34300564842 and 34300567216). The correction is also included on those branches. Ubuntu 22.04, Ubuntu 24.04 and Windows CI all pass on the standalone repair: https://github.com/Globulation2/glob2/actions/runs/34300786788 . @Giszmo please review and merge once green.
