### PR TITLE
Stop Map::syncStep from spinning when no gradient is allocated

### DIFF
--- a/src/map/MapStep.cpp
+++ b/src/map/MapStep.cpp
@@ -93,9 +93,10 @@ void Map::syncStep(Uint32 stepCounter)
 			updateExploredArea(team);
 	}
 	
-	// We only update one gradient per step, round robin over the gradients in use:
-	bool updated=false;
-	while (!updated)
+	// We only update one gradient per step, round robin over the gradients in use.
+	// Fields are allocated lazily: the second pass runs on freshly reset flags,
+	// so finding nothing there means no gradient exists yet and there is nothing to do.
+	for (int pass=0; pass<2; pass++)
 	{
 		int numberOfTeam=game->mapHeader.getNumberOfTeams();
 		for (int t=0; t<numberOfTeam; t++)

--- a/test/BuildingExpelHarness.cpp
+++ b/test/BuildingExpelHarness.cpp
@@ -33,8 +33,6 @@ struct World
 		game.map.setGame(&game);
 		game.addTeam(0);
 		team = game.teams[0];
-		// The gradient scheduler expects an in-use field; allocation is now lazy.
-		game.map.getResourceGradient(0, WOOD, 0);
 	}
 
 	// Game::addBuilding creates the building; the map footprint is registered separately.
@@ -225,6 +223,17 @@ static void healingIsKeptProRata()
 	std::puts("PASS healing is kept pro rata");
 }
 
+// Gradients are allocated lazily, so a fresh world has none: the per-step
+// round robin must still return instead of spinning until one appears.
+static void stepsWithoutAnyGradient()
+{
+	World world;
+	world.step(3);
+	world.game.map.getResourceGradient(0, WOOD, 0);
+	world.step(3);
+	std::puts("PASS a world without gradients keeps stepping");
+}
+
 int main()
 {
 	GlobalContainer globals;
@@ -234,6 +243,7 @@ int main()
 	globals.buildingsTypes.init();
 	IntBuildingType::init();
 	Race::loadDefault();
+	stepsWithoutAnyGradient();
 	destroyedInnExpelsEveryone();
 	noRoomKillsTheSurplus();
 	healingIsKeptProRata();

--- a/test/TrappedUnitLifecycleTest.cpp
+++ b/test/TrappedUnitLifecycleTest.cpp
@@ -82,8 +82,6 @@ struct Fixture {
         int x, y, dx, dy;
         assert(!building->findGroundExit(&x, &y, &dx, &dy, false));
         assert(game.addUnit(40, 40, 1, WORKER, 0, 0, 0, 0));
-        // The gradient scheduler expects an in-use field; allocation is now lazy.
-        game.map.getResourceGradient(0, WOOD, 0);
     }
 };
 using Trace = std::vector<std::vector<Uint32>>;
@@ -137,7 +135,6 @@ Trace eliminationAndSave(int resource, int purpose) {
     input.seekFromStart(0);
     assert(restored.game.load(&input));
     restored.game.setWaitingOnMask(0);
-    restored.game.map.getResourceGradient(0, WOOD, 0);
     randomGenerator = checkpointRng;
     const auto after = state(restored.game, f.id);
     for (size_t i = 0; i < before.size(); ++i)


### PR DESCRIPTION
`Map::syncStep`'s round robin is `while (!updated)` with `updated` never set; it only exits through the returns inside its scans. Since gradients are allocated lazily (cac37e99), a team set without a single allocated field never reaches a return: a fresh world, a game with no teams, or a loaded game before any unit asks for a field hangs the whole game step. #186 hit it when its expulsion harness was rebased onto master (357d5fd7 papered over it by touching one gradient at setup, same as `TrappedUnitLifecycleTest`).

Fix: two passes instead of an open-ended loop. The first pass finds the next field still due; the second runs on freshly reset flags and finds the first allocated field. Finding nothing on the second pass means nothing is allocated.

Also drops the `getResourceGradient` workarounds from `BuildingExpelHarness` and `TrappedUnitLifecycleTest`, and adds a bare-world stepping scenario to `BuildingExpelHarness` so a regression fails the harness rather than the CI job timeout.

Verified locally (release build): `BuildingExpelHarness` 4/4 scenarios, `TrappedUnitLifecycleTest` via `run-savegame-safety-tests.py` all PASS with identical trace digests before and after save/load.

Note for #212: that branch already restructures this loop into `pickRoundRobinField` with the same two-pass shape, so its rebase resolves by keeping its own version.
