### PR TITLE
Rasterise interface text for the screen it is drawn on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,14 @@ jobs:
           timeout 60s xvfb-run -a -s '-screen 0 1600x1400x24' ./build/libgag/src/WindowResizeHarness gl
           timeout 60s xvfb-run -a -s '-screen 0 1600x1400x24' ./build/libgag/src/WindowResizeHarness software
 
+      - name: Build and run the scaled text regression
+        env:
+          LIBGL_ALWAYS_SOFTWARE: 1
+        run: |
+          scons -j$(nproc) release=1 server=0 text-raster-test
+          mkdir -p artifacts/text-raster
+          timeout 60s xvfb-run -a -s '-screen 0 1600x1400x24' ./build/libgag/src/TextRasterHarness artifacts/text-raster
+
       - name: Check game rendering across repeated map copies
         env:
           SDL_VIDEODRIVER: dummy

--- a/libgag/include/SDLGraphicContext.h
+++ b/libgag/include/SDLGraphicContext.h
@@ -417,6 +417,8 @@ namespace GAGCore
 		float getUiScale(void) const { return uiScale; }
 		//! the scale the last setRes() was asked for, before the window floor reduced it
 		float getWantedUiScale(void) const { return wantedUiScale; }
+		//! drawable pixels per logical pixel for text drawn on this context, 1 when unscaled
+		float textRenderScale(void);
 		//! the interface scale the desktop asks for, or 0 when nothing reports one
 		static float querySystemUiScale(void);
 		//! the scale actually used for a preference; 0 follows the desktop, GLOB2_UI_SCALE wins

--- a/libgag/include/TrueTypeFont.h
+++ b/libgag/include/TrueTypeFont.h
@@ -38,38 +38,76 @@ namespace GAGCore
 		virtual Style getStyle(void) const;
 		
 	protected:
+		struct CacheKey
+		{
+			std::string text;
+			Style style;
+			//! Whether this entry holds the raster made for the screen, which only the screen can use
+			bool scaled;
+
+			bool operator<(const CacheKey &o) const
+			{
+				if (text != o.text) return (text < o.text);
+				if (style < o.style) return true;
+				if (o.style < style) return false;
+				return (scaled < o.scaled);
+			}
+		};
+
+		struct CacheData
+		{
+			DrawableSurface *s;
+			unsigned lastAccessed;
+			//! Size in logical pixels, as the authored font size measures it
+			int w, h;
+			//! The raster's own size in logical pixels. Hinting rounds every size differently,
+			//! so this is close to but not exactly w x h, and drawing at it keeps one raster
+			//! pixel on one screen pixel instead of stretching glyphs by a few percent.
+			float drawW, drawH;
+		};
+
 		//! Init internal variables
 		void init(void);
 		virtual void drawString(DrawableSurface *surface, int x, int y, int w, const std::string text, Uint8 alpha);
 		virtual void drawString(DrawableSurface *surface, float x, float y, float w, const std::string text, Uint8 alpha);
 		virtual void pushStyle(Style style);
 		virtual void popStyle(void);
-		
-		//! If text is cached, returns its surface. If it is not, create, cache and return surface
-		DrawableSurface *getStringCached(const std::string text);
+
+		//! If text is cached, returns its entry. If it is not, create, cache and return it.
+		//! scaled asks for the raster made for a magnifying target; the reported size is the
+		//! authored one either way.
+		const CacheData *getStringCached(const std::string text, bool scaled);
+		//! Whether text drawn on this target is resampled on its way to the screen
+		bool targetScalesText(const DrawableSurface *surface) const;
 		//! If cache is too big, remove old entry
 		void cleanupCache(void);
-#ifdef HAVE_FRIBIDI 
+		//! Drop every rendered string, for instance when their raster or textures went stale
+		void clearCache(void);
+		//! Reopen the rasterisation font when the screen started scaling text differently
+		void updateRenderScale(void);
+		//! Apply the current style to both the metrics and the rasterisation font
+		void applyStyle(void);
+		//! The text as it is handed to SDL_ttf: reordered where fribidi is available
+		std::string shapeText(const std::string &text) const;
+#ifdef HAVE_FRIBIDI
 		char *getBIDIString (const std::string text);
-#endif		
+#endif
 	protected:
+		//! Metrics at the size the layout was authored in. Every width and height reported
+		//! to callers comes from here, so a finer raster never moves a widget.
 		TTF_Font *font;
+		//! Rasterisation at size * renderScale; the same object as font while renderScale is 1
+		TTF_Font *renderFont;
+		//! Where font was loaded from, so the raster can be reopened at another size
+		std::string fontFilename;
+		//! The size the layout was authored in
+		unsigned baseSize;
+		//! Drawable pixels per logical pixel the cached rasters were made for
+		float renderScale;
+		//! GL context the cached textures belong to
+		unsigned textureGeneration;
 		std::stack<Style> styleStack;
