### PR TITLE
Round-trip gradients: send workers to the resource nearest for the whole trip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,11 @@ jobs:
           scons -j$(nproc) release=1 server=0 resource-fetch-target-test
           python3 test/run-savegame-safety-tests.py --check-preferences build/src/ResourceFetchTargetHarness .
 
+      - name: Build and run the round-trip hunger gate regression
+        run: |
+          scons -j$(nproc) release=1 server=0 round-trip-hunger-gate-test
+          python3 test/run-savegame-safety-tests.py --check-preferences build/src/RoundTripHungerGateHarness .
+
       - name: Test savegame loading and atomic autosaves
         run: |
           scons -j$(nproc) release=1 server=0 savegame-safety-test buffered-file-test

--- a/src/FileFormatVersions.h
+++ b/src/FileFormatVersions.h
@@ -89,6 +89,9 @@ static constexpr int FILE_FORMAT_VERSION_PENDING_CONSTRUCTION = 90;
 //! Saved-game live RNG, occupancy, fog buffers and cached routing fields.
 static constexpr int FILE_FORMAT_VERSION_CONTINUATION_STATE = 91;
 
+//! A building's round-trip fields and gradient use stamps join the cached routing fields.
+static constexpr int FILE_FORMAT_VERSION_ROUND_TRIP_FIELDS = 95;
+
 // === Save-file section signatures (4-byte ASCII tags) ===
 // Embedded as four chars at the start of each save section so a corrupted
 // stream fails fast. NEVER change these values — old saves on disk depend

--- a/src/Game_io.cpp
+++ b/src/Game_io.cpp
@@ -284,7 +284,7 @@ bool Game::load(GAGCore::InputStream *stream)
 		std::istringstream input(state.str());
 		input.imbue(std::locale::classic());
 		if (!(input >> savedRandom)) return false;
-		map.loadRuntimeState(stream);
+		map.loadRuntimeState(stream, versionMinor);
 	}
 	gameSection.commit();
 

--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -23,10 +23,10 @@ static constexpr Uint32 REPLAY_MIN_VALID_ORDERS = 5;
 
 //! Oldest replay format (the VERSION_MINOR the replay was written with) that
 //! the reader still accepts. Replays older than this are rejected: versions 90, 92,
-//! 93 and 94 changed the simulation (weighted pathfinding and diagonal timing,
-//! hiring-bucket iteration, trapped-colony elimination, fetch-job apportionment),
-//! so earlier replays would diverge from what happened.
-static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 94;
+//! 93, 94 and 95 changed the simulation (weighted pathfinding and diagonal timing,
+//! hiring-bucket iteration, trapped-colony elimination, fetch-job apportionment,
+//! round-trip routing and hiring), so earlier replays would diverge from what happened.
+static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 95;
 
 /// This class is used for reading replays.
 /// The replay stream is kept open and read every time you do retrieveOrder.

--- a/src/SConscript
+++ b/src/SConscript
@@ -662,3 +662,10 @@ if not env['server']:
     regression_sources += local.Object('BuildingExpelHarness.o', '#test/BuildingExpelHarness.cpp')
     regression_test = local.Program('BuildingExpelHarness', regression_sources)
     local.Alias('building-expel-test', regression_test)
+
+# Real engine regression for the resource hunger gate, built only by its explicit target.
+if not env['server']:
+    regression_sources = [source for source in source_files if source != 'Glob2.cpp']
+    regression_sources += local.Object('RoundTripHungerGateHarness.o', '#test/RoundTripHungerGateHarness.cpp')
+    regression_test = local.Program('RoundTripHungerGateHarness', regression_sources)
+    local.Alias('round-trip-hunger-gate-test', regression_test)

--- a/src/Version.h
+++ b/src/Version.h
@@ -6,7 +6,7 @@
 // This is the version of map and savegame format, and all of the recorded data on the server
 #define VERSION_MAJOR 0
 #define MINIMUM_VERSION_MINOR 58
-#define VERSION_MINOR 94
+#define VERSION_MINOR 95
 // version 91 saves the live RNG and routing state for deterministic continuation.
 // version 10 adds script saved in game
 // version 11 the gamesfiles do saves which building has been seen under fog of war.
@@ -100,6 +100,8 @@
 // version 94 apportions fetch jobs across the resources a building wants instead of
 //            letting the nearest one take every slot, and prices a loaded candidate
 //            rather than refusing it: the simulation changed again
+// version 95 routes and hires by round trip (fetch plus carry) and saves the
+//            round-trip fields with the map runtime state: the simulation changed again
 
 //This must be updated when there are changes to YOG, MapHeader, GameHeader, BasePlayer, BaseTeam,
 //NetMessage, and the likes, in parallel to change of the VERSION_MINOR above

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -588,10 +588,12 @@ public:
 	// All swimming classes share passability, but keep separate weighted fields.
 	//! Round-trip gradients per resource type and swim class (see Map::roundTripGradient),
 	//! NULL until a unit fetching that resource for this building asks for one, freed again
-	//! when unused for a while. Their last rebuild and last use, in steps.
+	//! by freeIdleRoundTripGradients when unused for a while. Their last rebuild and last
+	//! use, in steps.
 	Uint16 *roundTripGradient[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	Uint32 roundTripGradientStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	Uint32 roundTripGradientUsedStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
+	void freeIdleRoundTripGradients();
 	bool locked[SWIM_VARIANT_COUNT]; //True if the building is not reachable.
 
 	// Per-swim-variant tri-state cache of whether a clearing flag has any

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -436,6 +436,10 @@ private:
 		Unit* choosen;
 	};
 
+	/// Lets test/RoundTripHungerGateHarness.cpp reach considerUnitForResource
+	/// without exposing it to game callers, as GameGUI does for its own harness.
+	friend class RoundTripHungerGateHarness;
+
 	/// Whether a unit is a possible hire at all: harvest-capable, idle, healthy,
 	/// high enough level, and close enough to reach this building before going
 	/// hungry. Fills *distBuilding on success; on failure tallies the rejection

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -586,14 +586,18 @@ public:
 	Uint32 lastGlobalGradientUpdateStepCounter[SWIM_CLASS_COUNT];
 	// These flags track physical access (cannot swim / can swim), not travel cost.
 	// All swimming classes share passability, but keep separate weighted fields.
+	//! Last step a unit asked for the gradient; freeIdleGradients drops it when that is long ago.
+	Uint32 globalGradientUsedStep[SWIM_CLASS_COUNT];
 	//! Round-trip gradients per resource type and swim class (see Map::roundTripGradient),
 	//! NULL until a unit fetching that resource for this building asks for one, freed again
