### PR TITLE
Read and write wire fields through memcpy instead of unaligned casts

### DIFF
--- a/src/Marshaling.h
+++ b/src/Marshaling.h
@@ -8,55 +8,69 @@
 #include <string.h>
 
 // Useful function for marshalling
-// TODO: we have to add another version for all those if we want them to work for spark CPUs.
+// Wire fields may start at any byte offset; memcpy avoids alignment and aliasing UB.
 
 // 32 bit:
 
 inline void addSint32(const Uint8 *data, Sint32 val, int pos)
 {
-	*((Sint32 *)(data+pos))=SDL_SwapBE32(val);
+	const Uint32 wire=SDL_SwapBE32(static_cast<Uint32>(val));
+	memcpy(const_cast<Uint8 *>(data)+pos, &wire, sizeof(wire));
 }
 
 inline Sint32 getSint32(const Uint8 *data, int pos)
 {
-	return (Sint32)SDL_SwapBE32( *((Sint32 *)(data+pos)) );
+	Uint32 wire;
+	memcpy(&wire, data+pos, sizeof(wire));
+	return static_cast<Sint32>(SDL_SwapBE32(wire));
 }
 
 inline void addUint32(const Uint8 *data, Uint32 val, int pos)
 {
-	*((Uint32 *)(data+pos))=SDL_SwapBE32(val);
+	const Uint32 wire=SDL_SwapBE32(static_cast<Uint32>(val));
+	memcpy(const_cast<Uint8 *>(data)+pos, &wire, sizeof(wire));
 }
 
 inline Uint32 getUint32(const Uint8 *data, int pos)
 {
-	return (Uint32)SDL_SwapBE32( *((Uint32 *)(data+pos)) );
+	Uint32 wire;
+	memcpy(&wire, data+pos, sizeof(wire));
+	return static_cast<Uint32>(SDL_SwapBE32(wire));
 }
 
 inline Uint32 getUint32RAW(const Uint8 *data, int pos)
 {
-	return *(Uint32 *)(((Uint8 *)data) +pos) ;
+	Uint32 value;
+	memcpy(&value, data+pos, sizeof(value));
+	return value;
 }
 
 // 16 bit:
 
 inline void addSint16(const Uint8 *data, Sint16 val, int pos)
 {
-	*((Sint16 *)(data+pos))=SDL_SwapBE16(val);
+	const Uint16 wire=SDL_SwapBE16(static_cast<Uint16>(val));
+	memcpy(const_cast<Uint8 *>(data)+pos, &wire, sizeof(wire));
 }
 
 inline void addUint16(const Uint8 *data, Uint16 val, int pos)
 {
-	*((Sint16 *)(data+pos))=SDL_SwapBE16(val);
+	const Uint16 wire=SDL_SwapBE16(static_cast<Uint16>(val));
+	memcpy(const_cast<Uint8 *>(data)+pos, &wire, sizeof(wire));
 }
 
 inline Sint16 getSint16(const Uint8 *data, int pos)
 {
-	return (Sint16)SDL_SwapBE16(*((Sint16 *)(data+pos)));
+	Uint16 wire;
+	memcpy(&wire, data+pos, sizeof(wire));
+	return static_cast<Sint16>(SDL_SwapBE16(wire));
 }
 
 inline Uint16 getUint16(const Uint8 *data, int pos)
 {
-	return (Uint16)SDL_SwapBE16(*((Uint16 *)(data+pos)));
+	Uint16 wire;
+	memcpy(&wire, data+pos, sizeof(wire));
+	return static_cast<Uint16>(SDL_SwapBE16(wire));
 }
 
 // 8 bit:


### PR DESCRIPTION
## What

`src/Marshaling.h` read and wrote every 16- and 32-bit wire field by casting the
byte pointer to `Sint32*`/`Uint32*`/`Sint16*`/`Uint16*` and dereferencing it.
Wire fields start at arbitrary byte offsets, so those accesses are unaligned and
violate strict aliasing. They abort under UBSan, and on a target that faults on
unaligned loads they would break outright.

This replaces them with `memcpy` of the already-swapped value. The 8-bit
accessors keep their direct byte access, which is always aligned.

`Marshaling.h` backs `Order*.cpp`, `BaseTeam.cpp` and
`MapGenerationDescriptor.cpp`, so this sits squarely on the replay and network
path where identical execution across platforms is the requirement.

## Compatibility

No format change. `memcpy` of the swapped value writes the same bytes the cast
wrote, so saves, replays and network packets are unchanged on every platform
that ran the old code successfully. `MINIMUM_VERSION_MINOR`, the replay gates
and the YOG version gates are all untouched.

## Verification

Rather than argue it, I built master with and without this change and ran the
same headless game on each:

```
GLOB2_TEST_SEED=4242 GLOB2_REPLAY_PATH=... \
  ./build/src/glob2 -test-games-nox 1 --map SmallForTwo --matchup nicowar,warrush
```

Both runs: 34,498 ticks, 2,907 orders, `winner_team=0`. The replays are
**byte-identical**, which includes the per-tick state checksums they carry:

```
f541f81f0af7b97b0e7a1be8fbf89409a595411647c052f60f965a5e41b330a3  master-base.replay
f541f81f0af7b97b0e7a1be8fbf89409a595411647c052f60f965a5e41b330a3  master-fixed.replay
```

Also on this branch:
- `test/TestsRunner` — OK (190 tests)
- `glob2-server` startup suite — NetMessage serialization, NetListener &
  NetConnection, YOGGameInfo, YOGMessage, YOGPlayerSessionInfo and
  NetReteamingInformation all pass. That suite is the direct exerciser of the
  changed accessors.

Platform coverage I could **not** verify: this was all on macOS/arm64. The
change is a strict improvement on any platform, but the cross-platform checksum
comparison that would prove byte-identical output on Linux and Windows is left
to CI and to a reviewer with those machines.

## Provenance

The fix was originally written on a since-deleted Maxima tournament branch and
was recovered from it; it is unrelated to that AI work, which is why it is here
as its own change rather than inside #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfax2ecD9Y3vnLhocZFYxp