### PR TITLE
Remove Maxima's legacy zero-capacity swarm retirement

### DIFF
--- a/data/maxima/base.strategy
+++ b/data/maxima/base.strategy
@@ -169,7 +169,6 @@ demands.aggression_target_bonus = 20
 
 # Economy policy: infrastructure targets, unit-production ratios, service
 # safeguards, and adaptation for large or amphibious economies.
-economy.swarm_retirement_enabled = true
 economy.large_economy_adaptation_enabled = true
 economy.amphibious_network_maintenance_enabled = true
 economy.food_service_safeguards_enabled = true

--- a/doc/MaximaFoodLedger.md
+++ b/doc/MaximaFoodLedger.md
@@ -131,8 +131,8 @@ A retirement also requires all of:
 One building is retired at a time, lowest coverage first. Freeing its wheat
 often clears the others without further deletions.
 
-This supersedes the older rule that retired only swarms with no farm capacity at
-all; `food.enabled` selects between them.
+This replaced the older rule that retired only swarms with no farm capacity at
+all, which has since been removed: with `food.enabled` off, nothing is retired.
 
 ## Saturation
 

--- a/doc/MaximaStrategyConfiguration.md
+++ b/doc/MaximaStrategyConfiguration.md
@@ -145,7 +145,7 @@ The complete switch inventory is:
 
 | Policy area | Switches |
 | --- | --- |
-| Economy adaptations | `economy.swarm_retirement_enabled`, `economy.large_economy_adaptation_enabled`, `economy.amphibious_network_maintenance_enabled`, `economy.food_service_safeguards_enabled`, `economy.worker_birth_throttle_enabled` |
+| Economy adaptations | `economy.large_economy_adaptation_enabled`, `economy.amphibious_network_maintenance_enabled`, `economy.food_service_safeguards_enabled`, `economy.worker_birth_throttle_enabled` |
 | Development actions | `upgrades.enabled`, `repairs.enabled` |
 | Military responses | `military.explorer_defense_enabled`, `military.warrior_training_backlog_throttle_enabled`, `military.preemptive_defense_enabled`, `military.preemptive_amphibious_enabled` |
 | Strategic postures | `postures.recover_enabled`, `postures.defend_enabled`, `postures.expand_enabled`, `postures.develop_enabled`, `postures.mobilize_enabled`, `postures.campaign_enabled`, `postures.finish_enabled` |
@@ -333,8 +333,8 @@ count is not an input, so constructing another swarm cannot manufacture its own
 staffing demand. Colonization has independent construction permission for genuinely
 new food territory; completed colonies still count toward this production target. The existing supply-weighted
 allocator distributes the budget over completed swarms. Construction scheduling,
-inn policy, unit production mix, and retirement of unusable remote swarms remain
-separate responsibilities.
+inn policy, unit production mix, and food-ledger retirement remain separate
+responsibilities.
 
 The old global caps, committed swarm target, per-headroom staffing tiers, birth
 survival thresholds, and their unused bonuses have been removed from the schema.

--- a/src/AIMaxima.cpp
+++ b/src/AIMaxima.cpp
@@ -50,6 +50,8 @@ namespace
 	// Let default explorer movement reveal most of the map before active scouting.
 	const int ACTIVE_RECON_MIN_EXPLORED_PERCENT=80;
 	const int PREEMPTIVE_UNREACHABLE=-1;
