### PR TITLE
Price a loaded fetch candidate instead of refusing it

### DIFF
--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -26,7 +26,7 @@ static constexpr Uint32 REPLAY_MIN_VALID_ORDERS = 5;
 //! changed the simulation (fetch-job apportionment), as version 90 did before
 //! it (weighted pathfinding, diagonal timing), so earlier replays would diverge
 //! from what happened.
-static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 91;
+static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 92;
 
 /// This class is used for reading replays.
 /// The replay stream is kept open and read every time you do retrieveOrder.

--- a/src/Version.h
+++ b/src/Version.h
@@ -6,7 +6,7 @@
 // This is the version of map and savegame format, and all of the recorded data on the server
 #define VERSION_MAJOR 0
 #define MINIMUM_VERSION_MINOR 58
-#define VERSION_MINOR 91
+#define VERSION_MINOR 92
 // version 10 adds script saved in game
 // version 11 the gamesfiles do saves which building has been seen under fog of war.
 // version 12 saves map name into SessionGame instead of BaseMap.
@@ -95,6 +95,8 @@
 //            the simulation changed, so replays recorded before it diverge and are refused
 // version 91 apportions fetch jobs across the resources a building wants instead of
 //            letting the nearest one take every slot: the simulation changed again
+// version 92 prices a loaded fetch candidate instead of refusing it, so hiring order
+//            changed again
 
 //This must be updated when there are changes to YOG, MapHeader, GameHeader, BasePlayer, BaseTeam,
 //NetMessage, and the likes, in parallel to change of the VERSION_MINOR above

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -472,12 +472,12 @@ private:
 	/// Both are deliberate and must be preserved.
 	void selectUnitCarryingWantedResource(const int* targets, const int* served, BringResourcesSelection& sel);
 
-	/// The two fetch-out selection passes, in priority order, for one resource:
-	/// an empty-handed unit first, then one carrying something this building
-	/// does not want. Each scans all candidates and updates `sel` with the best
-	/// match, assigning destinationPurpose only to the unit it chooses.
-	void selectEmptyHandedUnit(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel);
-	void selectUnitCarryingUnwantedResource(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel);
+	/// The fetch-out selection pass for one resource. Scans all candidates and
+	/// updates `sel` with the best match, assigning destinationPurpose only to
+	/// the unit it chooses. A candidate holding something else is charged
+	/// CARRIED_RESOURCE_PENALTY_TILES of detour rather than excluded, so it is
+	/// hired when it is enough closer to be worth the loss.
+	void selectFetcher(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel);
 
 	/// This function updates the resources pointer. The variable resources can either point to local resources
 	/// or team resources, depending on the BuildingType.

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -21,6 +21,13 @@ namespace
 	/// harvest level dominates the comparison; the walk level breaks ties.
 	constexpr int HARVEST_LEVEL_WEIGHT = 10;
 
+	/// Tiles of detour a candidate pays for turning up with a resource this
+	/// building cannot take. Whatever it carries is lost the moment it harvests
+	/// again, so an empty-handed unit this much further away is the better hire,
+	/// and a building that does want the cargo gets its chance at the unit. A
+	/// price, not a veto: past this margin the loaded unit is still hired.
+	constexpr int CARRIED_RESOURCE_PENALTY_TILES = 5;
+
 	/// Composite "experience" key used to rank resource-carrying candidates;
 	/// higher is preferred.
 	int bringResourcesLevel(const Unit* unit)
@@ -189,7 +196,7 @@ void Building::selectUnitCarryingWantedResource(const int* targets, const int* s
 	}
 }
 
-void Building::selectEmptyHandedUnit(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel)
+void Building::selectFetcher(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel)
 {
 	for(int n=0; n<Unit::MAX_COUNT; ++n)
 	{
@@ -197,44 +204,26 @@ void Building::selectEmptyHandedUnit(const BringResourcesCandidate* candidates, 
 		if(unit==NULL)
 			continue;
 
-		if (unit->carriedResource<0)
-		{
-			int value=candidates[n].distance;
-			int level = bringResourcesLevel(unit);
-			if ((level>sel.maxLevel) || (level==sel.maxLevel && value<sel.minValue))
-			{
-				sel.minValue=value;
-				sel.maxLevel=level;
-				sel.choosen=unit;
-				unit->destinationPurpose=wantedResource;
-			}
-		}
-	}
-}
-
-void Building::selectUnitCarryingUnwantedResource(const BringResourcesCandidate* candidates, int wantedResource, BringResourcesSelection& sel)
-{
-	for(int n=0; n<Unit::MAX_COUNT; ++n)
-	{
-		Unit* unit=candidates[n].unit;
-		if(unit==NULL)
+		// A unit already carrying what is wanted is a delivery, not a fetch, and
+		// selectUnitCarryingWantedResource has first refusal on it.
+		int carried=unit->carriedResource;
+		if(carried==wantedResource)
 			continue;
 
-		int r2=unit->carriedResource;
-		if ((r2>=0) && !neededResource(r2))
+		int value=candidates[n].distance;
+		if(carried>=0)
+			value += CARRIED_RESOURCE_PENALTY_TILES<<Q8_FIXED_POINT_SHIFT;
+		int level = bringResourcesLevel(unit);
+		if ((level>sel.maxLevel) || (level==sel.maxLevel && value<sel.minValue))
 		{
-			int value=candidates[n].distance;
-			int level = bringResourcesLevel(unit);
-			if ((level>sel.maxLevel) || (level==sel.maxLevel && value<sel.minValue))
-			{
-				sel.minValue=value;
-				sel.maxLevel=level;
-				sel.choosen=unit;
-				unit->destinationPurpose=wantedResource;
-			}
+			sel.minValue=value;
+			sel.maxLevel=level;
+			sel.choosen=unit;
+			unit->destinationPurpose=wantedResource;
 		}
 	}
 }
+
 
 bool Building::subscribeToBringResourcesStep()
 {
@@ -279,9 +268,7 @@ bool Building::subscribeToBringResourcesStep()
 					continue;
 				BringResourcesCandidate candidates[Unit::MAX_COUNT];
 				gatherBringResourcesCandidates(candidates, r);
-				selectEmptyHandedUnit(candidates, r, sel);
-				if (sel.choosen==NULL)
-					selectUnitCarryingUnwantedResource(candidates, r, sel);
+				selectFetcher(candidates, r, sel);
 			}
 		}
 

