### PR TITLE
Fix conversion abort after a blocked occupant's building is destroyed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,11 @@ jobs:
           ./build/src/EnteringUnitSaveHarness
           ./build/src/EnteringUnitSaveHarness --load test/fixtures/entering-explorer/reproducer.game
 
+      - name: Build and run the building occupant death regression
+        run: |
+          scons -j$(nproc) release=1 server=0 building-occupant-death-test
+          ./build/src/BuildingOccupantDeathHarness
+
       - name: Build and run the entering unit draw regression
         run: |
           scons -j$(nproc) release=1 server=0 entering-unit-draw-test

--- a/src/SConscript
+++ b/src/SConscript
@@ -622,3 +622,10 @@ if not env['server'] and 'hiring-bucket-test' in COMMAND_LINE_TARGETS:
     hiring_sources = [source for source in source_files if source != 'Glob2.cpp']
     hiring_sources += local.Object('HiringBucketHarness.o', '#test/HiringBucketHarness.cpp')
     local.Alias('hiring-bucket-test', local.Program('HiringBucketHarness', hiring_sources))
+
+# Real-engine regression for destruction while a unit is waiting for an exit.
+if not env['server']:
+    occupant_sources = [source for source in source_files if source != 'Glob2.cpp']
+    occupant_sources += local.Object('BuildingOccupantDeathHarness.o', '#test/BuildingOccupantDeathHarness.cpp')
+    occupant_test = local.Program('BuildingOccupantDeathHarness', occupant_sources)
+    local.Alias('building-occupant-death-test', occupant_test)