-		
-		struct CacheKey
-		{
-			std::string text;
-			Style style;
-			
-			bool operator<(const CacheKey &o) const { if (text == o.text) return (style < o.style); else return (text < o.text);  }
-		};
-		
-		struct CacheData
-		{
-			DrawableSurface *s;
-			unsigned lastAccessed;
-		};
-		
+
 		unsigned now;
 		std::map<CacheKey, CacheData> cache;
 		std::map<unsigned, std::map<CacheKey, CacheData>::iterator> timeCache;

--- a/libgag/src/GraphicContext.cpp
+++ b/libgag/src/GraphicContext.cpp
@@ -291,6 +291,21 @@ namespace GAGCore
 		return windowW && sdlsurface && (windowW != sdlsurface->w || windowH != sdlsurface->h);
 	}
 
+	float GraphicContext::textRenderScale(void)
+	{
+		// Only the GL path magnifies each texture on its way to the screen, so only there
+		// does a finer glyph raster reach more pixels. The software path composes the whole
+		// frame in the logical surface, which caps every glyph at its logical size.
+		if (!(optionFlags & USEGPU))
+			return 1.0f;
+		// Any scale resamples the glyphs, including the slight reduction a fullscreen
+		// resolution the display cannot deliver exactly produces.
+		const float scale = drawableScale();
+		if (std::fabs(scale - 1.0f) < 0.01f)
+			return 1.0f;
+		return std::clamp(scale, 0.25f, 4.0f);
+	}
+
 	float GraphicContext::requestedUiScale = 0.0f;
 
 	namespace
@@ -606,6 +621,9 @@ namespace GAGCore
 				}
 				++glContextGeneration;
 				#ifdef HAVE_OPENGL
+				// The new context starts at the GL defaults, so a cache still describing the
+				// replaced one would skip the enables the next draw call needs.
+				glState.resetCache();
 				// Map the logical projection onto a centered, aspect-correct sub-rect of the
 				// drawable so fullscreen scales without distorting circles into ellipses.
 				// The drawable is in pixels; on HiDPI it is larger than the window points mouse events use.

--- a/libgag/src/SConscript
+++ b/libgag/src/SConscript
@@ -36,6 +36,9 @@ if not env['server']:
     resize_test = aspect_env.Program('WindowResizeHarness',
         [aspect_env.Object('WindowResizeHarness.o', '#test/WindowResizeHarness.cpp'), l1])
     env.Alias('resize-test', resize_test)
+    text_raster_test = aspect_env.Program('TextRasterHarness',
+        [aspect_env.Object('TextRasterHarness.o', '#test/TextRasterHarness.cpp'), l1])
+    env.Alias('text-raster-test', text_raster_test)
 else:
     Default(l2)
 

--- a/libgag/src/TrueTypeFont.cpp
+++ b/libgag/src/TrueTypeFont.cpp
@@ -2,10 +2,13 @@
 // Copyright (C) 2001-2004 Stephane Magnenat & Luc-Olivier de Charrière
 
 #include "TrueTypeFont.h"
+#include "GraphicContextPrivate.h"
 #include <Toolkit.h>
 #include <SupportFunctions.h>
 #include <FileManager.h>
+#include <algorithm>
 #include <assert.h>
+#include <cmath>
 #include <iostream>
 
 #ifdef HAVE_FRIBIDI 
@@ -30,6 +33,10 @@ namespace GAGCore
 	void TrueTypeFont::init(void)
 	{
 		font = NULL;
+		renderFont = NULL;
+		baseSize = 0;
+		renderScale = 1.0f;
+		textureGeneration = 0;
 		now = 0;
 		cacheHit = 0;
 		cacheMiss = 0;
@@ -53,9 +60,10 @@ namespace GAGCore
 						cacheMiss << " misses (" << static_cast<float>(cacheMiss)/cacheTotal << ")" << std::endl;
 			}
 			// free cache
-			for (std::map<CacheKey, CacheData>::iterator it = cache.begin(); it != cache.end(); ++it)
-				delete it->second.s;
-			// close font
+			clearCache();
+			// close fonts
+			if (renderFont && renderFont != font)
+				TTF_CloseFont(renderFont);
 			TTF_CloseFont(font);
 		}
 	}
@@ -68,20 +76,106 @@ namespace GAGCore
 			font = TTF_OpenFontRW(fontStream, 1, size);
 			if (font)
 			{
+				fontFilename = filename;
+				baseSize = size;
+				renderFont = font;
+				renderScale = 1.0f;
 				setStyle(Style(STYLE_NORMAL, 255, 255, 255));
 				return true;
 			}
 		}
 		return false;
 	}