+	// Save format that dropped the zero-capacity swarm retirement records.
+	const int LegacySwarmRetirementRemovedVersion=99;
 
 	int clamp_score(int value)
 	{
@@ -561,7 +563,6 @@ Maxima::DirectorPlan::DirectorPlan()
 	  upgrade_level2_pool_weight(0), upgrade_level2_barracks_weight(0),
 	  first_prestige_trained_workers(0), second_prestige_trained_workers(0),
 	  second_prestige_population_min(0),
-	  swarm_retirement_enabled(true),
 	  food_ledger_enabled(true), food_retirement_enabled(true),
 	  food_inn_burden_percent(60), food_swarm_burden_percent(60),
 	  food_recovered_percent(85), food_burden_confirm_ticks(3000),
@@ -2970,8 +2971,6 @@ void Maxima::finalize_director_plan(Context& echo)
 		strategy.upgrades.second_prestige_trained_workers;
 	budget.second_prestige_population_min=
 		strategy.upgrades.second_prestige_population_min;
-	budget.swarm_retirement_enabled=
-		strategy.economy.swarm_retirement_enabled;
 	budget.food_ledger_enabled=strategy.food.enabled;
 	budget.food_retirement_enabled=strategy.food.retirement_enabled;
 	budget.food_inn_burden_percent=strategy.food.inn_burden_coverage_percent;
@@ -3647,9 +3646,6 @@ Maxima::Maxima(Player *player)
 		buildings_under_construction_per_type[n]=0;
 	development_planner_initialized=false;
 	development_reported_states.clear();
-	remote_swarm_since.clear();
-	remote_swarms_ready.clear();
-	remote_swarm_deletion_issued.clear();
 	food_burden_since.clear();
 	food_retirement_issued.clear();
 	last_food_retirement_tick=-1000000;
@@ -3757,7 +3753,13 @@ template<class Archive> void Maxima::executionState(Archive& a)
 		bool retiredAdaptiveStaffing=false;
 		a("budget.inn_adaptive_staffing_enabled",retiredAdaptiveStaffing);
 	}