--- a/src/building/Misc.cpp
+++ b/src/building/Misc.cpp
@@ -34,7 +34,11 @@ void Building::kill(void)
 	{
 		//TODO: We should somehow try to save their lives. In training buildings they should just drop out untrained etc.
 		Unit *u=*it;
-		if (u->displacement==Unit::DIS_INSIDE)
+		// Finishing service does not place a unit on the map until an exit is
+		// found. A blocked exiting unit is still an occupant, not a survivor
+		// that can be released into random activity with no map slot.
+		if (u->displacement==Unit::DIS_INSIDE
+			|| (u->displacement==Unit::DIS_EXITING_BUILDING && u->movement==Unit::MOV_INSIDE))
 			u->isDead=true;
 
 		if (u->displacement==Unit::DIS_ENTERING_BUILDING)

--- a/test/BuildingOccupantDeathHarness.cpp
+++ b/test/BuildingOccupantDeathHarness.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// A completed service does not put a unit on the map until an exit is found.
+#include "GlobalContainer.h"
+#include "Game.h"
+#include "GameGUI.h"
+#include "Unit.h"
+#include "Building.h"
+#include "IntBuildingType.h"
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+struct Occupant : Unit
+{
+    using Unit::Unit;
+    using Unit::handleMovementExitingBuilding;
+    using Unit::handleAction;
+};
+
+static void destroyedDuringExit(int unitType, bool blocked)
+{
+    GameGUI gui;
+    Game& game = gui.game;
+    game.map.setSize(5, 5, GRASS);
+    game.map.setGame(&game);
+    game.addTeam(0);
+    game.addTeam(1);
+    game.teams[0]->race.loadDefault();
+    game.teams[1]->race.loadDefault();
+    auto* team = game.teams[0];
+    const int innType = globalContainer->buildingsTypes.getTypeNum("inn", 0, false);
+    auto* inn = game.addBuilding(8, 8, innType, 0);
+    require(inn != nullptr, "create inn");
+    auto* unit = new Occupant(8, 8, 0, unitType, team, 0);
+    team->myUnits[0] = unit;
+    unit->attachedBuilding = inn;
+    unit->setTargetBuilding(inn);
+    inn->unitsInside.push_back(unit);
+    unit->activity = Unit::ACT_UPGRADING;
+    unit->displacement = Unit::DIS_EXITING_BUILDING;
+    unit->movement = Unit::MOV_INSIDE;
+    unit->destinationPurpose = FEED;
+    unit->needToRecheckMedical = true;
+    const bool flying = unit->performance[FLY];
+    std::vector<Unit*> blockers;
+    if (blocked)
+    {
+        if (flying)
+        {
+            for (int x = 8; x < 8 + inn->type->width; ++x)
+                for (int y = 8; y < 8 + inn->type->height; ++y)
+                {
+                    auto* blocker = game.addUnit(x, y, 1, EXPLORER, 0, 0, 0, 0);
+                    require(blocker != nullptr, "occupy air exit");
+                    blockers.push_back(blocker);
+                }
+        }
+        else
+        {
+            for (int x = 7; x <= 8 + inn->type->width; ++x)
+                for (int y = 7; y <= 8 + inn->type->height; ++y)
+                {
+                    if (x >= 8 && x < 8 + inn->type->width && y >= 8 && y < 8 + inn->type->height)
+                        continue;
+                    auto& resource = game.map.getResource(x, y);
+                    resource.type = WOOD;
+                    resource.amount = 1;
+                }
+        }
+    }
+    unit->handleMovementExitingBuilding();
+    require(unit->movement == (blocked ? Unit::MOV_INSIDE : Unit::MOV_EXITING_BUILDING),
+            "exit search reflects available space");
+    unit->handleAction();
+    inn->kill();
+    require(bool(unit->isDead) == blocked, "destroyed inn kills trapped occupants but spares units that exited");
+    require(unit->attachedBuilding == nullptr && inn->unitsInside.empty(), "destroyed inn releases subscriptions");
+    if (blocked)
+    {
+        // The team must collect the dead unit before it can seek food and convert.
+        team->syncStep();
+        require(team->myUnits[0] == nullptr, "trapped occupant is collected on next team step");
+        for (const auto* blocker : blockers)
+            require(game.map.getAirUnit(blocker->posX, blocker->posY) == blocker->gid,
+                    "indoor death preserves other units' map slots");
+    }
+    else
+    {
+        require((flying ? game.map.getAirUnit(unit->posX, unit->posY)
+                        : game.map.getGroundUnit(unit->posX, unit->posY)) == unit->gid,
+                "successful exit retains map occupancy");
+    }
+}
+
+int main()
+{
+    GlobalContainer globals;
+    globalContainer = &globals;
+    globals.runNoX = true;
+    globals.settings.rememberUnit = false;
+    globals.buildingsTypes.init();
+    IntBuildingType::init();
+    for (int type : {WORKER, EXPLORER})
+        for (bool blocked : {true, false})
+            destroyedDuringExit(type, blocked);
+    std::puts("PASS: destroyed inns collect trapped ground/air occupants and preserve successful exits");
+}


### PR DESCRIPTION
Destroying a building while an occupant has finished service but cannot find an exit released the unit into random activity without a map slot. A hungry worker could then select an enemy inn and abort on the map-occupancy assertion during conversion.

Treat `DIS_EXITING_BUILDING` with `MOV_INSIDE` as still indoors when the building dies, using the existing occupant-death policy. Units that successfully exited remain alive. Conversion assertions remain intact, and no other unit's map slot is overwritten.

Validation:
- Added a real-engine regression covering blocked and successful exits for ground and air units, next-step collection, and preservation of other air units' occupancy; wired it into Linux CI.
- The regression fails against the original destruction code and passes with the fix on Linux. A clean build from current master plus this change also passes the new regression on macOS, plus the adjacent entering-unit save/load regression (40 directions/positions and corruption controls).
- Replayed the original failing 2v2 scenario (FourSquares1, seed 805328015) using an isolated binary with only this translation unit changed: original abort at tick 57950; corrected run exits normally at tick 92802 under a 100000-tick cap.

Tournament queues and the frozen engine were not changed. Diagnostic outcomes are not tournament observations. This PR contains only the core fix and its regression/build integration.