+
+	void TrueTypeFont::clearCache(void)
+	{
+		for (std::map<CacheKey, CacheData>::iterator it = cache.begin(); it != cache.end(); ++it)
+			delete it->second.s;
+		cache.clear();
+		timeCache.clear();
+	}
+
+	void TrueTypeFont::updateRenderScale(void)
+	{
+		if (!font)
+			return;
+
+		// Glyphs are rasterised once and then resampled with the rest of the frame, so on a
+		// scaled screen they are the only part of the interface that cannot use the pixels it
+		// is given. Rasterise them at the size they are actually drawn at instead, while every
+		// reported metric keeps coming from the authored size: the layout does not move.
+		const float wanted = _gc ? _gc->textRenderScale() : 1.0f;
+		const unsigned generation = _gc ? _gc->getGLContextGeneration() : 0;
+		// A texture from a replaced GL context no longer names anything
+		if (generation != textureGeneration)
+		{
+			clearCache();
+			textureGeneration = generation;
+		}
+		// Font sizes are integers: only a scale that changes the raster size is worth reopening
+		const unsigned wantedSize = std::max(1u, static_cast<unsigned>(std::lround(baseSize * wanted)));
+		const unsigned currentSize = std::max(1u, static_cast<unsigned>(std::lround(baseSize * renderScale)));
+		if (wantedSize == currentSize)
+		{
+			renderScale = wanted;
+			return;
+		}
+
+		TTF_Font *replacement = NULL;
+		if (wantedSize != baseSize)
+		{
+			if (SDL_RWops *fontStream = Toolkit::getFileManager()->open(fontFilename, "rb"))
+				replacement = TTF_OpenFontRW(fontStream, 1, wantedSize);
+			if (!replacement && verbose)
+				std::cerr << "TrueTypeFont : cannot reopen " << fontFilename << " at size " << wantedSize
+					<< ", keeping the authored raster" << std::endl;
+		}
+
+		clearCache();
+		if (renderFont && renderFont != font)
+			TTF_CloseFont(renderFont);
+		// Falling back to the authored raster only costs sharpness, so a failed reopen is not fatal
+		renderFont = replacement ? replacement : font;
+		renderScale = replacement ? wanted : 1.0f;
+		applyStyle();
+	}
+
+	void TrueTypeFont::applyStyle(void)
+	{
+		assert(font);
+		assert(styleStack.size() > 0);
+		TTF_SetFontStyle(font, styleStack.top().shape);
+		if (renderFont && renderFont != font)
+			TTF_SetFontStyle(renderFont, styleStack.top().shape);
+	}
+
+	bool TrueTypeFont::targetScalesText(const DrawableSurface *surface) const
+	{
+		// Only the screen carries a scaled GL viewport. An offscreen surface, for instance the
+		// one an overlay dialog composes itself on, stores logical pixels and would have to
+		// resample a raster made for the screen before anything reaches it.
+		return renderFont != font && _gc != NULL && surface == static_cast<const DrawableSurface *>(_gc);
+	}
+
+	std::string TrueTypeFont::shapeText(const std::string &text) const
+	{
+#ifdef HAVE_FRIBIDI
+		char *bidiStr = const_cast<TrueTypeFont *>(this)->getBIDIString(text);
+		std::string shaped(bidiStr);
+		delete []bidiStr;
+		return shaped;
+#else
+		return text;
+#endif
+	}
 	
 	int TrueTypeFont::getStringWidth(const std::string string)
 	{
-		DrawableSurface *s = getStringCached(string);
+		const CacheData *data = getStringCached(string, renderFont != font);
 		int w;
-		if (s)
+		if (data)
 		{
-			w = s->getW();
+			w = data->w;
 			cleanupCache();
 		}
 		else
@@ -94,10 +188,10 @@ namespace GAGCore
 		int h;
 		if (!string.empty())
 		{
-			DrawableSurface *s = getStringCached(string);
-			if (s)
+			const CacheData *data = getStringCached(string, renderFont != font);
+			if (data)
 			{
-				h = s->getH();
+				h = data->h;
 				cleanupCache();
 			}
 			else
@@ -148,7 +242,7 @@ namespace GAGCore
 		assert(font);
 		
 		styleStack.push(style);
-		TTF_SetFontStyle(font, style.shape);
+		applyStyle();
 	}
 	
 	void TrueTypeFont::popStyle(void)
@@ -158,7 +252,7 @@ namespace GAGCore
 		if (styleStack.size() > 1)
 		{
 			styleStack.pop();
-			TTF_SetFontStyle(font, styleStack.top().shape);
+			applyStyle();
 		}
 	}
 	
@@ -169,17 +263,18 @@ namespace GAGCore
 		return styleStack.top();
 	}
 	