-	//! by freeIdleRoundTripGradients when unused for a while. Their last rebuild and last
+	//! by freeIdleGradients when unused for a while. Their last rebuild and last
 	//! use, in steps.
 	Uint16 *roundTripGradient[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	Uint32 roundTripGradientStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	Uint32 roundTripGradientUsedStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
-	void freeIdleRoundTripGradients();
+	//! Drop the building's and the round-trip gradients nobody asked for lately. Only
+	//! buildings with fetchers need one, and each is a full map of Uint16.
+	void freeIdleGradients();
 	bool locked[SWIM_VARIANT_COUNT]; //True if the building is not reachable.
 
 	// Per-swim-variant tri-state cache of whether a clearing flag has any

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -586,6 +586,12 @@ public:
 	Uint32 lastGlobalGradientUpdateStepCounter[SWIM_CLASS_COUNT];
 	// These flags track physical access (cannot swim / can swim), not travel cost.
 	// All swimming classes share passability, but keep separate weighted fields.
+	//! Round-trip gradients per resource type and swim class (see Map::roundTripGradient),
+	//! NULL until a unit fetching that resource for this building asks for one, freed again
+	//! when unused for a while. Their last rebuild and last use, in steps.
+	Uint16 *roundTripGradient[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
+	Uint32 roundTripGradientStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
+	Uint32 roundTripGradientUsedStep[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	bool locked[SWIM_VARIANT_COUNT]; //True if the building is not reachable.
 
 	// Per-swim-variant tri-state cache of whether a clearing flag has any

--- a/src/building/Lifecycle.cpp
+++ b/src/building/Lifecycle.cpp
@@ -166,25 +166,35 @@ void Building::resetPathfindGradients()
 	}
 }
 
-void Building::freeIdleRoundTripGradients()
+void Building::freeIdleGradients()
 {
-	// Fetchers keep a gradient alive by reading it; 500 ticks after the last one, it goes.
-	constexpr Uint32 ROUND_TRIP_IDLE_TICKS = 500;
+	// Units keep a gradient alive by reading it; 500 ticks after the last one, it goes.
+	constexpr Uint32 IDLE_TICKS = 500;
 	Uint32 now = owner->game->stepCounter;
-	for (int r=0; r<MAX_NB_RESOURCES; r++)
-		for (int c=0; c<SWIM_CLASS_COUNT; c++)
-			if (roundTripGradient[r][c] && roundTripGradientUsedStep[r][c]+ROUND_TRIP_IDLE_TICKS<now)
+	for (int c=0; c<SWIM_CLASS_COUNT; c++)
+	{
+		if (globalGradient[c] && globalGradientUsedStep[c]+IDLE_TICKS<now)
+		{
+			delete[] globalGradient[c];
+			globalGradient[c] = NULL;
+		}
+		for (int r=0; r<MAX_NB_RESOURCES; r++)
+			if (roundTripGradient[r][c] && roundTripGradientUsedStep[r][c]+IDLE_TICKS<now)
 			{
 				delete[] roundTripGradient[r][c];
 				roundTripGradient[r][c] = NULL;
 			}
+	}
 }
 
 void Building::freeGradients()
 {
 	resetPathfindGradients();
 	for (int i=0; i<SWIM_CLASS_COUNT; i++)
+	{
 		lastGlobalGradientUpdateStepCounter[i] = 0;
+		globalGradientUsedStep[i] = 0;
+	}
 	for (int i=0; i<SWIM_VARIANT_COUNT; i++)
 		anyResourceToClear[i] = 0;
 }

--- a/src/building/Lifecycle.cpp
+++ b/src/building/Lifecycle.cpp
@@ -20,7 +20,11 @@
 Building::Building(GAGCore::InputStream *stream, BuildingsTypes *types, Team *owner, Sint32 versionMinor)
 {
 	for (int i=0; i<SWIM_CLASS_COUNT; i++)
+	{
 		globalGradient[i]=NULL;
+		for (int r=0; r<MAX_NB_RESOURCES; r++)
+			roundTripGradient[r][i]=NULL;
+	}
 	freeGradients();
 	load(stream, types, owner, versionMinor);
 }
@@ -112,7 +116,11 @@ Building::Building(int x, int y, Uint16 gid, Sint32 typeNum, Team *team, Buildin
 		inUpgrade[i]=LS_UNKNOWN;
 
 	for (int i=0; i<SWIM_CLASS_COUNT; i++)
+	{
 		globalGradient[i]=NULL;
+		for (int r=0; r<MAX_NB_RESOURCES; r++)
+			roundTripGradient[r][i]=NULL;
+	}
 	freeGradients();
 
 	verbose=false;
@@ -148,6 +156,13 @@ void Building::resetPathfindGradients()
 	{
 		delete[] globalGradient[i];
 		globalGradient[i] = NULL;
+		for (int r=0; r<MAX_NB_RESOURCES; r++)
+		{
+			delete[] roundTripGradient[r][i];
+			roundTripGradient[r][i] = NULL;
+			roundTripGradientStep[r][i] = 0;
+			roundTripGradientUsedStep[r][i] = 0;
+		}
 	}
 }
 

--- a/src/building/Lifecycle.cpp
+++ b/src/building/Lifecycle.cpp
@@ -166,6 +166,20 @@ void Building::resetPathfindGradients()
 	}
 }
 