--- a/test/FetchApportionmentHarness.cpp
+++ b/test/FetchApportionmentHarness.cpp
@@ -116,6 +116,102 @@ static void siteSpreadsItsFetchersAcrossBothResources()
 	std::puts("PASS a market site spreads its fetchers over wood and stone");
 }
 
+
+// One hiring pass on a site that wants stone, with two candidates at the given
+// positions, the second holding corn the site cannot take. Returns the
+// gid of the unit hired, and reports each candidate's scored distance.
+static int hireOneOfTwo(int emptyX, int emptyY, int loadedX, int loadedY, int* emptyCost, int* loadedCost)
+{
+	GameGUI gui;
+	Game& game = gui.game;
+	game.map.setSize(5, 5, GRASS); // 32x32
+	game.map.setGame(&game);
+	game.addTeam(0);
+	Team* team = game.teams[0];
+
+	const Sint32 siteType = globalContainer->buildingsTypes.getTypeNum("market", 0, true);
+	const BuildingType* type = globalContainer->buildingsTypes.get(siteType);
+	const int siteX = 8, siteY = 8;
+	TestBuilding* site = new TestBuilding(siteX, siteY, Building::GIDfrom(0, 0), siteType, team,
+	                                      &globalContainer->buildingsTypes, 1, 1);
+	team->myBuildings[0] = site;
+	game.map.setBuilding(siteX, siteY, type->width, type->height, site->gid);
+
+	// Stone only, so the apportionment has exactly one job to staff.
+	site->resources[WOOD] = type->maxResource[WOOD];
+	require(site->neededResource(WOOD) == 0, "the site wants no more wood");
+	require(site->neededResource(STONE) > 0, "the site still wants stone");
+	require(game.map.incResource(22, 9, STONE, 0), "seed the stone tile");
+
+	const int positions[2][2] = {{emptyX, emptyY}, {loadedX, loadedY}};
+	for (int n = 0; n < 2; ++n)
+	{
+		Unit* unit = new Unit(positions[n][0], positions[n][1], n, WORKER, team, 0);
+		team->myUnits[n] = unit;
+		unit->performance[WALK] = 10;
+		unit->performance[HARVEST] = 10;
+		unit->activity = Unit::ACT_RANDOM;
+		unit->displacement = Unit::DIS_RANDOM;
+		unit->medical = Unit::MED_FREE;
+		unit->attachedBuilding = NULL;
+		unit->trigHungry = 100;
+		unit->hungry = unit->trigHungry + 1000 * unit->race->hungriness;
+	}
+	// Unit 1 turns up holding corn, which this site has no use for at all.
+	team->myUnits[1]->carriedResource = CORN;
+	require(site->neededResource(CORN) == 0, "the corn is of no use here");
+
+	const int swimClass = team->myUnits[0]->swimClass();
+	for (int n = 0; n < 2; ++n)
+	{
+		Unit* unit = team->myUnits[n];
+		int distBuilding = 0, distResource = 0;
+		require(game.map.buildingAvailable(site, swimClass, unit->posX, unit->posY, &distBuilding),
+			"the site is reachable from the candidate");
+		require(game.map.resourceAvailable(0, STONE, swimClass, unit->posX, unit->posY, &distResource),
+			"the stone is reachable from the candidate");
+		*(n == 0 ? emptyCost : loadedCost) = distBuilding + distResource;
+	}
+
+	site->refreshCallLists();
+	require(site->hireOne(), "somebody is hired");
+	require(site->unitsWorking.size() == 1, "exactly one unit is hired");
+	Unit* chosen = site->unitsWorking.front();
+	require(chosen->destinationPurpose == STONE, "hired for the stone");
+	return chosen->gid;
+}
+
+// A loaded candidate pays a detour, so an empty-handed one that is no closer
+// wins; the geometry is mirrored so neither position nor scan order decides it.
+static void anEmptyHandedUnitWinsAllElseEqual()
+{
+	int emptyCost = 0, loadedCost = 0;
+	int hired = hireOneOfTwo(5, 7, 5, 11, &emptyCost, &loadedCost);
+	std::printf("mirrored: empty=%d loaded=%d hired=%d\n", emptyCost, loadedCost, hired);
+	require(emptyCost == loadedCost, "the two candidates really are equally placed");
+	require(hired == 0, "the empty-handed unit is hired");
+
+	// Same geometry with the cargo on the other unit: the empty one wins again.
+	int mirroredEmpty = 0, mirroredLoaded = 0;
+	int hiredMirrored = hireOneOfTwo(5, 11, 5, 7, &mirroredEmpty, &mirroredLoaded);
+	require(hiredMirrored == 0, "still the empty-handed unit, whichever position it holds");
+
+	std::puts("PASS a loaded candidate loses to an equally placed empty-handed one");
+}
+
+// But the detour is a price, not a veto: far enough ahead and the loaded unit
+// is still the better hire.
+static void aLoadedUnitFarEnoughAheadIsStillHired()
+{
+	int emptyCost = 0, loadedCost = 0;
+	int hired = hireOneOfTwo(5, 9, 13, 9, &emptyCost, &loadedCost);
+	std::printf("lopsided: empty=%d loaded=%d hired=%d\n", emptyCost, loadedCost, hired);
+	require(loadedCost + 5 < emptyCost, "the loaded unit is more than the penalty ahead");
+	require(hired == 1, "the loaded unit is hired anyway");
+
+	std::puts("PASS a loaded candidate far enough ahead is hired despite the penalty");
+}
+
 int main(int argc, char** argv)
 {
 	SDL_SetMainReady();
@@ -130,6 +226,8 @@ int main(int argc, char** argv)
 	IntBuildingType::init();
 	Race::loadDefault();
 	siteSpreadsItsFetchersAcrossBothResources();
+	anEmptyHandedUnitWinsAllElseEqual();
+	aLoadedUnitFarEnoughAheadIsStillHired();
 	std::puts("Fetch apportionment regressions passed");
 	return 0;
 }