-	DrawableSurface *TrueTypeFont::getStringCached(const std::string text)
+	const TrueTypeFont::CacheData *TrueTypeFont::getStringCached(const std::string text, bool scaled)
 	{
 		assert(font);
 		assert(styleStack.size()>0);
 		
+		updateRenderScale();
+		scaled = scaled && (renderFont != font);
+
 		CacheKey key;
 		key.text = text;
 		key.style = styleStack.top();
-		
-		CacheData data;
-		DrawableSurface *s;
+		key.scaled = scaled;
 		
 		std::map<CacheKey, CacheData>::iterator keyIt = cache.find(key);
 		if (keyIt == cache.end())
@@ -190,31 +285,34 @@ namespace GAGCore
 			c.g = styleStack.top().color.g;
 			c.b = styleStack.top().color.b;
 			c.a = styleStack.top().color.a;
-#ifdef HAVE_FRIBIDI 
-			char *bidiStr = getBIDIString(text);
-			SDL_Surface *temp = TTF_RenderUTF8_Blended(font, bidiStr, c);
-			delete []bidiStr;
-#else		
-			SDL_Surface *temp = TTF_RenderUTF8_Blended(font, text.c_str(), c);
-#endif
+			const std::string shaped = shapeText(text);
+			SDL_Surface *temp = TTF_RenderUTF8_Blended(scaled ? renderFont : font, shaped.c_str(), c);
 			if (temp == NULL)
 				return NULL;
 			
 			// create key
+			CacheData data;
 			data.lastAccessed = now;
-			data.s = s = new DrawableSurface(temp);
-			assert(s);
+			data.s = new DrawableSurface(temp);
+			assert(data.s);
 			SDL_FreeSurface(temp);
+			// The raster may be finer than the layout; callers only ever see the authored size
+			const float rasterScale = (scaled && renderScale > 0.0f) ? renderScale : 1.0f;
+			data.drawW = data.s->getW() / rasterScale;
+			data.drawH = data.s->getH() / rasterScale;
+			if (!scaled || TTF_SizeUTF8(font, shaped.c_str(), &data.w, &data.h) != 0)
+			{
+				data.w = static_cast<int>(std::lround(data.drawW));
+				data.h = static_cast<int>(std::lround(data.drawH));
+			}
 			
 			// store in cache
-			cache[key] = data;
-			timeCache[now] = cache.find(key);
+			keyIt = cache.insert(std::make_pair(key, data)).first;
+			timeCache[now] = keyIt;
 			cacheMiss++;
 		}
 		else
 		{
-			// get surface
-			s = keyIt->second.s;
 			// erase old time association
 			timeCache.erase(keyIt->second.lastAccessed);
 			// set new time
@@ -224,7 +322,7 @@ namespace GAGCore
 			cacheHit++;
 		}
 		now++;
-		return s;
+		return &keyIt->second;
 	}
 #ifdef HAVE_FRIBIDI 
 	char *TrueTypeFont::getBIDIString (const std::string text)
@@ -261,9 +359,15 @@ namespace GAGCore
 	void TrueTypeFont::drawString(DrawableSurface *surface, int x, int y, int w, const std::string text, Uint8 alpha)
 	{
 		// get
-		DrawableSurface *s = getStringCached(text);
-		if (s == NULL)
+		const bool scaled = targetScalesText(surface);
+		const CacheData *data = getStringCached(text, scaled);
+		if (data == NULL)
 			return;
+		DrawableSurface *s = data->s;
+		// Drawn at the raster's own size, from the same origin as before, so no glyph is
+		// resampled. The reported width stays the authored one, which the raster matches to
+		// within the rounding the font applies differently at every size.
+		const float dw = data->drawW, dh = data->drawH;
 		
 		// render
 		if (w)
@@ -272,10 +376,15 @@ namespace GAGCore
 			surface->getClipRect(&rx, &ry, &rw, &rh);
 			int nrw = std::min(rw, x + w - rx);
 			surface->setClipRect(rx, ry, nrw, rh);
-			surface->drawSurface(x, y, s, alpha);
+			if (scaled)
+				surface->drawSurface(static_cast<float>(x), static_cast<float>(y), dw, dh, s, alpha);
+			else
+				surface->drawSurface(x, y, s, alpha);
 			surface->setClipRect(rx, ry, rw, rh);
 			
 		}
+		else if (scaled)
+			surface->drawSurface(static_cast<float>(x), static_cast<float>(y), dw, dh, s, alpha);
 		else
 			surface->drawSurface(x, y, s, alpha);
 		
