### PR TITLE
Hire a fetcher for one delivery at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,10 @@ jobs:
           scons -j$(nproc) release=1 server=0 hiring-bucket-test
           python3 test/run-savegame-safety-tests.py --check-preferences build/src/HiringBucketHarness .
 
+      - name: Build and run the gig-release regression
+        run: |
+          scons -j$(nproc) release=1 server=0 gig-release-test
+          python3 test/run-savegame-safety-tests.py --check-preferences build/src/GigReleaseHarness .
       - name: Build and run the resource-fetch target regression
         run: |
           scons -j$(nproc) release=1 server=0 resource-fetch-target-test

--- a/src/ReplayReader.h
+++ b/src/ReplayReader.h
@@ -23,11 +23,11 @@ static constexpr Uint32 REPLAY_MIN_VALID_ORDERS = 5;
 
 //! Oldest replay format (the VERSION_MINOR the replay was written with) that
 //! the reader still accepts. Replays older than this are rejected: versions 90, 92,
-//! 93, 94, 95 and 96 changed the simulation (weighted pathfinding and diagonal timing,
+//! 93, 94, 95, 96 and 97 changed the simulation (weighted pathfinding and diagonal timing,
 //! hiring-bucket iteration, trapped-colony elimination, fetch-job apportionment,
-//! round-trip routing and hiring, Echo building-order ids surviving a load), so
-//! earlier replays would diverge from what happened.
-static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 96;
+//! round-trip routing and hiring, Echo building-order ids surviving a load,
+//! per-delivery hiring), so earlier replays would diverge from what happened.
+static constexpr Uint16 REPLAY_MINIMUM_VERSION_MINOR = 97;
 
 /// This class is used for reading replays.
 /// The replay stream is kept open and read every time you do retrieveOrder.

--- a/src/SConscript
+++ b/src/SConscript
@@ -659,6 +659,12 @@ if not env['server'] and 'hiring-bucket-test' in COMMAND_LINE_TARGETS:
     hiring_sources += local.Object('HiringBucketHarness.o', '#test/HiringBucketHarness.cpp')
     local.Alias('hiring-bucket-test', local.Program('HiringBucketHarness', hiring_sources))
 
+# After a delivery the worker is released only while a fifth of the team is idle.
+if not env['server'] and 'gig-release-test' in COMMAND_LINE_TARGETS:
+    gig_sources = [source for source in source_files if source != 'Glob2.cpp']
+    gig_sources += local.Object('GigReleaseHarness.o', '#test/GigReleaseHarness.cpp')
+    local.Alias('gig-release-test', local.Program('GigReleaseHarness', gig_sources))
+
 if not env['server'] and 'custom-setup-test' in COMMAND_LINE_TARGETS:
     custom_sources = [source for source in source_files if source != 'Glob2.cpp']
     custom_sources += local.Object('CustomGameSetupHarness.o', '#test/CustomGameSetupHarness.cpp')

--- a/src/Version.h
+++ b/src/Version.h
@@ -6,7 +6,7 @@
 // This is the version of map and savegame format, and all of the recorded data on the server
 #define VERSION_MAJOR 0
 #define MINIMUM_VERSION_MINOR 58
-#define VERSION_MINOR 96
+#define VERSION_MINOR 97
 // version 91 saves the live RNG and routing state for deterministic continuation.
 // version 10 adds script saved in game
 // version 11 the gamesfiles do saves which building has been seen under fog of war.
@@ -105,6 +105,9 @@
 // version 96 saves AIEcho::Construction::BuildingOrder::id, which was assigned at
 //            runtime and never serialised, so every pending building order restored
 //            from a save carried an uninitialised heap value as its register key
+// version 97 hires a fetcher for one delivery at a time: a unit that has just
+//            dropped off goes back to the free pool instead of re-hiring itself
+//            for its building's next trip, so every trip is auctioned
 
 //This must be updated when there are changes to YOG, MapHeader, GameHeader, BasePlayer, BaseTeam,
 //NetMessage, and the likes, in parallel to change of the VERSION_MINOR above

--- a/src/team/Team.h
+++ b/src/team/Team.h
@@ -116,6 +116,10 @@ public:
 	//! Give `unit`'s fetching job to a team mate and take the mate's job, when that
 	//! shortens the two trips together by more than a few tiles (see TeamStep.cpp).
 	void swapTask(Unit *unit);