+void Building::freeIdleRoundTripGradients()
+{
+	// Fetchers keep a gradient alive by reading it; 500 ticks after the last one, it goes.
+	constexpr Uint32 ROUND_TRIP_IDLE_TICKS = 500;
+	Uint32 now = owner->game->stepCounter;
+	for (int r=0; r<MAX_NB_RESOURCES; r++)
+		for (int c=0; c<SWIM_CLASS_COUNT; c++)
+			if (roundTripGradient[r][c] && roundTripGradientUsedStep[r][c]+ROUND_TRIP_IDLE_TICKS<now)
+			{
+				delete[] roundTripGradient[r][c];
+				roundTripGradient[r][c] = NULL;
+			}
+}
+
 void Building::freeGradients()
 {
 	resetPathfindGradients();

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -39,6 +39,8 @@ namespace
 void Building::step(void)
 {
 	computeWishedResources(wishedResources);
+	if (((owner->game->stepCounter + gid) & 255) == 0)
+		freeIdleRoundTripGradients();
 
 	updateCallLists();
 	if(underAttackTimer>0)

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -103,7 +103,12 @@ bool Building::considerUnitForResource(Unit* unit, int wantedResource, int* dist
 		return false;
 	}
 
-	*dist = (distBuilding + distResource)<<Q8_FIXED_POINT_SHIFT;
+	// Score by the whole job: the round-trip field when a fetcher has already
+	// built one, the plain walk out and back otherwise.
+	int roundTrip = 0;
+	if(!owner->map->roundTripDistance(this, wantedResource, unit->swimClass(), unit->posX, unit->posY, &roundTrip))
+		roundTrip = distBuilding + distResource;
+	*dist = roundTrip<<Q8_FIXED_POINT_SHIFT;
 	return true;
 }
 

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -40,7 +40,7 @@ void Building::step(void)
 {
 	computeWishedResources(wishedResources);
 	if (((owner->game->stepCounter + gid) & 255) == 0)
-		freeIdleRoundTripGradients();
+		freeIdleGradients();
 
 	updateCallLists();
 	if(underAttackTimer>0)

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -4,6 +4,7 @@
 #include <list>
 #include <math.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <climits>
 
 #include "Building.h"
@@ -106,10 +107,14 @@ bool Building::considerUnitForResource(Unit* unit, int wantedResource, int* dist
 	}
 
 	// Score by the whole job: the round-trip field when a fetcher has already
-	// built one, the plain walk out and back otherwise.
+	// built one. Without one, estimate the carry leg rather than reach for the
+	// building distance alone: a unit standing at the building carries as far
+	// as it walked out, and one standing at the resource carries the building
+	// distance. Building a field here instead would cost one per resource of
+	// every hiring building, nearly all of them never fetched.
 	int roundTrip = 0;
 	if(!owner->map->roundTripDistance(this, wantedResource, unit->swimClass(), unit->posX, unit->posY, &roundTrip))
-		roundTrip = distBuilding + distResource;
+		roundTrip = distResource + std::max(distBuilding, distResource);
 	*dist = roundTrip<<Q8_FIXED_POINT_SHIFT;
 	return true;
 }

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -77,7 +77,7 @@ class Map
 {
 public:
 	void saveRuntimeState(GAGCore::OutputStream *stream) const;
-	void loadRuntimeState(GAGCore::InputStream *stream);
+	void loadRuntimeState(GAGCore::InputStream *stream, Sint32 versionMinor);
 	//! Type of terrain (used for undermap)
 
 	// === Tile geometry (cross-slice) ===

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -598,6 +598,8 @@ public:
 	static constexpr int SWIM_CLASS_EVEN = 3;
 	//! Cheapest possible step for a class, the A* heuristic unit.
 	static int minStepCost(int swimClass);
+	//! Highest cost a gradient can hold (see MapInternal.h).
+	static constexpr int GRADIENT_COST_LIMIT = 0xFFFF - 1 - 1 - 42;
 	//! Cost of stepping (dx, dy) into the cell at targetIndex, in gradient units.
 	int stepCost(int dx, int dy, size_t targetIndex, int swimClass) const;
 	
@@ -629,22 +631,38 @@ public:
 	// the pathfinding gradients are built by propagateGradient. Defined in
 	// MapGradientGlobal.cpp.
 	void updateGlobalGradient(Uint8 *gradient);
-	//! Dijkstra on a freshly seeded field (see MapInternal.h). Seed costs must be
-	//! between 0 and the largest terrain step (currently 42); do not pass a completed
-	//! field. Uses shared scratch storage: calls across all Maps must be serial and
-	//! non-reentrant. swimClass must be in [0, SWIM_CLASS_COUNT).
-	void propagateGradient(Uint16 *gradient, int swimClass);
+	//! Dijkstra from every seeded cell of a pathfinding gradient (see MapInternal.h).
+	//! Seeds may carry any cost up to GRADIENT_COST_LIMIT (0 for GRADIENT_AT_GOAL; e.g. a
+	//! resource tile seeded with its distance to a building); do not pass a completed
+	//! field. With maxCost, cells that would cost more stay unreachable. Uses shared
+	//! scratch storage: calls across all Maps must be serial and non-reentrant.
+	//! swimClass must be in [0, SWIM_CLASS_COUNT).
+	void propagateGradient(Uint16 *gradient, int swimClass, int maxCost = GRADIENT_COST_LIMIT);
 	//! Step toward the neighbour with the highest value minus step cost. strict requires
 	//! real progress; otherwise a random sidestep to an equal cell is accepted when blocked.
 	bool directionByGradient(Uint32 teamMask, int swimClass, int x, int y, const Uint16 *gradient, int *dx, int *dy, bool strict) const;
 	void updateResourcesGradient(int teamNumber, Uint8 resourceType, int swimClass);
-	bool pathfindResource(int teamNumber, Uint8 resourceType, int swimClass, int x, int y, int *dx, int *dy, bool *stopWork);
+	//! Direction toward a resource of resourceType. With a target building the round-trip
+	//! gradient is descended, so the unit heads for the resource that is nearest for
+	//! fetching and carrying it there; without one, for the resource nearest to itself.
+	bool pathfindResource(int teamNumber, Uint8 resourceType, int swimClass, int x, int y, int *dx, int *dy, bool *stopWork, Building *target);
 #ifndef YOG_SERVER_ONLY
 	void pathfindRandom(Unit *unit);
 #endif  // !YOG_SERVER_ONLY
 
 	//! Rebuild the building's full-map gradient for a swim class.
 	void updateGlobalGradient(Building *building, int swimClass);
+	//! Rebuild the building's round-trip gradient for a resource type and swim class:
+	//! every tile of that resource is seeded with its distance to the building, so a
+	//! cell's value is the cheapest fetch-and-carry trip from there.
+	void updateRoundTripGradient(Building *building, int resourceType, int swimClass);
+	//! The building's round-trip gradient, built or refreshed on demand. NULL when the
+	//! building cannot be reached.
+	const Uint16 *roundTripGradient(Building *building, int resourceType, int swimClass);
+	//! Tiles of the cheapest trip from (x, y) to a resource of resourceType and on to the
+	//! building, read from a round-trip gradient a fetcher's walk has already built. False
+	//! when there is none or no such trip; the caller then scores by the plain distances.
+	bool roundTripDistance(Building *building, int resourceType, int swimClass, int x, int y, int *dist);
 	//! The building's gradient for a swim class, built or refreshed as needed; NULL if the building is unreachable.
 	const Uint16 *buildingGradient(Building *building, int swimClass);
 	bool buildingAvailable(Building *building, int swimClass, int x, int y, int *dist);

--- a/src/map/gradient/MapGradientBuilding.cpp
+++ b/src/map/gradient/MapGradientBuilding.cpp
@@ -11,6 +11,8 @@
 
 // updateGlobalGradient(Building*): the full-map gradient toward a building, a
 // flag's zone or, for a clearing flag, the clearable resources in its range.
+// updateRoundTripGradient: the gradient of the trip to a resource and on to
+// the building.
 
 void Map::updateGlobalGradient(Building *building, int swimClass)
 {
@@ -125,4 +127,43 @@ void Map::updateGlobalGradient(Building *building, int swimClass)
 		building->locked[canSwim]=false;
 
 	propagateGradient(gradient, swimClass);
+}
+
+
+void Map::updateRoundTripGradient(Building *building, int resourceType, int swimClass)
+{
+	Uint16 *gradient=building->roundTripGradient[resourceType][swimClass];
+	assert(gradient);
+	building->roundTripGradientStep[resourceType][swimClass]=game->stepCounter;
+	const Uint16 *toBuilding=building->globalGradient[swimClass];
+	const Uint16 *toResource=getResourceGradient(building->owner->teamNumber, resourceType, swimClass);
+	// Same obstacles as the resource gradient. A resource tile is seeded with
+	// the cost of carrying from the cheapest free cell next to it, where the
+	// unit harvests, to the building.
+	Uint16 bestSeed=GRADIENT_UNREACHABLE;
+	for (size_t i=0; i<size; i++)
+	{
+		if (toResource[i]!=GRADIENT_AT_GOAL)
+		{
+			gradient[i]=toResource[i]==GRADIENT_FORBIDDEN ? GRADIENT_FORBIDDEN : GRADIENT_UNREACHABLE;
+			continue;
+		}
+		size_t x=i&wMask;
+		size_t y=i>>wDec;
+		Uint16 best=GRADIENT_UNREACHABLE;
+		for (int d=0; d<8; d++)
+		{
+			size_t n=coordToIndex(x+tabClose[d][0], y+tabClose[d][1]);
+			if (toResource[n]>GRADIENT_UNREACHABLE && toBuilding[n]>best)
+				best=toBuilding[n];
+		}
+		gradient[i]=best;
+		if (best>bestSeed)
+			bestSeed=best;
+	}
+	// Units farther than this from the cheapest fetch are scored by the plain
+	// distances instead (the callers fall back when a cell is unreachable
+	// here), which keeps the build small on big maps.
+	constexpr int ROUND_TRIP_RANGE=128*GRADIENT_STEP;
+	propagateGradient(gradient, swimClass, GRADIENT_AT_GOAL-bestSeed+ROUND_TRIP_RANGE);
 }

--- a/src/map/gradient/MapGradientField.cpp
+++ b/src/map/gradient/MapGradientField.cpp
@@ -5,7 +5,9 @@
 #include "MapInternal.h"
 #include "Utilities.h"
 
+#include <algorithm>
 #include <cstdlib>
+#include <utility>
 #include <vector>
 
 // Building and reading the pathfinding gradients (cell values: MapInternal.h).
@@ -24,11 +26,15 @@ namespace
 	constexpr int BUCKETS = MAX_STEP + 1;
 	// Costs above this would run into the sentinels; propagation stops there.
 	constexpr int COST_LIMIT = GRADIENT_AT_GOAL - GRADIENT_UNREACHABLE - 1 - MAX_STEP;
+	static_assert(COST_LIMIT == Map::GRADIENT_COST_LIMIT);
 
 	// Shared scratch storage retains capacity between fields. Calls must be serial
 	// and non-reentrant, including calls on different Maps. Before parallelizing
 	// propagation, give each worker its own workspace; these are not cached fields.
 	std::vector<int> buckets[BUCKETS];
+	// Seeds whose cost lies beyond the bucket window, sorted by (cost, cell);
+	// each enters its bucket once the sweep reaches its cost.
+	std::vector<std::pair<int, int>> deferredSeeds;
 }
 
 static_assert(WATER_STEP[Map::SWIM_CLASS_EVEN] == GRADIENT_STEP);
@@ -66,24 +72,41 @@ int Map::stepCost(int dx, int dy, size_t targetIndex, int swimClass) const
 }
 
 // Seeds are the cells above GRADIENT_UNREACHABLE; each starts at its own cost