-	a("budget.swarm_retirement_enabled",budget.swarm_retirement_enabled);
+	if(a.version()<LegacySwarmRetirementRemovedVersion)
+	{
+		// Saves before version 99 carry the zero-capacity swarm retirement
+		// switch here. The rule is gone; consume the record to stay aligned.
+		bool retiredSwarmRetirementEnabled=false;
+		a("budget.swarm_retirement_enabled",retiredSwarmRetirementEnabled);
+	}
 	if(a.version()>=StaffingControl::SaveVersion)
 	{
 		a("budget.staffing_window_samples",budget.staffing_window_samples);
@@ -3878,15 +3880,23 @@ template<class Archive> void Maxima::executionState(Archive& a)
 	a("accessible_algae_units",accessible_algae_units);
 	a("development_planner_initialized",development_planner_initialized);
 	a("development_reported_states",development_reported_states);
-	a("remote_swarm_since",remote_swarm_since);
+	if(a.version()<LegacySwarmRetirementRemovedVersion)
+	{
+		std::map<int,int> retiredRemoteSwarmSince;
+		a("remote_swarm_since",retiredRemoteSwarmSince);
+	}
 	a("food_burden_since",food_burden_since);
 	a("food_retirement_issued",food_retirement_issued);
 	a("last_food_retirement_tick",last_food_retirement_tick);
 	a("food_supported_inns",food_supported_inns);
 	a("food_supported_swarms",food_supported_swarms);
 	a("food_ledger_valid",food_ledger_valid);
-	a("remote_swarms_ready",remote_swarms_ready);
-	a("remote_swarm_deletion_issued",remote_swarm_deletion_issued);
+	if(a.version()<LegacySwarmRetirementRemovedVersion)
+	{
+		std::set<int> retiredRemoteSwarms;
+		a("remote_swarms_ready",retiredRemoteSwarms);
+		a("remote_swarm_deletion_issued",retiredRemoteSwarms);
+	}
 	a("operating_colonies",operating_colonies);
 	a("last_preemptive_effective_zone_max",last_preemptive_effective_zone_max);
 	a("last_preemptive_amphibious_active",last_preemptive_amphibious_active);
@@ -5102,13 +5112,8 @@ Maxima::collect_development_intents(
 			budget.priority_towers,strategy.staffing.construction_large_workers}};
 	for(size_t i=0;i<sizeof(demands)/sizeof(demands[0]);++i)
 	{
-		int current=development_planner.committedBuildingCount(
+		const int current=development_planner.committedBuildingCount(
 			world,demands[i].type);
-		if(demands[i].type==IntBuildingType::SWARM_BUILDING)
-			for(size_t b=0;b<world.buildings.size();++b)
-				if(!world.buildings[b].site
-				   &&remote_swarms_ready.count(world.buildings[b].id))
-					current=std::max(0,current-1);
 		if(demands[i].desired>current)
 		{
 			DevelopmentIntent intent;intent.buildingType=demands[i].type;
@@ -5356,10 +5361,9 @@ void Maxima::development_cycle(Context& echo)
 		}
 		refreshedWorld=collect_development_world(echo,&worldSignature);
 		development_planner.observe(refreshedWorld,worldSignature);
-		// The ledger supersedes the older zero-capacity swarm rule: an
-		// under-supplied building is a burden whatever its distance from wheat.
+		// An under-supplied building is a burden whatever its distance from
+		// wheat; with the ledger disabled nothing is retired.
 		if(budget.food_ledger_enabled)update_food_retirement(echo,refreshedWorld);
-		else update_swarm_retirement(echo);
 		// Reconcile any starting construction site when it first becomes a completed
 		// building. Planner-owned campus and standalone actions are ignored here.
 		development_planner.adoptStartingBuildings(refreshedWorld);
@@ -5754,84 +5758,6 @@ void Maxima::update_food_retirement(Context& echo,
 		<<"\tcompleted_swarms="<<completed_swarms;
 	emit_telemetry(echo,"food_retirement",fields.str());
 }
-
-void Maxima::update_swarm_retirement(Context& echo)
-{
-	if(!budget.swarm_retirement_enabled)
-	{
-		remote_swarm_since.clear();
-		remote_swarms_ready.clear();
-		remote_swarm_deletion_issued.clear();
-		return;
-	}
-	const int probation_ticks=3000;
-
-	std::set<int> present;
-	int useful=0;
-	BuildingSearch swarms(echo);
-	swarms.add_condition(new SpecificBuildingType(IntBuildingType::SWARM_BUILDING));
-	swarms.add_condition(new NotUnderConstruction);
-	for(building_search_iterator i=swarms.begin();i!=swarms.end();++i)
-	{
-		const int id=*i;present.insert(id);
-		Building* building=echo.get_building_register().get_building(id);
-		if(!building)continue;
-		const bool productive=nearby_farm_capacity(echo,id)>0;
-		if(productive)++useful;
-		if(productive)
-		{
-			remote_swarm_since.erase(id);
-			remote_swarms_ready.erase(id);
-			continue;
-		}
-		if(!remote_swarm_since.count(id))remote_swarm_since[id]=timer;
-		if(timer-remote_swarm_since[id]>=probation_ticks)
-			remote_swarms_ready.insert(id);
-		if(timer%1000<budget.farming_normal_interval)
-		{
-			std::ostringstream fields;
-			fields<<"\tbuilding_id="<<id<<"\tfarm_capacity="<<nearby_farm_capacity(echo,id)
-				<<"\tremote_age="<<(timer-remote_swarm_since[id])
-				<<"\tready="<<(remote_swarms_ready.count(id)?1:0);
-			emit_telemetry(echo,"swarm_retirement",fields.str());
-		}
-	}
-	for(std::map<int,int>::iterator i=remote_swarm_since.begin();
-		i!=remote_swarm_since.end();)
-		if(!present.count(i->first))remote_swarm_since.erase(i++);else ++i;
-	for(std::set<int>::iterator i=remote_swarms_ready.begin();
-		i!=remote_swarms_ready.end();)
-		if(!present.count(*i))remote_swarms_ready.erase(i++);else ++i;
-
-	const bool safe=!budget.recovery_active&&snapshot.critical_food==0
-		&&snapshot.own_buildings_under_attack==0&&snapshot.own_units_under_attack==0;
-	if(timer%1000<budget.farming_normal_interval)
-	{
-		std::ostringstream fields;fields<<"\tuseful_swarms="<<useful
-			<<"\tdesired_swarms="<<budget.desired_swarms
-			<<"\tready="<<remote_swarms_ready.size()
-			<<"\tsafe="<<(safe?1:0)
-			<<"\tcritical_food="<<snapshot.critical_food
-			<<"\trecovery="<<(budget.recovery_active?1:0)
-			<<"\tbuildings_attacked="<<snapshot.own_buildings_under_attack
-			<<"\tunits_attacked="<<snapshot.own_units_under_attack;
-		emit_telemetry(echo,"swarm_retirement_summary",fields.str());
-	}
-	if(!safe||useful<budget.desired_swarms)return;
-	for(std::set<int>::const_iterator i=remote_swarms_ready.begin();
-		i!=remote_swarms_ready.end();++i)
-		if(!remote_swarm_deletion_issued.count(*i))
-		{
-			echo.add_management_order(new DestroyBuilding(*i));
-			remote_swarm_deletion_issued.insert(*i);
-			std::ostringstream fields;fields<<"\tbuilding_id="<<*i
-				<<"\tuseful_swarms="<<useful
-				<<"\tdesired_swarms="<<budget.desired_swarms;
-			emit_telemetry(echo,"swarm_retirement_issued",fields.str());
-			break;
-		}
-}
-
 
 void Maxima::manage_buildings(Context& echo)
 {

--- a/src/AIMaxima.h
+++ b/src/AIMaxima.h
@@ -185,7 +185,6 @@ private:
 		int first_prestige_trained_workers;
 		int second_prestige_trained_workers;
 		int second_prestige_population_min;
-		bool swarm_retirement_enabled;
 		///Food ledger authority. The director decides whether the ledger runs,
 		///what coverage counts as a burden and how long one must persist. The
 		///executor only measures coverage and issues the retirement order.
@@ -644,10 +643,6 @@ private:
 	std::map<int, StaffingControl::State> staffing_control;
 	///Runs one control pass and issues the order when the request changes.
 	int staff_building(AIMaximaRuntime::Context& echo, int id);
-	std::map<int, int> remote_swarm_since;
-	std::set<int> remote_swarms_ready;
-	std::set<int> remote_swarm_deletion_issued;
-	void update_swarm_retirement(AIMaximaRuntime::Context& echo);
 	///Food ledger retirement. A building whose protected farm capacity stays
 	///below its burden threshold for the confirmation window is removed, but
 	///only while doing so cannot leave the population without inn seats.

--- a/src/AIMaximaStrategy.cpp
+++ b/src/AIMaximaStrategy.cpp
@@ -194,7 +194,6 @@ namespace
 		INT_SPEC(demands, aggression_warrior_weight, "demands.aggression_warrior_weight", 0, 20, "weight", "demands", "Trained-warrior contribution to aggression", StrategyImpactHigh),
 		INT_SPEC(demands, aggression_enemy_weight, "demands.aggression_enemy_weight", 0, 20, "weight", "demands", "Enemy-force penalty to aggression", StrategyImpactHigh),
 		INT_SPEC(demands, aggression_target_bonus, "demands.aggression_target_bonus", 0, 100, "score", "demands", "Aggression bonus when an enemy target is known", StrategyImpactHigh),
-		BOOL_SPEC(economy, swarm_retirement_enabled, "economy.swarm_retirement_enabled", "enabled", "economy", "Allow safe retirement of remote unproductive swarms", StrategyImpactHigh),
 		BOOL_SPEC(economy, large_economy_adaptation_enabled, "economy.large_economy_adaptation_enabled", "enabled", "economy", "Enable persistent large-economy adaptation", StrategyImpactHigh),
 		BOOL_SPEC(economy, amphibious_network_maintenance_enabled, "economy.amphibious_network_maintenance_enabled", "enabled", "economy", "Maintain pool capacity after committing to an amphibious economy", StrategyImpactHigh),
 		BOOL_SPEC(economy, food_service_safeguards_enabled, "economy.food_service_safeguards_enabled", "enabled", "economy", "Expand inn construction demand for observed food-service backlog", StrategyImpactCritical),

--- a/src/AIMaximaStrategy.h
+++ b/src/AIMaximaStrategy.h
@@ -198,7 +198,6 @@ struct MaximaStrategy
 
 	struct Economy
 	{
-		bool swarm_retirement_enabled;
 		bool large_economy_adaptation_enabled;
 		bool amphibious_network_maintenance_enabled;
 		bool food_service_safeguards_enabled;

--- a/src/Version.h
+++ b/src/Version.h
@@ -6,7 +6,8 @@
 // This is the version of map and savegame format, and all of the recorded data on the server
 #define VERSION_MAJOR 0
 #define MINIMUM_VERSION_MINOR 58
-#define VERSION_MINOR 98
+#define VERSION_MINOR 99
+// version 99 removes Maxima's zero-capacity swarm retirement and its saved state.
 // version 98 adds the standalone Maxima AI and its saved execution state,
 // and changes simulation results, so earlier clients and replays are refused.
 // version 91 saves the live RNG and routing state for deterministic continuation.

--- a/test/MaximaEconomyRegressionTest.cpp
+++ b/test/MaximaEconomyRegressionTest.cpp
@@ -477,26 +477,6 @@ void trackerLogicalCadence()
     }
 }
 
-void retirementRequiresHarvestRoute()
-{
-    Fixture f;
-    f.swarm(10,10); f.supply(10,10);
-    auto& ai=*f.ai; auto& c=ai.context; c.initialize();
-    ai.budget.swarm_retirement_enabled=true; ai.budget.desired_swarms=1;
-    ai.timer=1; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarm_since.empty());
-    f.game.map.setNoResource(16,11,1);
-    ai.timer=4000; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarm_since.count(0));
-    // Explicitly forbidden territory is not available productive capacity.
-    for(int y=0;y<64;++y) for(int x=0;x<64;++x)
-        f.game.map.addForbidden(x,y,f.player.team->teamNumber);
-    ai.update_swarm_retirement(c);
-    assert(ai.remote_swarm_since.count(0));
-    ai.timer=7000; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarms_ready.count(0));
-}
-
 void holidayHarvestCapacity()
 {
     Game game(NULL);
@@ -572,7 +552,6 @@ int main()
     crisisProductionPause();
     completionReallocatesColony();
     trackerLogicalCadence();
-    retirementRequiresHarvestRoute();
     holidayHarvestCapacity();
     std::cout<<"Maxima economy regression tests passed\n";
 }