+	/// Whether at least `percent` of the team's living workers are idle
+	/// (ACT_RANDOM). Read after a delivery to decide whether to release the
+	/// worker for the hiring auction.
+	bool idleWorkerShareAtLeast(int percent) const;
 	//! Give `unit` a team mate's inn and the mate `unit`'s, when that shortens the
 	//! two walks together by more than a few tiles; called as `unit` books its place.
 	void swapInn(Unit *unit);

--- a/src/team/TeamStep.cpp
+++ b/src/team/TeamStep.cpp
@@ -260,6 +260,21 @@ namespace
 	}
 }
 
+bool Team::idleWorkerShareAtLeast(int percent) const
+{
+	int workers=0, idle=0;
+	for (int i=0; i<Unit::MAX_COUNT; i++)
+	{
+		const Unit *u=myUnits[i];
+		if (!u || u->typeNum!=WORKER || u->isDead)
+			continue;
+		workers++;
+		if (u->activity==Unit::ACT_RANDOM)
+			idle++;
+	}
+	return workers>0 && idle*100>=percent*workers;
+}
+
 void Team::swapTask(Unit *unit)
 {
 	if (!isFetching(unit))

--- a/src/unit/UnitConsts.h
+++ b/src/unit/UnitConsts.h
@@ -54,6 +54,9 @@ const int NB_UNIT_LEVELS=4;
 //! when the counter is treated as "fully arrived" (Unit.cpp:296, 304;
 //! UnitMovement.cpp; MapQuery.cpp; TypeSteps.cpp turret bullet timing).
 static constexpr int UNIT_DELTA_MAX = 255;
+/// Share of a team's workers that must be idle for a worker to be released
+/// after a delivery instead of keeping its building (Unit::handleDisplacement).
+static constexpr int RELEASE_IDLE_WORKER_PERCENT = 20;
 //! Modular quantum that wraps a unit's `delta` counter, equal to
 //! UNIT_DELTA_MAX + 1. Used in expressions like (256 - delta) / speed.
 static constexpr int UNIT_DELTA_QUANTUM = 256;

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -140,23 +140,133 @@ void Unit::handleDisplacement(void)
 						validTarget=false;
 						assert(needToRecheckMedical);
 					}