-// (0 for GRADIENT_AT_GOAL). Seed costs must be in [0, MAX_STEP], so the initial
-// queue fits one bucket rotation. Reseed before reuse; a propagated field is
-// not a valid seed buffer. GRADIENT_FORBIDDEN cells are obstacles.
-void Map::propagateGradient(Uint16 *gradient, int swimClass)
+// (0 for GRADIENT_AT_GOAL, anything up to COST_LIMIT otherwise, e.g. a resource
+// tile seeded with its distance to a building). Seeds within one bucket rotation
+// start in the queue; dearer ones join it when the frontier reaches their cost.
+// Reseed before reuse; a propagated field is not a valid seed buffer.
+// GRADIENT_FORBIDDEN cells are obstacles.
+void Map::propagateGradient(Uint16 *gradient, int swimClass, int maxCost)
 {
+	const int limit = std::min(maxCost, COST_LIMIT);
 	for (int b = 0; b < BUCKETS; b++)
 		buckets[b].clear();
+	deferredSeeds.clear();
 	size_t pending = 0;
 	for (size_t i = 0; i < size; i++)
 		if (gradient[i] > GRADIENT_UNREACHABLE)
 		{
 			int cost = GRADIENT_AT_GOAL - gradient[i];
-			assert(cost <= MAX_STEP);
-			buckets[cost % BUCKETS].push_back((int)i);
+			if (cost <= MAX_STEP)
+			{
+				buckets[cost % BUCKETS].push_back((int)i);
+				pending++;
+			}
+			else
+				deferredSeeds.push_back({cost, (int)i});
+		}
+	std::sort(deferredSeeds.begin(), deferredSeeds.end());
+	size_t nextSeed = 0;
+	for (int cur = 0; (pending > 0 || nextSeed < deferredSeeds.size()) && cur <= limit; cur++)
+	{
+		if (pending == 0)
+			cur = deferredSeeds[nextSeed].first; // the queue is empty: jump to the next seed
+		for (; nextSeed < deferredSeeds.size() && deferredSeeds[nextSeed].first == cur; nextSeed++)
+		{
+			buckets[cur % BUCKETS].push_back(deferredSeeds[nextSeed].second);
 			pending++;
 		}
-	for (int cur = 0; pending > 0 && cur <= COST_LIMIT; cur++)
-	{
 		std::vector<int> &bucket = buckets[cur % BUCKETS];
 		// Relaxations may append to other buckets but never to this one
 		// (each step is positive and less than BUCKETS), so iteration is safe.
@@ -107,7 +130,7 @@ void Map::propagateGradient(Uint16 *gradient, int swimClass)
 			auto& diagonalBucket = buckets[diagonalCost % BUCKETS];
 			auto relax = [&](size_t n, int cost, std::vector<int>& destination)
 			{
-				if (gradient[n] != GRADIENT_FORBIDDEN && cost < GRADIENT_AT_GOAL - gradient[n])
+				if (gradient[n] != GRADIENT_FORBIDDEN && cost <= limit && cost < GRADIENT_AT_GOAL - gradient[n])
 				{
 					gradient[n] = (Uint16)(GRADIENT_AT_GOAL - cost);
 					destination.push_back((int)n);

--- a/src/map/io/MapIO.cpp
+++ b/src/map/io/MapIO.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2001-2004 Stephane Magnenat & Luc-Olivier de Charrière
 
 #include "Map.h"
+#include "FileFormatVersions.h"
 #include "MapInternal.h"
 #include "Game.h"
 #include "Utilities.h"
@@ -407,6 +408,22 @@ void Map::saveRuntimeState(GAGCore::OutputStream *stream) const
 				stream->writeUint32(building->lastGlobalGradientUpdateStepCounter[sw], "lastUpdate");
 				stream->writeLeaveSection();
 			}
+			stream->writeEnterSection("roundTrip");
+			for (int sw=0; sw<SWIM_CLASS_COUNT; ++sw)
+			{
+				stream->writeEnterSection(sw);
+				stream->writeUint32(building->globalGradientUsedStep[sw], "usedStep");
+				for (int r=0; r<MAX_NB_RESOURCES; ++r)
+				{
+					stream->writeEnterSection(r);
+					saveGradient(stream, building->roundTripGradient[r][sw], size);
+					stream->writeUint32(building->roundTripGradientStep[r][sw], "step");
+					stream->writeUint32(building->roundTripGradientUsedStep[r][sw], "usedStep");
+					stream->writeLeaveSection();
+				}
+				stream->writeLeaveSection();
+			}
+			stream->writeLeaveSection();
 			stream->writeEnterSection("access");
 			for (int sw=0; sw<SWIM_VARIANT_COUNT; ++sw)
 			{
@@ -425,7 +442,7 @@ void Map::saveRuntimeState(GAGCore::OutputStream *stream) const
 	stream->writeLeaveSection();
 }
 
-void Map::loadRuntimeState(GAGCore::InputStream *stream)
+void Map::loadRuntimeState(GAGCore::InputStream *stream, Sint32 versionMinor)
 {
 	stream->readEnterSection("mapRuntime");
 	const bool fogIsA=loadFlag(stream,"fogIsA");
@@ -489,6 +506,25 @@ void Map::loadRuntimeState(GAGCore::InputStream *stream)
 				loadGradient(stream, building->globalGradient[sw], size);
 				building->dirtyGradient[sw]=loadFlag(stream,"dirty");
 				building->lastGlobalGradientUpdateStepCounter[sw]=stream->readUint32("lastUpdate");
+				stream->readLeaveSection();
+			}
+			if (versionMinor >= FILE_FORMAT_VERSION_ROUND_TRIP_FIELDS)
+			{
+				stream->readEnterSection("roundTrip");
+				for (int sw=0; sw<SWIM_CLASS_COUNT; ++sw)
+				{
+					stream->readEnterSection(sw);
+					building->globalGradientUsedStep[sw]=stream->readUint32("usedStep");
+					for (int r=0; r<MAX_NB_RESOURCES; ++r)
+					{
+						stream->readEnterSection(r);
+						loadGradient(stream, building->roundTripGradient[r][sw], size);
+						building->roundTripGradientStep[r][sw]=stream->readUint32("step");
+						building->roundTripGradientUsedStep[r][sw]=stream->readUint32("usedStep");
+						stream->readLeaveSection();
+					}
+					stream->readLeaveSection();
+				}
 				stream->readLeaveSection();
 			}
 			stream->readEnterSection("access");

--- a/src/map/pathfind/MapPathfindBuilding.cpp
+++ b/src/map/pathfind/MapPathfindBuilding.cpp
@@ -22,9 +22,8 @@ constexpr Uint32 DIRTY_REBUILD_TICKS = 25;
 constexpr Uint32 STUCK_REBUILD_TICKS = 128;
 // A round-trip gradient follows its two parents with at most this delay (the
 // resource gradient stays authoritative for reachability, so staleness only
-// costs a detour), and is freed when nobody asked for it for this long.
+// costs a detour). Building::freeIdleRoundTripGradients drops unused ones.
 constexpr Uint32 ROUND_TRIP_REFRESH_TICKS = 120;
-constexpr Uint32 ROUND_TRIP_IDLE_TICKS = 500;
 
 bool isClearingFlag(const Building *building)
 {
@@ -86,14 +85,6 @@ const Uint16 *Map::roundTripGradient(Building *building, int resourceType, int s
 	if (gradient==NULL)
 		gradient=new Uint16[size];
 	updateRoundTripGradient(building, resourceType, swimClass);
-	// Rebuilds are rare enough to also drop the building's gradients nobody asked for lately.
-	for (int r=0; r<MAX_NB_RESOURCES; r++)
-		for (int c=0; c<SWIM_CLASS_COUNT; c++)
-			if (building->roundTripGradient[r][c] && building->roundTripGradientUsedStep[r][c]+ROUND_TRIP_IDLE_TICKS<now)
-			{
-				delete[] building->roundTripGradient[r][c];
-				building->roundTripGradient[r][c]=NULL;
-			}
 	return gradient;
 }
 

--- a/src/map/pathfind/MapPathfindBuilding.cpp
+++ b/src/map/pathfind/MapPathfindBuilding.cpp
@@ -22,7 +22,7 @@ constexpr Uint32 DIRTY_REBUILD_TICKS = 25;
 constexpr Uint32 STUCK_REBUILD_TICKS = 128;
 // A round-trip gradient follows its two parents with at most this delay (the
 // resource gradient stays authoritative for reachability, so staleness only
-// costs a detour). Building::freeIdleRoundTripGradients drops unused ones.
+// costs a detour). Building::freeIdleGradients drops unused ones.
 constexpr Uint32 ROUND_TRIP_REFRESH_TICKS = 120;
 
 bool isClearingFlag(const Building *building)
@@ -38,6 +38,7 @@ const Uint16 *Map::buildingGradient(Building *building, int swimClass)
 	Uint16 *&gradient=building->globalGradient[swimClass];
 	Uint32 lastUpdate=building->lastGlobalGradientUpdateStepCounter[swimClass];
 	Uint32 now=game->stepCounter;
+	building->globalGradientUsedStep[swimClass]=now;
 	bool rebuild=false;
 	if (gradient==NULL)
 	{

--- a/src/map/pathfind/MapPathfindBuilding.cpp
+++ b/src/map/pathfind/MapPathfindBuilding.cpp
@@ -11,7 +11,8 @@
 
 
 
-// Building pathfinding (buildingGradient, buildingAvailable, pathfindBuilding, dirtyBuildingGradients)
+// Building pathfinding (buildingGradient, buildingAvailable, roundTripGradient,
+// roundTripDistance, pathfindBuilding, dirtyBuildingGradients)
 
 namespace {
 
@@ -19,6 +20,11 @@ namespace {
 constexpr Uint32 DIRTY_REBUILD_TICKS = 25;
 // A unit that cannot make progress forces a rebuild at most this often (~5 s).
 constexpr Uint32 STUCK_REBUILD_TICKS = 128;
+// A round-trip gradient follows its two parents with at most this delay (the
+// resource gradient stays authoritative for reachability, so staleness only
+// costs a detour), and is freed when nobody asked for it for this long.
+constexpr Uint32 ROUND_TRIP_REFRESH_TICKS = 120;
+constexpr Uint32 ROUND_TRIP_IDLE_TICKS = 500;
 
 bool isClearingFlag(const Building *building)
 {
@@ -61,6 +67,49 @@ bool Map::buildingAvailable(Building *building, int swimClass, int x, int y, int
 	Uint16 g=gradient[coordToIndex(x, y)];
 	for (int d=0; d<8 && g<=GRADIENT_UNREACHABLE; d++)
 		g=gradient[coordToIndex(x+tabClose[d][0], y+tabClose[d][1])];
+	if (g<=GRADIENT_UNREACHABLE)
+		return false;
+	*dist=gradientTiles(g);
+	return true;
+}
+
+
+const Uint16 *Map::roundTripGradient(Building *building, int resourceType, int swimClass)
+{
+	if (buildingGradient(building, swimClass)==NULL)
+		return NULL;
+	Uint32 now=game->stepCounter;
+	Uint16 *&gradient=building->roundTripGradient[resourceType][swimClass];
+	building->roundTripGradientUsedStep[resourceType][swimClass]=now;
+	if (gradient!=NULL && building->roundTripGradientStep[resourceType][swimClass]+ROUND_TRIP_REFRESH_TICKS>now)
+		return gradient;
+	if (gradient==NULL)
+		gradient=new Uint16[size];
+	updateRoundTripGradient(building, resourceType, swimClass);
+	// Rebuilds are rare enough to also drop the building's gradients nobody asked for lately.
+	for (int r=0; r<MAX_NB_RESOURCES; r++)
+		for (int c=0; c<SWIM_CLASS_COUNT; c++)
+			if (building->roundTripGradient[r][c] && building->roundTripGradientUsedStep[r][c]+ROUND_TRIP_IDLE_TICKS<now)
+			{
+				delete[] building->roundTripGradient[r][c];
+				building->roundTripGradient[r][c]=NULL;
+			}
+	return gradient;
+}
+
+bool Map::roundTripDistance(Building *building, int resourceType, int swimClass, int x, int y, int *dist)
+{
+	// Only gradients a fetcher keeps alive: hiring looks at every needed
+	// resource of every building, far more than ever get fetched.
+	const Uint16 *gradient=building->roundTripGradient[resourceType][swimClass];
+	if (gradient==NULL)
+		return false;
+	// It may be a few ticks older than the resource gradient the callers walk
+	// by; never report a resource that one says is gone.
+	if (!resourceAvailable(building->owner->teamNumber, resourceType, swimClass, x, y))
+		return false;
+	building->roundTripGradientUsedStep[resourceType][swimClass]=game->stepCounter;
+	Uint16 g=gradient[coordToIndex(x, y)];
 	if (g<=GRADIENT_UNREACHABLE)
 		return false;
 	*dist=gradientTiles(g);

--- a/src/map/pathfind/MapPathfindRessource.cpp
+++ b/src/map/pathfind/MapPathfindRessource.cpp
@@ -10,11 +10,13 @@
 
 // Resource pathfinding for units (pathfindResource, pathfindRandom)
 
-bool Map::pathfindResource(int teamNumber, Uint8 resourceType, int swimClass, int x, int y, int *dx, int *dy, bool *stopWork)
+#ifndef YOG_SERVER_ONLY
+bool Map::pathfindResource(int teamNumber, Uint8 resourceType, int swimClass, int x, int y, int *dx, int *dy, bool *stopWork, Building *target)
 {
 	assert(resourceType<MAX_RESOURCES);
 	const Uint16 *gradient=getResourceGradient(teamNumber, resourceType, swimClass);
-	Uint16 here=gradient[coordToIndex(x, y)];
+	size_t hereIndex=coordToIndex(x, y);
+	Uint16 here=gradient[hereIndex];
 	Uint32 teamMask=Team::teamNumberToMask(teamNumber);
 	if (here==GRADIENT_FORBIDDEN)
 	{
@@ -29,13 +31,22 @@ bool Map::pathfindResource(int teamNumber, Uint8 resourceType, int swimClass, in
 	*stopWork=false;
 	if (here==GRADIENT_AT_GOAL)
 		return false; // standing where the resource was: it is gone, wander until the gradient is rebuilt
+	if (target)
+	{
+		// The round-trip gradient may lag behind this one by a few ticks; when
+		// it is blocked or stale here, the plain gradient below still leads to
+		// a resource.
+		const Uint16 *roundTrip=roundTripGradient(target, resourceType, swimClass);
+		if (roundTrip && roundTrip[hereIndex]>GRADIENT_UNREACHABLE
+			&& directionByGradient(teamMask, swimClass, x, y, roundTrip, dx, dy, true))
+			return true;
+	}
 	if (directionByGradient(teamMask, swimClass, x, y, gradient, dx, dy, true))
 		return true;
 	return directionByGradient(teamMask, swimClass, x, y, gradient, dx, dy, false);
 }
 
 
-#ifndef YOG_SERVER_ONLY
 void Map::pathfindRandom(Unit *unit)
 {
 	int x=unit->posX;

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -161,7 +161,12 @@ void Unit::handleDisplacement(void)
 								if (need>0)
 								{
 									int distToResource;
-									if (map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource))
+									bool available=map->roundTripDistance(attachedBuilding, r, swimClass(), posX, posY, &distToResource);
+									if (available)
+										distToResource=(distToResource+1)/2; // half the round trip: the unit is at the building
+									else
+										available=map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource);
+									if (available)
 									{
 										if ((distToResource<<1)>=timeLeft)
 											continue; //We don't choose this resource, because it won't have time to reach the resource and bring it back.

--- a/src/unit/UnitMovement.cpp
+++ b/src/unit/UnitMovement.cpp
@@ -558,7 +558,7 @@ void Unit::handleMovementGoingToResource()
 	Map *map=owner->map;
 	int teamNumber=owner->teamNumber;
 	bool stopWork;
-	if (map->pathfindResource(teamNumber, destinationPurpose, swimClass(), posX, posY, &dx, &dy, &stopWork))
+	if (map->pathfindResource(teamNumber, destinationPurpose, swimClass(), posX, posY, &dx, &dy, &stopWork, attachedBuilding))
 	{
 		directionFromDxDy();
 		movement=MOV_GOING_DX_DY;

--- a/test/GradientTest.cpp
+++ b/test/GradientTest.cpp
@@ -171,6 +171,44 @@ void GradientTest::testSeedBelowGoalPropagates()
 	CPPUNIT_ASSERT_EQUAL(GRADIENT_STEP + GRADIENT_DIAGONAL_STEP, cost(g, map, 5, 5));
 }
 
+void GradientTest::testSeedsBeyondBucketWindow()
+{
+	// Seeds may start at any cost, as the round-trip gradients seed resource
+	// tiles with their distance to a building. Walls along x=2 and y=2 cut
+	// the torus into one 7x7 rectangle with the goal in the corner (3,3) and
+	// a seed at cost 60 in the opposite corner (1,1), 84 from the goal.
+	GrassMap map;
+	std::vector<Uint16> g = blank(map);
+	for (int i = 0; i < 8; i++)
+	{
+		g[map.coordToIndex(2, i)] = GRADIENT_FORBIDDEN;
+		g[map.coordToIndex(i, 2)] = GRADIENT_FORBIDDEN;
+	}
+	g[map.coordToIndex(3, 3)] = GRADIENT_AT_GOAL;
+	g[map.coordToIndex(1, 1)] = GRADIENT_AT_GOAL - 60;
+	map.propagateGradient(g.data(), 0);
+	CPPUNIT_ASSERT_EQUAL(0, cost(g, map, 3, 3));
+	CPPUNIT_ASSERT_EQUAL(60, cost(g, map, 1, 1));
+	// (0,0) and (1,0): 70 through the seed, 70 and 80 from the goal.
+	CPPUNIT_ASSERT_EQUAL(70, cost(g, map, 0, 0));
+	CPPUNIT_ASSERT_EQUAL(70, cost(g, map, 1, 0));
+	// (7,7): four diagonals from the goal beat 88 through the seed.
+	CPPUNIT_ASSERT_EQUAL(56, cost(g, map, 7, 7));
+	CPPUNIT_ASSERT_EQUAL((int)GRADIENT_FORBIDDEN, (int)g[map.coordToIndex(2, 5)]);
+}
+
+void GradientTest::testMaxCostStopsPropagation()
+{
+	GrassMap map;
+	std::vector<Uint16> g = blank(map);
+	g[map.coordToIndex(0, 0)] = GRADIENT_AT_GOAL;
+	map.propagateGradient(g.data(), 0, 20);
+	CPPUNIT_ASSERT_EQUAL(20, cost(g, map, 2, 0));
+	CPPUNIT_ASSERT_EQUAL(14, cost(g, map, 1, 1));
+	CPPUNIT_ASSERT_EQUAL((int)GRADIENT_UNREACHABLE, (int)g[map.coordToIndex(3, 0)]);
+	CPPUNIT_ASSERT_EQUAL((int)GRADIENT_UNREACHABLE, (int)g[map.coordToIndex(2, 2)]);
+}
+
 void GradientTest::testDirectionPrefersCheapestTotal()
 {
 	GrassMap map;

--- a/test/GradientTest.h
+++ b/test/GradientTest.h
@@ -15,6 +15,8 @@ class GradientTest: public CppUnit::TestFixture
 		CPPUNIT_TEST( testWaterCostsBySwimClass );
 		CPPUNIT_TEST( testUnreachableCellsStayUnreachable );
 		CPPUNIT_TEST( testSeedBelowGoalPropagates );
+		CPPUNIT_TEST( testSeedsBeyondBucketWindow );
+		CPPUNIT_TEST( testMaxCostStopsPropagation );
 		CPPUNIT_TEST( testDirectionPrefersCheapestTotal );
 		CPPUNIT_TEST( testDirectionBlockedNeighbour );
 		CPPUNIT_TEST( testSwimClassFromSpeeds );
@@ -27,6 +29,8 @@ public:
 	void testWaterCostsBySwimClass();
 	void testUnreachableCellsStayUnreachable();
 	void testSeedBelowGoalPropagates();
+	void testSeedsBeyondBucketWindow();
+	void testMaxCostStopsPropagation();
 	void testDirectionPrefersCheapestTotal();
 	void testDirectionBlockedNeighbour();
 	void testSwimClassFromSpeeds();

--- a/test/RoundTripHungerGateHarness.cpp
+++ b/test/RoundTripHungerGateHarness.cpp
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-engine regression: the hunger check that decides whether a unit may be
+// hired for a resource must measure the walk to that resource, not the length
+// of the whole fetch-and-carry trip.
+#define SDL_MAIN_HANDLED
+#ifdef main
+#undef main
+#endif
+#include "GlobalContainer.h"
+#include "FileManager.h"
+#include <SDL.h>
+#include <string>
+#include "Game.h"
+#include "GameGUI.h"
+#include "Unit.h"
+#include "Team.h"
+#include "Building.h"
+#include "BuildingType.h"
+#include "MapInternal.h"
+#include "Race.h"
+#include "Ressource.h"
+#include "IntBuildingType.h"
+#include "FixedPoint.h"
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+	if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+// considerUnitForResource is private; a friend fixture reaches it without
+// exposing it to game callers, the way GameGUISelectionHarness does.
+class RoundTripHungerGateHarness
+{
+public:
+	static bool consider(Building* building, Unit* unit, int resource, int* dist)
+		{ return building->considerUnitForResource(unit, resource, dist); }
+};
+
+static void aUnitIsJudgedOnTheWalkToTheResource()
+{
+	GameGUI gui;
+	Game& game = gui.game;
+	game.map.setSize(5, 5, GRASS); // 32x32
+	game.map.setGame(&game);
+	game.addTeam(0);
+	Team* team = game.teams[0];
+
+	const Sint32 siteType = globalContainer->buildingsTypes.getTypeNum("market", 0, true);
+	require(siteType >= 0, "the market building site type exists");
+	const BuildingType* type = globalContainer->buildingsTypes.get(siteType);
+
+	const int siteX = 8, siteY = 8;
+	Building* site = new Building(siteX, siteY, Building::GIDfrom(0, 0), siteType, team,
+	                              &globalContainer->buildingsTypes, 4, 4);
+	team->myBuildings[0] = site;
+	game.map.setBuilding(siteX, siteY, type->width, type->height, site->gid);
+	require(site->neededResource(WOOD) > 0, "the site still wants wood");
+
+	// One patch of wood, a walk away from a unit standing at the site.
+	const int woodX = siteX + 9, woodY = siteY;
+	require(game.map.incResource(woodX, woodY, WOOD, 0), "seed the wood tile");
+
+	Unit* unit = new Unit(siteX - 2, siteY, 0, WORKER, team, 0);
+	team->myUnits[0] = unit;
+	unit->performance[WALK] = 10;
+	unit->performance[HARVEST] = 10;
+	unit->activity = Unit::ACT_RANDOM;
+	unit->displacement = Unit::DIS_RANDOM;
+	unit->medical = Unit::MED_FREE;
+	unit->attachedBuilding = NULL;
+	const int swimClass = unit->swimClass();
+
+	int distBuilding = 0, distResource = 0;
+	require(game.map.buildingAvailable(site, swimClass, unit->posX, unit->posY, &distBuilding),
+		"the site is reachable");
+	require(game.map.resourceAvailable(0, WOOD, swimClass, unit->posX, unit->posY, &distResource),
+		"the wood is reachable");
+
+	// The round-trip field only exists once somebody has fetched this resource
+	// for this building, which is when the two lengths can be confused.
+	require(game.map.roundTripGradient(site, WOOD, swimClass) != NULL, "the round-trip field builds");
+	int roundTrip = 0;
+	require(game.map.roundTripDistance(site, WOOD, swimClass, unit->posX, unit->posY, &roundTrip),
+		"the round trip is known here");
+	std::printf("distBuilding=%d distResource=%d roundTrip=%d\n", distBuilding, distResource, roundTrip);
+	require(roundTrip - distBuilding > distResource,
+		"the trip really is longer than the walk to the wood, so the two are distinguishable");
+
+	// Just enough time to reach the wood, not enough for the whole trip. The
+	// unit is hireable: it eats at the site on the way back.
+	const int timeLeft = distResource + 2;
+	require(timeLeft > distBuilding, "the site itself is within reach");
+	require(timeLeft < roundTrip - distBuilding, "the whole trip does not fit in the same budget");
+	unit->trigHungry = 100;
+	unit->hungry = unit->trigHungry + timeLeft * unit->race->hungriness;
+
+	int dist = 0;
+	require(RoundTripHungerGateHarness::consider(site, unit, WOOD, &dist),
+		"a unit that can reach the wood is hireable for it");
+
+	std::puts("PASS the hunger check measures the walk to the resource, not the whole trip");
+}
+
+// Without a round-trip field the score still has to be a round trip, or a
+// resource that has one is ranked against a resource that does not on two
+// different scales.
+static void theFallbackScoresAWholeRoundTrip()
+{
+	GameGUI gui;
+	Game& game = gui.game;
+	game.map.setSize(5, 5, GRASS); // 32x32
+	game.map.setGame(&game);
+	game.addTeam(0);
+	Team* team = game.teams[0];
+
+	const Sint32 siteType = globalContainer->buildingsTypes.getTypeNum("market", 0, true);
+	const BuildingType* type = globalContainer->buildingsTypes.get(siteType);
+	const int siteX = 8, siteY = 8;
+	Building* site = new Building(siteX, siteY, Building::GIDfrom(0, 0), siteType, team,
+	                              &globalContainer->buildingsTypes, 4, 4);
+	team->myBuildings[0] = site;
+	game.map.setBuilding(siteX, siteY, type->width, type->height, site->gid);
+
+	require(game.map.incResource(siteX + 9, siteY, WOOD, 0), "seed the wood tile");
+
+	// Standing at the building, so the walk out and the carry home are close to
+	// the same length and the whole job is close to twice the walk.
+	Unit* unit = new Unit(siteX - 2, siteY, 0, WORKER, team, 0);
+	team->myUnits[0] = unit;
+	unit->performance[WALK] = 10;
+	unit->performance[HARVEST] = 10;
+	unit->activity = Unit::ACT_RANDOM;
+	unit->displacement = Unit::DIS_RANDOM;
+	unit->medical = Unit::MED_FREE;
+	unit->attachedBuilding = NULL;
+	unit->trigHungry = 100;
+	unit->hungry = unit->trigHungry + 1000 * unit->race->hungriness;
+
+	const int swimClass = unit->swimClass();
+	int distBuilding = 0, distResource = 0, unused = 0;
+	require(game.map.buildingAvailable(site, swimClass, unit->posX, unit->posY, &distBuilding),
+		"the site is reachable");
+	require(game.map.resourceAvailable(0, WOOD, swimClass, unit->posX, unit->posY, &distResource),
+		"the wood is reachable");
+	require(!game.map.roundTripDistance(site, WOOD, swimClass, unit->posX, unit->posY, &unused),
+		"no round-trip field exists for a building nothing has fetched for");
+	require(distBuilding < distResource, "the unit is nearer the site than the wood");
+
+	int dist = 0;
+	require(RoundTripHungerGateHarness::consider(site, unit, WOOD, &dist), "the unit is hireable for the wood");
+
+	const int wholeTrip = distResource + std::max(distBuilding, distResource);
+	std::printf("fallback: distBuilding=%d distResource=%d scored=%d expected=%d\n",
+		distBuilding, distResource, dist, wholeTrip<<Q8_FIXED_POINT_SHIFT);
+	require(dist == (wholeTrip<<Q8_FIXED_POINT_SHIFT),
+		"the fallback scores the walk out plus the carry home");
+
+	std::puts("PASS the fallback score is a whole round trip, not a one-way walk");
+}
+
+int main(int argc, char** argv)
+{
+	SDL_SetMainReady();
+	require(argc == 3, "usage: harness PROFILE ROOT");
+	require(std::string(argv[1]).find("glob2-save-test-") == 0, "disposable profile required");
+	GlobalContainer globals(argv[1]);
+	globals.fileManager->addDir(argv[2]);
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+	aUnitIsJudgedOnTheWalkToTheResource();
+	theFallbackScoresAWholeRoundTrip();
+	std::puts("Round-trip hunger gate regressions passed");
+	return 0;
+}

--- a/test/SavegameSafetyHarness.cpp
+++ b/test/SavegameSafetyHarness.cpp
@@ -7,6 +7,7 @@
 #undef main
 #endif
 #include "GlobalContainer.h"
+#include "Version.h"
 #include "Engine.h"
 #include "Utilities.h"
 #include "Order.h"
@@ -265,7 +266,7 @@ static void checkRandomContinuation(bool text, bool ai)
 		MemoryStreamBackend source(runtimeText.data(),runtimeText.size());
 		source.seekFromStart(0);
 		TextInputStream reader(&source);
-		restored.game.map.loadRuntimeState(&reader);
+		restored.game.map.loadRuntimeState(&reader, VERSION_MINOR);
 	}
 
 	// The normal saved-game loader replaces the player header after loading.


### PR DESCRIPTION
Successor to #193, which GitHub closed when its head branch was renamed from `feat/pathfinding-lanes` to `feat/pathfinding-round-trip` (the lanes commit had already left it; the traffic-lane work is #213). genixpro's review and Leo's measurements are on #193. Rebased onto current master (e3a01b05, after #223 fetch apportionment and #186); five commits, linear, no merge commits. #197 (task swaps) and #213 (traffic lanes) are stacked on this branch.

**Round-trip gradients.** A worker fetching for a building walked to the resource nearest to *itself*, often on the far side of the base from where it delivers. A building now owns a round-trip gradient per resource type and swim class: every tile of that resource is seeded with the cost of carrying from beside it to the building, and `Map::propagateGradient` runs from those seeds (it now takes seeds at any cost, and an optional cost bound). Descending it minimises trip-to-resource plus trip-back, so `pathfindResource` with the target building follows it, falling back to the plain resource gradient when blocked or stale. Hiring (`considerUnitForResource`, per wanted resource since #223) and the next-resource choice after a delivery score by the same distance when a fetcher has already built the field, and by an estimate otherwise: `distResource + max(distBuilding, distResource)`, exact at both ends of the walk (hiring looks at every needed resource of every building, far more than ever get fetched, so no field is built for it). Refreshed at most every 120 ticks, propagated 128 tiles beyond the cheapest fetch, freed after 500 ticks unused; the building's own gradient is freed on the same timer.

**Commits**
1. Round-trip gradients and their use in routing and hiring.
2. Free a building's idle round-trip gradients on a timer.
3. Free a building's gradients unused for 500 ticks, not only its round-trip ones.
4. Estimate the carry leg when a building has no round-trip field yet, with `RoundTripHungerGateHarness` (now also run in CI). On master the hunger gate already measures the walk to the resource, so this commit is the scale fix plus the harness.
5. Save the round-trip fields with the map runtime state (format 95, replay floor 95). Master's continuation state saves every cached routing field so a loaded game continues bit for bit; without the round-trip fields and stamps a loaded game hired by the estimate where the uninterrupted one read a field, and `SavegameSafetyHarness` caught the drift within twenty steps. Older saves load with the fields empty.

**Verified on this rebase** (Linux, release build): 187 CppUnit tests; `RoundTripHungerGateHarness`, `ResourceFetchTargetHarness` (7 swim classes), `FetchApportionmentHarness`, `TrappedUnitLifecycleTest`, `BuildingExpelHarness`, `ImmobileUnitGradientHarness` and `SavegameSafetyHarness` (save, load, 300-step continuation) all pass.

**Measured on a human-paced test bed** (Leo's petri maps: four AINone island colonies, more job slots than workers, no forbidden areas; details, screenshots and the 80-minute chart in [this comment](https://github.com/Globulation2/glob2/pull/244#issuecomment-5625390834)): on the 108-worker island with four far-off inns, deliveries go from 194 to 217 (+12%) and survivors from 72 to 79 of 108 in 10 game minutes, 66 to 74 over 80 minutes; on the island where two inns are the bottleneck the round trip alone changes nothing and #197's inn swap is what saves workers; on the 8-worker island with 215 open job slots the gain is +3% here and +23% with #197's job swaps. The earlier Nicowar-vs-Nicowar numbers on #193 (+6%) undersell it because the AI re-plans its job requests every 100 ticks and never saturates its labour market.

**Feel:** workers pick the wheat or wood patch on the building's side of the base rather than the one nearest to where they were freed; visible as fewer long diagonal hauls across a base. Save format 95: the round-trip fields travel with the map runtime state, like the other cached routing fields.