--- a/test/MaximaImplementationIntegrationTest.cpp
+++ b/test/MaximaImplementationIntegrationTest.cpp
@@ -27,6 +27,7 @@
 #include "../src/AIMaxima.h"
 #include "../src/AIMaximaSwarmController.h"
 #undef private
+#include "../src/AIMaximaContinuation.h"
 #include "../src/building/Building.h"
 #include "../src/game/entities/BuildingType.h"
 #include "../src/building/IntBuildingType.h"
@@ -600,28 +601,6 @@ static void directorExecutionRegressions()
     ai.strategy.military.warrior_training_backlog_throttle_enabled=false;
     ai.build_policy_bids(); ai.arbitrate_policy_bids();
     assert(ai.budget.warrior_ratio>0);
-
-    // The only food lies ten tiles away across water, on a toroidal map.
-    for(int y=0;y<64;++y) for(int x=0;x<64;++x)
-        game.map.setMapDiscovered(x,y,player.team->me);
-    for(int y=0;y<64;++y) {
-        game.map.setTerrain(17,y,256); game.map.setTerrain(18,y,256);
-        game.map.setTerrain(40,y,256); game.map.setTerrain(41,y,256);
-    }
-    game.map.setResource(20,10,CORN,1);
-    ai.fertility_cache=AIMaxima::Farming::ExactFertilityCache();
-    ai.configure_development_planner();
-    ai.snapshot.swimming_workers=0; ai.finalize_director_plan(c);
-    ai.timer=100; ai.update_swarm_retirement(c);
-    ai.timer=3100; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarms_ready.count(0));
-    ai.snapshot.swimming_workers=20; ai.finalize_director_plan(c);
-    ai.update_swarm_retirement(c);
-    assert(ai.remote_swarms_ready.empty() && ai.remote_swarm_since.empty());
-    ai.snapshot.swimming_workers=0; ai.finalize_director_plan(c);
-    ai.timer=3200; ai.update_swarm_retirement(c);
-    ai.timer=6200; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarms_ready.count(0));
 }
 
 static void directorUpgradeRegressions()