### PR DESCRIPTION
Stacked on #223 — review that one first. Targets `fix/proportional-fetch-jobs`; retarget to `master` once #223 lands.

## The problem

Hiring consulted empty-handed candidates as a *tier*, and only looked at units carrying something the building cannot take once that tier came up empty. A loaded unit standing at the door therefore lost to an empty one anywhere on the map, however far away, and the job went to the longer trip.

## The change

Score them together and charge the loaded unit a fixed detour:

```cpp
/// Tiles of detour a candidate pays for turning up with a resource this
/// building cannot take.
constexpr int CARRIED_RESOURCE_PENALTY_TILES = 5;
```

Five tiles is enough that an empty-handed unit a short walk further away still wins — which leaves the cargo with its carrier long enough for a building that *does* want it to hire the unit first, which is the point — and small enough that a unit far enough ahead is still the better hire. A price, not a veto.

Merging the two passes also picks up a case that fell between them: a unit carrying a resource this building wants but has *already fully subscribed*. The delivery pass had no room for another of that resource, and the fetch-out pass only looked at units carrying something unneeded, so nothing could hire it. It is now hireable for a different resource, at the penalty.

**Note on levels.** `bringResourcesLevel` still dominates the comparison — a higher-level candidate beats a lower-level one regardless of distance or penalty. That is pre-existing and I have not touched it; the penalty only orders candidates of equal level. Say the word if you want the level tier priced too.

## Tests

Two new cases in `FetchApportionmentHarness`:

| case | result |
|---|---|
| two candidates placed symmetrically about the site, both scoring 19 | the empty-handed one is hired, **whichever of the two holds the cargo** — so neither position nor scan order decides it |
| loaded candidate at 12, empty at 18 | the loaded one is hired despite the penalty |

The second is the discriminating one: on `fix/proportional-fetch-jobs` without this change it reports

```
lopsided: empty=18 loaded=12 hired=0
FAIL: the loaded unit is hired anyway
```

The first passes either way by design — it is the guard against over-correcting, not the discriminator.

Also verified: `TestsRunner` (177 tests), `WinningConditionsHarness`, every engine harness CI runs, `scons server=1`, and a 47,298-tick headless AI game to a clean win.

## Not covered here

Your idea of dropping the cargo at a nearby building that *does* want it, when the detour is small, is a separate and larger change — it needs a cheap "who wants this near here" lookup and a detour budget, and it lives in the walking code rather than the hiring code. Not in this PR.

## Version numbering

This takes `VERSION_MINOR` 92. #225 also takes 92; they are independent, so whichever merges second needs a one-line bump to 93.