@@ -286,9 +395,12 @@ namespace GAGCore
 	void TrueTypeFont::drawString(DrawableSurface *surface, float x, float y, float w, const std::string text, Uint8 alpha)
 	{
 		// get
-		DrawableSurface *s = getStringCached(text);
-		if (s == NULL)
+		const bool scaled = targetScalesText(surface);
+		const CacheData *data = getStringCached(text, scaled);
+		if (data == NULL)
 			return;
+		DrawableSurface *s = data->s;
+		const float dw = data->drawW, dh = data->drawH;
 		
 		// render
 		if (w != 0.0f)
@@ -297,10 +409,15 @@ namespace GAGCore
 			surface->getClipRect(&rx, &ry, &rw, &rh);
 			int nrw = std::min(rw, (int)x + (int)w - rx);
 			surface->setClipRect(rx, ry, nrw, rh);
-			surface->drawSurface(x, y, s, alpha);
+			if (scaled)
+				surface->drawSurface(x, y, dw, dh, s, alpha);
+			else
+				surface->drawSurface(x, y, s, alpha);
 			surface->setClipRect(rx, ry, rw, rh);
 			
 		}
+		else if (scaled)
+			surface->drawSurface(x, y, dw, dh, s, alpha);
 		else
 			surface->drawSurface(x, y, s, alpha);
 		

