### PR TITLE
Assign a hired unit's purpose once, to the unit that is hired

### DIFF
--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -431,6 +431,10 @@ private:
 		int maxLevel;
 		int minValue;
 		Unit* choosen;
+		//! The resource `choosen` is being hired for. Held here rather than written
+		//! onto each candidate, so a unit that is considered and passed over keeps
+		//! the job it already had.
+		int resource;
 	};
 
 	/// Whether a unit is a possible hire at all: harvest-capable, idle, healthy,

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -227,14 +227,12 @@ void Building::selectUnitCarryingWantedResource(const int* targets, const int* s
 		int timeLeft=(unit->hungry-unit->trigHungry)/unit->race->hungriness;
 		int value=distBuilding-(timeLeft>>1);
 		int level = bringResourcesLevel(unit);
-		// Every carrying candidate has its destinationPurpose set to the
-		// resource it carries, not only the one finally chosen.
-		unit->destinationPurpose=r;
 		if ((level>sel.maxLevel) || (level==sel.maxLevel && value<sel.minValue))
 		{
 			sel.minValue=value;
 			sel.maxLevel=level;
 			sel.choosen=unit;
+			sel.resource=r;
 		}
 	}
 }
@@ -260,7 +258,7 @@ void Building::selectFetcher(const BringResourcesCandidate* candidates, int want
 			sel.minValue=value;
 			sel.maxLevel=level;
 			sel.choosen=unit;
-			unit->destinationPurpose=wantedResource;
+			sel.resource=wantedResource;
 		}
 	}
 }
@@ -288,6 +286,7 @@ bool Building::subscribeToBringResourcesStep()
 		sel.maxLevel = -1;
 		sel.minValue = INT_MAX;
 		sel.choosen = NULL;
+		sel.resource = -1;
 
 		// A unit already holding something we want delivers without a fetch trip,
 		// so it is taken ahead of the apportionment, which only directs the units
@@ -315,6 +314,7 @@ bool Building::subscribeToBringResourcesStep()
 
 		if (sel.choosen)
 		{
+			sel.choosen->destinationPurpose = sel.resource;
 			if (sel.choosen->attachedBuilding != NULL)
 				sel.choosen->attachedBuilding->removeUnitFromWorking(sel.choosen);
 			unitsWorking.push_back(sel.choosen);


### PR DESCRIPTION
Targets `feat/task-switch-penalty`, not master — the defect only exists on this branch.

`selectFetcher` and `selectUnitCarryingWantedResource` write `destinationPurpose` onto whichever candidate is momentarily cheapest and never restore it when a later candidate wins. While only idle units were candidates that was harmless: an idle unit is given a fresh purpose when it is really hired.

`unitIsAvailableToHire` on this branch admits units **already fetching for another building**, and for those the write lands on a job in flight. The unit is not hired, stays attached to its own building, and then harvests whatever the overwritten field names — `doesUnitTouchResource` and `carriedResource=destinationPurpose` both read it — and carries the wrong resource to a building that cannot take it. It plays the drop animation and drops nothing.

`fetchApportionment` counts subscriptions from the same field, so a building's `served` counts drift as well.

### Evidence

An invariant check over every fetcher — is its `destinationPurpose` a resource its own building can actually hold — on a four-player savegame, 4500 ticks:

```
                       fetcher samples   corrupt   distinct units
 master                          2123         4          2     (both already corrupt in the save)
 this branch                     1932        26         14
 this branch + fix               1870         2          1     (the one from the save)
```

The corrupt assignments are things like fetching wood for a swarm, or corn for a defence tower.

### Effect

Six seeds of the Playground bed, one binary with the old behaviour behind an env switch:

```
 seed        master        before           after
    7     2946 / 39     2918 / 76      2871 / 63
   11     2755 / 13     2908 / 31      2970 / 13
   12     1600 / 25     1818 / 47      1810 / 26
   13     2713 / 14     2540 / 62      2528 / 38
   14     2599 / 19     2584 / 41      2759 / 30
   15     2239 / 45     2130 / 67      2835 / 61

 median   2656 / 22     2562 / 54      2797 / 34
                         -3.5%          +5.3%
```

deliveries / starvation deaths. Better on starvation in six seeds out of six. Most of the branch's starvation regression against master was this bug rather than the task-switch idea — though at 34 against master's 22 the idea still costs lives, so the food exemption is still worth pursuing separately.

### The change

Carry the resource in `BringResourcesSelection` and assign `destinationPurpose` once, to the unit actually hired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