+					else if (owner->idleWorkerShareAtLeast(RELEASE_IDLE_WORKER_PERCENT))
+					{
+						// One delivery is one gig while there are idle hands: give the trip
+						// back to the pool and let Team::updateAllBuildingTasks, which runs
+						// later in this same tick after every unit has stepped, auction it
+						// among every free worker and every building that wants one. An
+						// idle worker may by chance stand closer to the next job than the
+						// one that just delivered. With nobody idle the auction could only
+						// hand the job back to this unit a tile later, so it keeps its
+						// building and picks its next trip itself, below.
+						if (verbose)
+							printf("guid=(%d) delivered, released for the auction.\n", gid);
+						stopAttachedForBuilding(false);
+					}
 					else
 					{
-						// One delivery is one gig. Hand the unit back to the free pool
-						// instead of letting it re-hire itself for the next trip out of
-						// its own building's wish list: Team::updateAllBuildingTasks runs
-						// later in this same tick, after every unit has stepped, and only
-						// ACT_RANDOM units are candidates. So the next trip is auctioned
-						// among every worker and every building that wants one, instead of
-						// belonging to whoever happened to deliver here last.
-						//
-						// The unit standing at the door is usually the cheapest hire and
-						// wins its own job back. When it does not, the random step it
-						// starts below is still in flight while the auction runs, so
-						// losing costs it that one tile and nothing else.
-						if (verbose)
-							printf("guid=(%d) delivered; back on the market.\n", gid);
-						stopAttachedForBuilding(false);
+						///Find a resource that the building wants and a location to get it from
+						///The location may be a market, or the harvesting the resource from the
+						///map.
+						int needs[MAX_NB_RESOURCES];
+						attachedBuilding->computeWishedResources(needs);
+						int teamNumber=owner->teamNumber;
+						int timeLeft = numberOfStepsLeftUntilHungry();
+						if (timeLeft > 0)
+						{
+							int bestResource=-1;
+							int minValue=owner->map->getW()+owner->map->getW();
+							bool takeInExchangeBuilding=false;
+							Map* map=owner->map;
+							for (int r=0; r<MAX_NB_RESOURCES; r++)
+							{
+								int need=needs[r];
+								if (need>0)
+								{
+									int distToResource;
+									bool available=map->roundTripDistance(attachedBuilding, r, swimClass(), posX, posY, &distToResource);
+									if (available)
+										distToResource=(distToResource+1)/2; // half the round trip: the unit is at the building
+									else
+										available=map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource);
+									if (available)
+									{
+										if ((distToResource<<1)>=timeLeft)
+											continue; //We don't choose this resource, because it won't have time to reach the resource and bring it back.
+										int value=distToResource/need;
+										if (value<minValue)
+										{
+											bestResource=r;
+											minValue=value;
+											takeInExchangeBuilding=false;
+										}
+									}
+
+									if (attachedBuilding->type->canFeedUnit)
+										for (std::list<Building *>::iterator bi=owner->canExchange.begin(); bi!=owner->canExchange.end(); ++bi)
+											if ((*bi)->resources[r]>0)
+											{
+												int buildingDist;
+												if (map->buildingAvailable(*bi, swimClass(), posX, posY, &buildingDist))
+												{
+													// We increase the cost to get a resource in an exchange building to reflect the costs to get the resources to the exchange building.
+													// increase is +5 as markets will in general be very close to fruits as they are the fruit teleporters.
+													int value=(buildingDist+5)/need;
+													if (value<minValue)
+													{
+														bestResource=r;
+														minValue=value;
+
+														ownExchangeBuilding=*bi;
+														setTargetBuilding(*bi);
+														takeInExchangeBuilding=true;
+													}
+												}
+											}
+								}
+							}
+
+							if (verbose)
+								printf("guid=(%d) bestResource=%d, minValue=%d\n", gid, bestResource, minValue);
+
+							if (bestResource>=0)
+							{
+								destinationPurpose=bestResource;
+								assert(activity==ACT_FILLING);
+								if (takeInExchangeBuilding)
+								{
+									displacement=DIS_GOING_TO_BUILDING;
+									targetX=targetBuilding->getMidX();
+									targetY=targetBuilding->getMidY();
+									targetBuilding->insertUnitToHarvesting(this);
+									validTarget=true;
+								}
+								else
+								{
+									int dummyDist;
+									if (auto off = owner->map->doesUnitTouchResource(this, destinationPurpose))
+									{
+										dx = off->dx;
+										dy = off->dy;
+										displacement=DIS_HARVESTING;
+										validTarget=false;
+									}
+									else if (map->resourceAvailableUpdate(teamNumber, destinationPurpose, swimClass(), posX, posY, &targetX, &targetY, &dummyDist))
+									{
+										displacement=DIS_GOING_TO_RESOURCE;
+										validTarget=true;
+									}
+									else
+									{
+										assert(false);//You can remove this assert(), but *do* notice me!
+										stopAttachedForBuilding(false);
+									}
+								}
+							}
+							else
+							{
+								if (verbose)
+									printf("guid=(%d) can't find any wished resource, unsubscribing.\n", gid);
+								stopAttachedForBuilding(false);
+							}
+						}
+						else
+						{
+							if (verbose)
+								printf("guid=(%d) not enough time for anything, unsubscribing.\n", gid);
+							stopAttachedForBuilding(false);
+						}
 					}
 				}
 			}

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -142,117 +142,21 @@ void Unit::handleDisplacement(void)
 					}
 					else
 					{
-						///Find a resource that the building wants and a location to get it from
-						///The location may be a market, or the harvesting the resource from the
-						///map.
-						int needs[MAX_NB_RESOURCES];
-						attachedBuilding->computeWishedResources(needs);
-						int teamNumber=owner->teamNumber;
-						int timeLeft = numberOfStepsLeftUntilHungry();
-						if (timeLeft > 0)
-						{
-							int bestResource=-1;
-							int minValue=owner->map->getW()+owner->map->getW();
-							bool takeInExchangeBuilding=false;
-							Map* map=owner->map;
-							for (int r=0; r<MAX_NB_RESOURCES; r++)
-							{
-								int need=needs[r];
-								if (need>0)
-								{
-									int distToResource;
-									bool available=map->roundTripDistance(attachedBuilding, r, swimClass(), posX, posY, &distToResource);
-									if (available)
-										distToResource=(distToResource+1)/2; // half the round trip: the unit is at the building
-									else
-										available=map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource);
-									if (available)
-									{
-										if ((distToResource<<1)>=timeLeft)
-											continue; //We don't choose this resource, because it won't have time to reach the resource and bring it back.
-										int value=distToResource/need;
-										if (value<minValue)
-										{
-											bestResource=r;
-											minValue=value;
-											takeInExchangeBuilding=false;
-										}
-									}
-
-									if (attachedBuilding->type->canFeedUnit)
-										for (std::list<Building *>::iterator bi=owner->canExchange.begin(); bi!=owner->canExchange.end(); ++bi)
-											if ((*bi)->resources[r]>0)
-											{
-												int buildingDist;
-												if (map->buildingAvailable(*bi, swimClass(), posX, posY, &buildingDist))
-												{
-													// We increase the cost to get a resource in an exchange building to reflect the costs to get the resources to the exchange building.
-													// increase is +5 as markets will in general be very close to fruits as they are the fruit teleporters.
-													int value=(buildingDist+5)/need;
-													if (value<minValue)
-													{
-														bestResource=r;
-														minValue=value;
-
-														ownExchangeBuilding=*bi;
-														setTargetBuilding(*bi);
-														takeInExchangeBuilding=true;
-													}
-												}
-											}
-								}
-							}
-
-							if (verbose)
-								printf("guid=(%d) bestResource=%d, minValue=%d\n", gid, bestResource, minValue);
-
-							if (bestResource>=0)
-							{
-								destinationPurpose=bestResource;
-								assert(activity==ACT_FILLING);
-								if (takeInExchangeBuilding)
-								{
-									displacement=DIS_GOING_TO_BUILDING;
-									targetX=targetBuilding->getMidX();
-									targetY=targetBuilding->getMidY();
-									targetBuilding->insertUnitToHarvesting(this);
-									validTarget=true;
-								}
-								else
-								{
-									int dummyDist;
-									if (auto off = owner->map->doesUnitTouchResource(this, destinationPurpose))
-									{
-										dx = off->dx;
-										dy = off->dy;
-										displacement=DIS_HARVESTING;
-										validTarget=false;
-									}
-									else if (map->resourceAvailableUpdate(teamNumber, destinationPurpose, swimClass(), posX, posY, &targetX, &targetY, &dummyDist))
-									{
-										displacement=DIS_GOING_TO_RESOURCE;
-										validTarget=true;
-									}
-									else
-									{
-										assert(false);//You can remove this assert(), but *do* notice me!
-										stopAttachedForBuilding(false);
-									}
-								}
-							}
-							else
-							{
-								if (verbose)
-									printf("guid=(%d) can't find any wished resource, unsubscribing.\n", gid);
-								stopAttachedForBuilding(false);
-							}
-						}
-						else
-						{
-							if (verbose)
-								printf("guid=(%d) not enough time for anything, unsubscribing.\n", gid);
-							stopAttachedForBuilding(false);
-						}
+						// One delivery is one gig. Hand the unit back to the free pool
+						// instead of letting it re-hire itself for the next trip out of
+						// its own building's wish list: Team::updateAllBuildingTasks runs
+						// later in this same tick, after every unit has stepped, and only
+						// ACT_RANDOM units are candidates. So the next trip is auctioned
+						// among every worker and every building that wants one, instead of
+						// belonging to whoever happened to deliver here last.
+						//
+						// The unit standing at the door is usually the cheapest hire and
+						// wins its own job back. When it does not, the random step it
+						// starts below is still in flight while the auction runs, so
+						// losing costs it that one tile and nothing else.
+						if (verbose)
+							printf("guid=(%d) delivered; back on the market.\n", gid);
+						stopAttachedForBuilding(false);
 					}
 				}
 			}