--- a/test/TextRasterHarness.cpp
+++ b/test/TextRasterHarness.cpp
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Text drawn on a scaled screen must be rasterised for the pixels it actually covers,
+// while the sizes it reports stay those of the authored font size.
+#include "GraphicContextPrivate.h"
+#include <TrueTypeFont.h>
+#include <SDL_ttf.h>
+#include <Toolkit.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace GAGCore;
+namespace {
+const char *const SAMPLES[] = {
+	"Globulation",
+	"iiillmmWW",
+	"The quick brown fox jumps over the lazy dog",
+	"0123456789",
+	"Wheat: 42/60",
+};
+
+class Context : public GraphicContext
+{
+public:
+	Context(int w, int h) : GraphicContext(w, h, USEGPU, "Glob2 text raster regression") {}
+	int surfaceW() const { return sdlsurface ? sdlsurface->w : 0; }
+	int surfaceH() const { return sdlsurface ? sdlsurface->h : 0; }
+	int pixelW() const { return drawableW; }
+	int pixelH() const { return drawableH; }
+	using GraphicContext::textRenderScale;
+	//! Where the scaled interface sits inside the drawable, which is centred when the two
+	//! aspect ratios differ.
+	void letterbox(float &scale, int &offX, int &offY) { glLetterbox(scale, offX, offY); }
+};
+
+void require(bool condition, const std::string &message)
+{
+	if (!condition) throw std::runtime_error(message);
+}
+
+struct Metrics
+{
+	std::vector<int> widths, heights;
+};
+
+Metrics measure(Font *font)
+{
+	Metrics m;
+	for (const char *sample : SAMPLES)
+	{
+		m.widths.push_back(font->getStringWidth(sample));
+		m.heights.push_back(font->getStringHeight(sample));
+	}
+	return m;
+}
+
+// The drawable, top row first.
+std::vector<unsigned char> readFrame(Context &context)
+{
+	const int w = context.pixelW(), h = context.pixelH();
+	std::vector<unsigned char> pixels(size_t(w) * h * 4, 0);
+#ifdef HAVE_OPENGL
+	glFlush();
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+	require(glGetError() == GL_NO_ERROR, "OpenGL reported an error while reading the frame");
+	std::vector<unsigned char> flipped(pixels.size());
+	for (int row = 0; row < h; ++row)
+		std::memcpy(&flipped[size_t(row) * w * 4], &pixels[size_t(h - 1 - row) * w * 4], size_t(w) * 4);
+	pixels.swap(flipped);
+#endif
+	return pixels;
+}
+
+void saveFrame(const std::vector<unsigned char> &pixels, int w, int h, const std::string &path)
+{
+	if (path.empty()) return;
+	SDL_Surface *frame = SDL_CreateRGBSurfaceWithFormatFrom(
+		const_cast<unsigned char *>(pixels.data()), w, h, 32, w * 4, SDL_PIXELFORMAT_RGBA32);
+	if (!frame) return;
+	SDL_SaveBMP(frame, path.c_str());
+	SDL_FreeSurface(frame);
+}
+
+// Draw one line of text on a black frame at a position that lands on the block grid.
+std::vector<unsigned char> drawSample(Context &context, Font *font, int logicalX, int logicalY)
+{
+	// Present once so the window system applies the current backing-buffer size, then draw
+	// into the back buffer and read that back before it is swapped away.
+	context.nextFrame();
+	context.setClipRect();
+	context.drawFilledRect(0, 0, context.surfaceW(), context.surfaceH(), Color::black);
+	font->setStyle(Font::Style(Font::STYLE_NORMAL, 255, 255, 255));
+	context.drawString(logicalX, logicalY, font, SAMPLES[2]);
+	return readFrame(context);
+}
+
+// Count blocks of scale x scale drawable pixels that are not a single flat colour. A glyph
+// rasterised at the authored size and then magnified fills every block uniformly, so detail
+// inside the blocks is exactly the detail the finer raster added.
+long countDetailedBlocks(const std::vector<unsigned char> &pixels, int w, int h, int block)
+{
+	long detailed = 0;
+	for (int by = 0; by + block <= h; by += block)
+		for (int bx = 0; bx + block <= w; bx += block)
+		{
+			const unsigned char *first = &pixels[(size_t(by) * w + bx) * 4];
+			bool uniform = true;
+			for (int y = 0; y < block && uniform; ++y)
+				for (int x = 0; x < block; ++x)
+				{
+					const unsigned char *p = &pixels[(size_t(by + y) * w + bx + x) * 4];
+					if (std::memcmp(p, first, 3) != 0) { uniform = false; break; }
+				}
+			if (!uniform) ++detailed;
+		}
+	return detailed;
+}
+
+long countLitPixels(const std::vector<unsigned char> &pixels, int w, int x0, int y0, int x1, int y1)
+{
+	long lit = 0;
+	for (int y = y0; y < y1; ++y)
+		for (int x = x0; x < x1; ++x)
+			if (pixels[(size_t(y) * w + x) * 4] > 32) ++lit;
+	return lit;
+}
+
+long countLitPixels(const std::vector<unsigned char> &pixels)
+{
+	long lit = 0;
+	for (size_t i = 0; i + 3 < pixels.size(); i += 4)
+		if (pixels[i] > 32) ++lit;
+	return lit;
+}
+
+// Rasterising for the screen is only worth anything if every raster pixel lands on exactly
+// one screen pixel. Hinting rounds each font size differently, so a raster squeezed into the
+// rectangle the authored size measures loses or repeats pixel columns inside single glyphs.
+// Rasterise the same string independently here and require the frame to match it.
+void checkRasterIsPixelExact(const std::vector<unsigned char> &frame, int frameW, float scale,
+	int offX, int offY, const char *text, int logicalX, int logicalY)
+{
+	const int size = static_cast<int>(std::lround(20 * scale));
+	TTF_Font *reference = TTF_OpenFont("data/fonts/sans.ttf", size);
+	require(reference != NULL, "Could not open the reference font at the scaled size");
+	SDL_Color white{255, 255, 255, 255};
+	SDL_Surface *rendered = TTF_RenderUTF8_Blended(reference, text, white);
+	require(rendered != NULL, "Could not rasterise the reference string");
+	SDL_Surface *ink = SDL_ConvertSurfaceFormat(rendered, SDL_PIXELFORMAT_RGBA32, 0);
+	SDL_FreeSurface(rendered);
+	require(ink != NULL, "Could not convert the reference string");
+
+	// White on black composites to exactly the glyph coverage, so the frame's red channel
+	// should reproduce the reference alpha.
+	const int originX = offX + static_cast<int>(std::lround(logicalX * scale));
+	const int originY = offY + static_cast<int>(std::lround(logicalY * scale));
+	long compared = 0, mismatched = 0, worst = 0;
+	for (int y = 0; y < ink->h; ++y)
+		for (int x = 0; x < ink->w; ++x)
+		{
+			const unsigned char *ref = static_cast<const unsigned char *>(ink->pixels) + y * ink->pitch + x * 4;
+			const unsigned char *got = &frame[(size_t(originY + y) * frameW + originX + x) * 4];
+			const long delta = std::abs(int(got[0]) - int(ref[3]));
+			++compared;
+			if (delta > 24) { ++mismatched; worst = std::max(worst, delta); }
+		}
+	SDL_FreeSurface(ink);
+	TTF_CloseFont(reference);
+
+	require(compared > 0, "The reference string is empty");
+	const double ratio = double(mismatched) / compared;
+	require(ratio < 0.005,
+		"The drawn glyphs do not match a raster made for this screen: "
+		+ std::to_string(mismatched) + " of " + std::to_string(compared)
+		+ " pixels differ (worst " + std::to_string(worst) + "). The raster is being stretched "
+		"into the rectangle the authored size measures instead of drawn at its own size.");
+}
+
+// An overlay dialog composes itself on its own surface, which holds logical pixels and has
+// no scaled blit to resample a finer raster with. Text drawn there has to keep arriving.
+void checkOverlayText(Context &context, Font *font, float scale)
+{
+	const int x = 100, y = 200, w = 400, h = 60;
+	DrawableSurface overlay(w, h);
+	overlay.drawFilledRect(0, 0, w, h, Color::black);
+	font->setStyle(Font::Style(Font::STYLE_NORMAL, 255, 255, 255));
+	overlay.drawString(4, 4, font, SAMPLES[0]);
+
+	context.nextFrame();
+	context.setClipRect();
+	context.drawFilledRect(0, 0, context.surfaceW(), context.surfaceH(), Color::black);
+	context.drawSurface(x, y, &overlay);
+	const std::vector<unsigned char> frame = readFrame(context);
+	const long lit = countLitPixels(frame, context.pixelW(),
+		static_cast<int>(x * scale), static_cast<int>(y * scale),
+		static_cast<int>((x + w) * scale), static_cast<int>((y + h) * scale));
+	require(lit > 0, "Text drawn on an overlay surface never reached the screen");
+}
+
+void run(const std::string &outputDir)
+{
+	const int windowW = 1280, windowH = 960;
+	// Open the window already scaled, the way a HiDPI desktop hands it over. The sharpness
+	// check must not depend on a mode switch, so that the saved frames compare one build
+	// against another rather than one context against its successor.
+	GraphicContext::setRequestedUiScale(2.0f);
+	Context context(windowW, windowH);
+	require(context.surfaceW() == windowW / 2, "The interface surface did not halve");
+
+	Toolkit::loadFont("data/fonts/sans.ttf", 20, "harness");
+	Font *font = Toolkit::getFont("harness");
+	require(font != NULL, "Could not load data/fonts/sans.ttf");
+
+	const float scale = context.textRenderScale();
+	require(scale > 1.05f, "The context does not scale text, so there is nothing to test");
+
+	const Metrics scaled = measure(font);
+	const std::vector<unsigned char> sharp = drawSample(context, font, 10, 10);
+	saveFrame(sharp, context.pixelW(), context.pixelH(), outputDir.empty() ? "" : outputDir + "/text-scaled.bmp");
+	require(countLitPixels(sharp) > 0, "Nothing was drawn on the scaled screen");
+
+	const int block = static_cast<int>(std::lround(scale));
+	require(std::fabs(scale - block) < 0.01f, "This display scales text by a fraction; the block test needs an integer");
+	const long detailed = countDetailedBlocks(sharp, context.pixelW(), context.pixelH(), block);
+	require(detailed > 0,
+		"Every " + std::to_string(block) + "x" + std::to_string(block)
+		+ " block of the frame is flat: the glyphs were magnified instead of rasterised for the screen");
+
+	{
+		float viewScale; int offX, offY;
+		context.letterbox(viewScale, offX, offY);
+		checkRasterIsPixelExact(sharp, context.pixelW(), scale, offX, offY, SAMPLES[2], 10, 10);
+	}
+	checkOverlayText(context, font, scale);
+
+	// A scale the screen does not make an integer of, and a screen that cannot deliver the
+	// requested resolution and therefore reduces it, resample glyphs just as a magnifying one
+	// does. Neither has a pixel grid to check blocks on, so check the raster itself.
+	for (auto attempt : {std::pair<float, const char *>{1.7f, "a fractional interface scale"},
+		{1.0f, "a resolution the screen cannot deliver"}})
+	{
+		// Fullscreen keeps the desktop's size, so asking for more than it has is what reduces.
+		const bool oversized = attempt.first == 1.0f;
+		const int w = oversized ? windowW * 3 : windowW, h = oversized ? windowH * 3 : windowH;
+		const Uint32 flags = GraphicContext::USEGPU | (oversized ? GraphicContext::FULLSCREEN : 0);
+		GraphicContext::setRequestedUiScale(attempt.first);
+		require(context.setRes(w, h, flags),
+			std::string("Could not reopen the window for ") + attempt.second);
+		// The geometry decides whether glyphs are resampled, not what the font code makes of it.
+		float other; int offX, offY;
+		context.letterbox(other, offX, offY);
+		if (std::fabs(other - 1.0f) < 0.01f)
+		{
+			std::printf("SKIP %s: this display does not scale for it\n", attempt.second);
+			continue;
+		}
+		// Drawn at the origin: any other position lands between device pixels once the scale
+		// is not an integer, and no raster can be exact about where it is not aligned.
+		const std::vector<unsigned char> frame = drawSample(context, font, 0, 0);
+		checkRasterIsPixelExact(frame, context.pixelW(), other, offX, offY, SAMPLES[2], 0, 0);
+		std::printf("     %s: scale %.3f, glyphs pixel-exact\n", attempt.second, other);
+	}
+
+	// Drop back to an unscaled interface. The reported sizes are what every layout in the
+	// game is written against, so they have to survive the switch unchanged, and the frame
+	// has to keep drawing through the replaced GL context.
+	GraphicContext::setRequestedUiScale(1.0f);
+	require(context.setRes(windowW, windowH, GraphicContext::USEGPU), "Could not reopen the window unscaled");
+	require(context.textRenderScale() > 0.0f, "The context reports no text scale");
+	require(context.surfaceW() == windowW, "The interface surface did not follow the window");
+
+	const Metrics reference = measure(font);
+	for (size_t i = 0; i < reference.widths.size(); ++i)
+	{
+		require(reference.widths[i] > 0 && reference.heights[i] > 0, "The font reports an empty string size");
+		require(scaled.widths[i] == reference.widths[i],
+			std::string("Text width moved with the interface scale: \"") + SAMPLES[i] + "\" "
+			+ std::to_string(reference.widths[i]) + " -> " + std::to_string(scaled.widths[i]));
+		require(scaled.heights[i] == reference.heights[i],
+			std::string("Text height moved with the interface scale: \"") + SAMPLES[i] + "\"");
+	}
+
+	const std::vector<unsigned char> flat = drawSample(context, font, 10, 10);
+	saveFrame(flat, context.pixelW(), context.pixelH(), outputDir.empty() ? "" : outputDir + "/text-unscaled.bmp");
+	require(countLitPixels(flat) > 0, "Nothing was drawn after the interface scale changed");
+
+	std::printf("PASS text raster: scale %.2f, metrics unchanged across %zu samples, glyphs pixel-exact, overlay text drawn, %ld detailed %dx%d blocks\n",
+		scale, reference.widths.size(), detailed, block, block);
+}
+}
+
+int main(int argc, char **argv)
+{
+#ifndef HAVE_OPENGL
+	std::fprintf(stderr, "OpenGL support is required\n");
+	return 1;
+#else
+	const std::string outputDir = argc > 1 ? argv[1] : "";
+	SDL_setenv("SDL_AUDIODRIVER", "dummy", 1);
+	// Keep the run out of the player's own profile.
+	if (!outputDir.empty()) SDL_setenv("GLOB2_USER_DIR", outputDir.c_str(), 0);
+	Toolkit::init("glob2");
+	try
+	{
+		run(outputDir);
+	}
+	catch (const std::exception &error)
+	{
+		std::fprintf(stderr, "FAIL: %s\n", error.what());
+		return 1;
+	}
+	return 0;
+#endif
+}


