### PR TITLE
Document the build dependencies in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,6 +24,28 @@ The simplest way to compile this package is:
      source code directory by typing `scons -c'.
 
 
+Dependencies
+============
+
+   Glob 2 needs a C++20 compiler, Python 3 and SCons. It builds against SDL 2;
+the SDL 1.2 packages are *not* needed and installing them does not help.
+
+   On Debian and Ubuntu, the build dependencies are:
+
+     apt install g++ python3 scons pkg-config \
+       libsdl2-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev \
+       libvorbis-dev libogg-dev libspeex-dev \
+       libboost-date-time-dev libboost-thread-dev libboost-system-dev \
+       zlib1g-dev libfribidi-dev libpcre3-dev \
+       libgl1-mesa-dev libglu1-mesa-dev libepoxy-dev
+
+   To also build and run the test suite, add `libcppunit-dev', plus `xvfb',
+`xauth' and `libgl1-mesa-dri' for the tests that need a display.
+
+   This list is kept in sync with the dependencies installed by the CI build in
+`.github/workflows/build.yml', which is what the project actually builds against.
+
+
 Compilers and Options
 =====================
 
@@ -57,6 +79,7 @@ Out of source compliation
 Specifying the System Type
 ==========================
 
-   `scons' will work on must Unix/Linux systems. However, to compile on windows,
-the flag `mingw=true' must be called. More information on compiling on Windows can
-be found at http://globulation2.org/wiki/Mingw_compilation
+   `scons' will work on most Unix/Linux systems. However, to compile on Windows,
+the flag `mingw=true' must be called. The MSYS2/MINGW64 package list used by the
+CI build is in `.github/workflows/build.yml'. More information on compiling on
+Windows can be found at https://globulation2.org/wiki/Mingw_compilation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Glob 2 #
 
-[![Build Status](https://travis-ci.com/Globulation2/glob2.svg?branch=master)](https://travis-ci.com/Globulation2/glob2)
+[![Build Status](https://github.com/Globulation2/glob2/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/Globulation2/glob2/actions/workflows/build.yml)
 
 [Globulation 2](http://www.globulation2.org/) is a real time strategy game that aims to remove all micro management.


### PR DESCRIPTION
INSTALL listed no dependencies at all. In #76 that leads a contributor to guess at an apt line, pull the SDL 1.2 packages, and be told "you only need SDL 2"; a Fedora packager hit the same confusion from the other side. The authoritative list already exists in `.github/workflows/build.yml` — this copies it to where someone building from source will actually look, and says explicitly that SDL 1.2 is not needed.

Every package listed appears verbatim in the CI workflow. `ca-certificates`, `git` and `ccache` are left out: the first two are container bootstrap, the third is the optional compiler cache.

Also points the Windows section at the MSYS2/MINGW64 package list in the same workflow, and fixes two stale bits it sits next to: an `http://` wiki link and a "must Unix/Linux systems" typo.

Separately, the Travis badge in `README.md` has returned 404 since the project moved to GitHub Actions. Repointed at the workflow that actually runs (new badge URL verified 200).

Docs only — no code, no build-system change.

Note this does **not** fix a Python 3 problem, because there is not one: `3dd1b31` is an ancestor of master, no Python 2 idioms remain in any SConstruct/SConscript/`*.py`, and master builds clean under Python 3.14.6 / SCons 4.10.1. The Python 3 complaints in #76 are about the 2009 release tarball, which is a tagging problem. This PR addresses the documentation gap that made people think there was a code problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