--- a/test/GigReleaseHarness.cpp
+++ b/test/GigReleaseHarness.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-engine regression: after a delivery a worker is released for the hiring
+// auction only when at least RELEASE_IDLE_WORKER_PERCENT of the team's workers
+// are idle; otherwise it keeps its building and picks its next trip itself.
+#define SDL_MAIN_HANDLED
+#ifdef main
+#undef main
+#endif
+#include "GlobalContainer.h"
+#include "FileManager.h"
+#include <SDL.h>
+#include <string>
+#include "Game.h"
+#include "GameGUI.h"
+#include "Unit.h"
+#include "UnitConsts.h"
+#include "Team.h"
+#include "MapInternal.h"
+#include "Race.h"
+#include "Ressource.h"
+#include "IntBuildingType.h"
+#include <cstdio>
+#include <cstdlib>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+	if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+struct TestUnit : Unit
+{
+	using Unit::Unit;
+	void deliver() { needToRecheckMedical = true; handleDisplacement(); }
+};
+
+// A worker standing at the door of an inn that wants wheat, wheat on its back,
+// about to deposit; `others` more workers of the team, idle or busy.
+struct Bed
+{
+	GameGUI gui;
+	Game& game;
+	Team* team;
+	Building* inn;
+	TestUnit* carrier;
+	Bed(int others, bool othersIdle) : game(gui.game)
+	{
+		game.map.setSize(5, 5, GRASS);
+		game.map.setGame(&game);
+		for (int y = 0; y < game.map.getH(); ++y)
+			for (int x = 0; x < game.map.getW(); ++x)
+				game.map.clearImmobileUnit(x, y);
+		game.addTeam(0);
+		team = game.teams[0];
+		team->race.loadDefault();
+		int innType = globalContainer->buildingsTypes.getTypeNum("inn", 0, false);
+		require(innType >= 0, "inn type exists");
+		inn = game.addBuilding(8, 8, innType, 0);
+		require(inn != nullptr, "inn placed");
+		game.map.setBuilding(8, 8, inn->type->width, inn->type->height, inn->gid);
+		inn->maxUnitWorking = 2;
+		inn->resources[CORN] = 0;
+		inn->updateCallLists();
+		require(game.map.incResource(14, 8, CORN, 0), "wheat within reach for the next trip");
+		// The carrier: attached, at the door, wheat on its back, depositing.
+		carrier = new TestUnit(7, 8, Unit::GIDfrom(0, 0), WORKER, team, 0);
+		team->myUnits[0] = carrier;
+		game.map.setGroundUnit(7, 8, carrier->gid);
+		carrier->activity = Unit::ACT_FILLING;
+		carrier->medical = Unit::MED_FREE;
+		carrier->attachedBuilding = inn;
+		inn->unitsWorking.push_back(carrier);
+		carrier->setTargetBuilding(inn);
+		carrier->destinationPurpose = CORN;
+		carrier->carriedResource = CORN;
+		carrier->displacement = Unit::DIS_FILLING_BUILDING;
+		carrier->dx = 1; carrier->dy = 0;
+		carrier->validTarget = false;
+		for (int i = 0; i < others; ++i)
+		{
+			Unit* u = game.addUnit(2 + i, 2, 0, WORKER, 0, 0, 0, 0);
+			require(u != nullptr, "place another worker");
+			u->medical = Unit::MED_FREE;
+			u->activity = othersIdle ? Unit::ACT_RANDOM : Unit::ACT_FILLING;
+		}
+	}
+};
+
+int main(int argc, char** argv)
+{
+	SDL_SetMainReady();
+	require(argc == 3, "usage: harness PROFILE ROOT");
+	require(std::string(argv[1]).find("glob2-save-test-") == 0, "disposable profile required");
+	GlobalContainer globals(argv[1]);
+	globals.fileManager->addDir(argv[2]);
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+	require(RELEASE_IDLE_WORKER_PERCENT == 20, "this harness assumes the one-in-five threshold");
+
+	{
+		// Four idle workers of five: released.
+		Bed bed(4, true);
+		require(bed.team->idleWorkerShareAtLeast(RELEASE_IDLE_WORKER_PERCENT), "four idle of five is above the threshold");
+		bed.carrier->deliver();
+		require(bed.inn->resources[CORN] == 1, "the wheat was deposited");
+		require(bed.carrier->activity == Unit::ACT_RANDOM && bed.carrier->attachedBuilding == NULL, "released for the auction");
+		require(bed.inn->unitsWorking.empty(), "no longer working for the inn");
+		std::puts("gig release: with idle hands the deliverer goes back to the pool");
+	}
+	{
+		// Four busy workers of five: keeps its building and heads out again.
+		Bed bed(4, false);
+		require(!bed.team->idleWorkerShareAtLeast(RELEASE_IDLE_WORKER_PERCENT), "nobody idle is below the threshold");
+		bed.carrier->deliver();
+		require(bed.inn->resources[CORN] == 1, "the wheat was deposited");
+		require(bed.carrier->activity == Unit::ACT_FILLING && bed.carrier->attachedBuilding == bed.inn, "keeps its building");
+		require(bed.carrier->displacement == Unit::DIS_GOING_TO_RESOURCE && bed.carrier->destinationPurpose == CORN, "already heading for the next wheat");
+		std::puts("gig release: with nobody idle the deliverer keeps its job");
+	}
+	{
+		// Exactly one idle of five: the threshold is inclusive.
+		Bed bed(4, false);
+		bed.team->myUnits[1]->activity = Unit::ACT_RANDOM;
+		require(bed.team->idleWorkerShareAtLeast(RELEASE_IDLE_WORKER_PERCENT), "one in five counts");
+		bed.carrier->deliver();
+		require(bed.carrier->activity == Unit::ACT_RANDOM, "released at exactly one in five");
+		std::puts("gig release: one idle worker in five is enough");
+	}
+	std::puts("PASS a delivery releases the worker only while a fifth of the team is idle");
+	return 0;
+}