### PR DESCRIPTION
Text renders pixelated because glyphs are rasterised once, at the fixed pixel
size the font is loaded with (20, 13 and 10 px), and that finished bitmap is
then resampled along with the rest of the frame to whatever size it occupies on
screen. Nothing ever re-renders text for the screen it is actually drawn on, so
at 200 % interface scale one glyph pixel becomes a 2x2 block of screen pixels.

Nor is a raised interface scale the only case. At 100 % it happens too whenever
the display cannot deliver the requested resolution exactly: a fullscreen
3456x2234 on a 16-inch MacBook is presented at 3456x2168, so every glyph is
reduced by 3 % and loses pixel rows.

### Before and after

| before | after |
| --- | --- |
| <img width="340" height="201" alt="Screenshot 2026-09-12 at 16 47 14" src="https://github.com/user-attachments/assets/afd1e3ea-21e9-4cf1-9233-dba5206e319b" />| <img width="333" height="192" alt="Screenshot 2026-09-12 at 16 48 10" src="https://github.com/user-attachments/assets/4de98cbe-b2f1-46b6-a1b3-9cc1e27b0134" />|

### What this does

`TrueTypeFont` keeps a second font handle at `size * scale` and draws from it,
while every reported metric still comes from the authored size, so no widget
moves. The scale is the new `GraphicContext::textRenderScale()`, which is 1 for
the software renderer. Hinting rounds each size differently ("Editor" is 61
logical pixels at size 20 but 118 device pixels at size 40, i.e. 59), so the
raster is drawn at its own size rather than stretched into the measured
rectangle; stretching repeats or drops pixel columns inside single glyphs.

Two fixes it depends on: a new GL context now resets the cached GL state, and the
string caches drop themselves when the context generation changes. Without them
the first draws after a resolution or scale change fill white quads from texture
names of the destroyed context.

`test/TextRasterHarness.cpp`, built and run in CI under Xvfb, requires unchanged
string metrics across a scale change, detail inside the scale-sized pixel blocks,
glyphs matching an independently rasterised reference at a magnifying, a
fractional and a reducing scale, and overlay text still reaching the screen. Each
check fails against the implementation it guards. 187 unit tests and a 600-tick
headless run (checksum `6b785f48`) are unchanged; simulation, saves, replays and
the protocol are untouched.

### What it does not cover

`OverlayScreen` composes itself on its own logical-size surface that is resampled
as one image, so the in-game menu, load/save, message boxes and the editor
dialogs look exactly as before. `DrawableSurface` has no scaled blit
(`// TODO : Implement`), so handing them a raster made for the screen would have
made their text vanish instead. Sharpening them needs either overlay widgets
drawn straight onto the context, or a device-resolution backing for those
surfaces plus that blit: a separate change across all widget drawing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