@@ -753,33 +732,60 @@ static void economyStaffingRegressions()
         assert(ratio==(count<5 ? 3 : 0));
         c.managementOrders.clear();
     }
+}
 
-    // Two islands: the first swarm's corn requires crossing a water strip.
-    // Retirement evaluates discovered harvesting routes, not hidden terrain.
-    for(int y=0;y<64;++y) for(int x=0;x<64;++x)
-        game.map.setMapDiscovered(x,y,player.team->me);
-    for(int y=0;y<64;++y)
-    { game.map.getTile(0,y).terrain=256; game.map.getTile(16,y).terrain=256; }
-    // The retained swarm needs renewable fertility as well as existing corn.
-    game.map.getTile(36,31).terrain=256;
-    game.map.setResource(19,11,CORN,5); game.map.setResource(34,31,CORN,5);
-    // This fixture changes terrain after manage_swarm populated the cache.
-    ai.fertility_cache=AIMaxima::Farming::ExactFertilityCache();
-    ai.budget.swarm_retirement_enabled=true; ai.budget.desired_swarms=1;
-    ai.budget.recovery_active=false; ai.budget.can_swim=true; ai.can_swim=false;
-    ai.timer=1; ai.update_swarm_retirement(c);
-    ai.timer=3001; ai.update_swarm_retirement(c);
-    assert(ai.remote_swarms_ready.empty());
-    for(auto order:c.managementOrders)
-        assert(!dynamic_cast<Management::DestroyBuilding*>(order.get()));
-    // Losing swimming restores the usual probation and retirement behavior.
-    ai.budget.can_swim=false; ai.can_swim=true;
-    ai.timer=3002; ai.update_swarm_retirement(c);
-    ai.timer=6002; ai.update_swarm_retirement(c);
-    bool deleted=false;
-    for(auto order:c.managementOrders)
-        if(auto d=dynamic_cast<Management::DestroyBuilding*>(order.get())) deleted|=d->id==0;
-    assert(deleted);
+// Saves written before version 99 still carry the retired zero-capacity swarm
+// retirement records. Writing at that format reproduces the old layout, and the
+// loader's gate must consume those records so every later field stays aligned.
+static void legacySwarmRetirementSaveGateRegression()
+{
+    Game game(NULL); game.map.setSize(6,6,GRASS); game.map.setGame(&game);
+    game.addTeam(); game.teams[0]->race.loadDefault();
+    Player player; player.setTeam(game.teams[0]);
+    std::map<int,size_t> written;
+    for(int formatVersion:{98,VERSION_MINOR})
+    {
+        AIMaxima::Maxima source(&player);
+        source.budget.second_prestige_population_min=11;
+        source.food_burden_since[7]=1234;
+        source.food_retirement_issued.insert(9);
+        source.last_food_retirement_tick=4321;
+        source.food_supported_inns=3; source.food_supported_swarms=2;
+        source.food_ledger_valid=true;
+        source.last_farming_tick=777; source.development_cycle_pending=true;
+        auto* backend=new GAGCore::MemoryStreamBackend;
+        GAGCore::BinaryOutputStream output(backend);
+        AIMaximaContinuation::Writer writer(&output,formatVersion);
+        source.executionState(writer);
+        const std::string bytes(backend->getBuffer(),backend->getPosition());
+        written[formatVersion]=bytes.size();
+
+        AIMaxima::Maxima loaded(&player);
+        GAGCore::BinaryInputStream input(
+            new GAGCore::MemoryStreamBackend(bytes.data(),bytes.size()));
+        input.seekFromStart(0);
+        AIMaximaContinuation::Reader reader(&input,formatVersion);
+        loaded.executionState(reader);
+        assert(loaded.budget.second_prestige_population_min==11);
+        assert(loaded.food_burden_since==source.food_burden_since);
+        assert(loaded.food_retirement_issued==source.food_retirement_issued);
+        assert(loaded.last_food_retirement_tick==4321);
+        assert(loaded.food_supported_inns==3 && loaded.food_supported_swarms==2);
+        assert(loaded.food_ledger_valid);
+        assert(loaded.last_farming_tick==777 && loaded.development_cycle_pending);
+    }
+    // The old format is exactly the new one plus the four retired records.
+    auto* legacyBackend=new GAGCore::MemoryStreamBackend;
+    GAGCore::BinaryOutputStream legacyOutput(legacyBackend);
+    AIMaximaContinuation::Writer legacy(&legacyOutput,98);
+    const bool retiredSwitch=false;
+    const std::map<int,int> retiredSince;
+    const std::set<int> retiredSet;
+    legacy("budget.swarm_retirement_enabled",retiredSwitch);
+    legacy("remote_swarm_since",retiredSince);
+    legacy("remote_swarms_ready",retiredSet);
+    legacy("remote_swarm_deletion_issued",retiredSet);
+    assert(written[98]==written[VERSION_MINOR]+legacyBackend->getPosition());
 }
 
 static void innCompletionStaffingRegressions()