### PR DESCRIPTION
Rebased onto master now that #253 is in. Two commits: per-delivery hiring, then Leo's gate on top.

## Summary

A worker stayed subscribed to its building until the building's whole wish list was satisfied. After every drop-off it picked its own next resource from `attachedBuilding->computeWishedResources()`, so the trip belonged to whoever had delivered there last, never to whoever was closest to it and never to another building that wanted a worker more.

**First commit:** release the unit after every deposit (`stopAttachedForBuilding(false)`), one gig at a time. `Team::updateAllBuildingTasks` runs later in the same tick, after every unit has stepped, and `considerUnitForBuilding` only accepts `ACT_RANDOM` units, so a unit freed during its own step is back on the market before that tick ends. The random step it starts on release is still in flight while the auction runs, so a unit that wins its own job back pays one tile for it.

**Second commit (Leo, after the numbers below):** release only while at least 20% of the team's living workers are idle (`RELEASE_IDLE_WORKER_PERCENT`, `Team::idleWorkerShareAtLeast`). The auction only moves work when idle workers exist that may by chance stand closer to the next job; with nobody idle it could only hand the trip back to the deliverer a tile later. Otherwise the worker keeps its building and picks its next trip as on master, market path included, so the "market fetch gap" of the first commit only exists while a fifth of the team is idle.

