### PR TITLE
Re-roll the harness's river map instead of asserting the first try

### DIFF
--- a/test/CustomGameSetupHarness.cpp
+++ b/test/CustomGameSetupHarness.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <unistd.h>
 
 GlobalContainer *globalContainer = nullptr;
@@ -826,13 +827,33 @@ int main(int argc, char **argv)
 	std::filesystem::create_directory(dir);
 	const auto map = (dir / "generated.map").string(), save = (dir / "match.game").string();
 	{
-		Game g(nullptr);
-		MapGenerator generator;
-		MapGenerationDescriptor d;
-		d.setMethodDefaults(MapGenerationDescriptor::eRIVER);
-		d.nbTeams = 4;
-		assert(generator.generateMap(g, d));
-		assert(g.teamsCount() == 4);
+		// A river roll that cannot seat four starting colonies is normal, not a
+		// bug: Map::makeRandomMap gives up when no grass patch is left far
+		// enough from the teams already placed, and Game::makeRandomMap gives up
+		// when the swarm or its workers will not fit. The game re-rolls rather
+		// than reporting failure (CustomGameScreen::generateMap), and so does
+		// the eight-landscape loop above. This call did neither, and a single
+		// roll fails often enough -- measured at 1 in 25 on an untouched tree --
+		// to have made this harness flake in CI.
+		//
+		// Re-rolling rather than pinning a seed is deliberate: the terrain comes
+		// from HeightMap, which draws on rand() rather than syncRand, so a seed
+		// would not reproduce the same map across platforms anyway -- and a seed
+		// that happens to seat four colonies under glibc could fail every single
+		// time under mingw or macOS libc.
+		std::unique_ptr<Game> generated;
+		for (int attempt = 0; attempt < 5 && !generated; ++attempt)
+		{
+			auto candidate = std::make_unique<Game>(nullptr);
+			MapGenerator generator;
+			MapGenerationDescriptor d;
+			d.setMethodDefaults(MapGenerationDescriptor::eRIVER);
+			d.nbTeams = 4;
+			if (generator.generateMap(*candidate, d) && candidate->teamsCount() == 4)
+				generated = std::move(candidate);
+		}
+		assert(generated);
+		Game &g = *generated;
 		CustomGameSetup setup;
 		GameHeader header;
 		setup.writeHeader(header, "test");


### PR DESCRIPTION
`CustomGameSetupHarness` aborts on `assert(generator.generateMap(g, d))` (test/CustomGameSetupHarness.cpp:834) often enough to be a real nuisance — I measured **1 failure in 25 runs** on an untouched tree. Across two Linux images that's roughly a 1-in-12 chance of a spurious red on any PR. It went red on #252 this way, on a change that touches only the sound mixer.

## The generator is not at fault

A river roll that cannot seat four starting colonies is a normal outcome:

- `Map::makeRandomMap` gives up when no grass patch is left far enough from the teams already placed (`maxSurface <= 0`).
- `Game::makeRandomMap` gives up when the swarm, or one of its workers, will not fit.

Both the game and this same harness already treat that as something to re-roll, not an error:

- `CustomGameScreen::generateMap` retries 5 times — *"Some rolls cannot fit every starting colony. Retry those rolls before reporting failure."*
- the eight-landscape loop directly above this call retries 5 times.

This one call did neither. It now re-rolls the same way, building each candidate in its own `Game` so a failed attempt cannot leave half-placed teams behind.

## Why re-roll rather than pin a seed

`generateMap` does accept a `syncSeed`, so pinning one looks tempting. It would not work: the terrain comes from `HeightMap`, which draws on `rand()` rather than `syncRand` — `Generator.cpp` says so at the top (*"also the Perlin Noise stuff uses random that is not based on syncRand"*). A seed would not reproduce the same map across platforms, and a seed that happens to seat four colonies under glibc could fail **every single time** under mingw or macOS libc. Five re-rolls put a spurious failure at about 1e-7 without depending on any of that.

## Verification

200 consecutive runs of the fixed harness on Linux/x86_64: **200 passes, 0 failures**. The same harness built from the same tree without this change: 24 passes, 1 failure in 25.

At the measured per-roll rate, 200 clean runs would happen by chance with probability ~3e-4, so this is not luck. The eight-landscape loop also ran 200 times without exhausting its own retries, which confirms its existing 5 are adequate too.

No production code is touched — this is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5GEG5t9ithd47SFm6PTDZ