@@ -1419,6 +1425,7 @@ int main(int argc,char** argv)
     reviewBugRegressions();
     missionForceRegressions();
     economyStaffingRegressions();
+    legacySwarmRetirementSaveGateRegression();
     explorerSwarmStaffingRegressions();
     completedSwarmBudgetRegressions();
     economicResourceAccessRegressions();

--- a/test/MaximaLiteralManifest.json
+++ b/test/MaximaLiteralManifest.json
@@ -3,8 +3,8 @@
   "algorithm": "sorted-comment-string-stripped-numeric-token-sha256",
   "sources": {
     "src/AIMaxima.cpp": {
-      "tokens": 1714,
-      "sha256": "aa39150ada91adbeb2c7834667b6900fda283d78f353fb3425082e86cd282dcc",
+      "tokens": 1698,
+      "sha256": "31bd1e1dd24664fc4dd9156670dd759fd5b99ce7c463f3129306e14d4d96fe5c",
       "classifications": [
         "live selection authorization, swimming-builder counts, and shared reactive-defense reserve",
         "schema-backed strategy member use",

--- a/test/MaximaReconPolicyTest.py
+++ b/test/MaximaReconPolicyTest.py
@@ -58,7 +58,7 @@ class MaximaReconPolicyTest(unittest.TestCase):
 
     def test_save_version_and_legacy_recon_gates(self):
         version = (ROOT / "src/Version.h").read_text()
-        self.assertIn("#define VERSION_MINOR 98", version)
+        self.assertIn("#define VERSION_MINOR 99", version)
         loader = self.source[self.source.index("bool Maxima::loadDirector"):]
         loader = loader[:loader.index("bool Maxima::load(")]
         # The mission section is the one part of the director state that is

--- a/test/MaximaStrategyConfigTest.py
+++ b/test/MaximaStrategyConfigTest.py
@@ -140,7 +140,6 @@ class MaximaStrategyConfigTest(unittest.TestCase):
 
     def test_tactic_switches_default_on_and_accept_false(self) -> None:
         expected = {
-            "economy.swarm_retirement_enabled",
             "economy.large_economy_adaptation_enabled",
             "economy.amphibious_network_maintenance_enabled",
             "economy.food_service_safeguards_enabled",

--- a/test/MaximaStrategyPolicyTest.py
+++ b/test/MaximaStrategyPolicyTest.py
@@ -48,7 +48,7 @@ class MaximaStrategyPolicyTest(unittest.TestCase):
 
     def test_current_save_omits_configuration_plans_and_phases(self) -> None:
         version = (ROOT / "src/Version.h").read_text()
-        self.assertIn("#define VERSION_MINOR 98", version)
+        self.assertIn("#define VERSION_MINOR 99", version)
         # The relentless offense changes simulation results, so an older client
         # must be refused rather than allowed to desync, and the trimmed Maxima
         # mission state needs its own load gate.
@@ -154,7 +154,7 @@ class MaximaStrategyPolicyTest(unittest.TestCase):
         ]
         # 689 with the gated tactical layer; the relentless offense removed 50
         # muster, casualty, relief and teamplay keys and added three.
-        self.assertEqual(644, len(specifications))
+        self.assertEqual(643, len(specifications))
         self.assertTrue(all(len(impact) == 1 for impact in impacts))
         self.assertEqual(
             {"Critical", "High", "Medium", "Low"},


### PR DESCRIPTION
## Intended result

The food ledger has judged inns and swarms by protected farm coverage since it landed; the older rule that retired only swarms with no reachable farm capacity survived behind `food.enabled=false` as a fallback nobody exercises. It had no inn equivalent and could not tell an under-supplied building from a well-sited one, and the upcoming relocation work builds on the ledger's route-distance quality instead.

This removes the rule, its probation state, the `economy.swarm_retirement_enabled` switch and the swarm-target deduction that depended on it. With the ledger disabled nothing is retired now; `doc/MaximaFoodLedger.md` says so. `nearby_farm_capacity` stays: it still feeds `observed.accessible_corn` for the director's sustainable inn count and the swarm controller.

## Compatibility

- **Saves:** version 98 → 99. The four retired records were positional in the continuation archive, so loading reads and discards them for formats before 99 (`MINIMUM_VERSION_MINOR` unchanged).
- **Replays / network:** refused against older builds by the version bump, as with every Maxima order change.
- **Feel:** none expected. The legacy path only ran with `food.enabled=false`, which the shipped strategy does not use.

## Verification

- `scons` build; all 15 native Maxima regression programs and 76 Python tests pass (`python3 test/run_maxima_implementation_regressions.py --build-dir build`, `python3 -m unittest discover -s test -p 'Maxima*Test.py'`).
- New `legacySwarmRetirementSaveGateRegression` writes execution state at format 98 and at the current format, loads both, and asserts the 98 stream is exactly the 99 stream plus the four retired records.
- Literal manifest regenerated for the removed probation constant and the new version gate; parameter-count pin moves 644 → 643.

## Limits

No captured version-98 save was available, so the load-gate evidence is the synthetic 98-format round trip above rather than a real save file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfax2ecD9Y3vnLhocZFYxp