Simulation behaviour changes, so `VERSION_MINOR` → 97 and the replay floor moves with it. No save-format change.

## Measurement of the first commit (release always)

Eight Nicowars on Playground, resumed from a tick-25000 save, run to 40000, both builds on top of #253, ASLR off, `MALLOC_PERTURB_=0` (every cell identical across fills 0/85/170). M = master, G = release always.

| seed | deliveries M / G | starvation deaths M / G | population M / G |
|---|---|---|---|
| 7 | 3289 / 3258 | 44 / 35 | 244 / 277 |
| 11 | 2839 / 2918 | 23 / 12 | 228 / 267 |
| 12 | 1792 / 1616 | 53 / 29 | 169 / 161 |
| 13 | 2669 / 2752 | 35 / 30 | 282 / 298 |
| 14 | 2939 / 3015 | 21 / 17 | 287 / 297 |
| 15 | 2987 / 2505 | 30 / 69 | 243 / 187 |
| **total** | **16515 / 16064** (−2.7%) | **206 / 192** (−6.8%) | **1453 / 1487** (+2.3%) |

petri2 (four AINone colonies, ten seeds, 120000 ticks): 37559 master vs 37411 (−0.4%), flat per 2048-tick window from the first minutes on (comment below). ~25% of deliveries changed employer the same tick, ~59% re-hired at the same building: the mechanism works, it just moves no work while free workers are plentiful.

## Measurement of the gated version

Running; tables follow in a comment.

## Feel

Per CLAUDE.md, this changes how the economy feels: while a fifth of the colony is idle, workers no longer "belong" to a building between trips, so units switch employers more often and the "N units working" counters fluctuate. With everyone busy nothing changes.

## Verification

- `gig-release-test` harness (new, in CI): four of five idle → released; nobody idle → keeps the inn and heads for the next wheat; exactly one in five → released.
- `TestsRunner` (187) plus the hiring harness set.

Authored by Carol (first commit) on Leo's idea; gate and rebase by Bob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
