### PR TITLE
Measure Maxima's carrier cost per harvesting tile from real round trips

### DIFF
--- a/doc/MaximaFoodLedger.md
+++ b/doc/MaximaFoodLedger.md
@@ -162,3 +162,60 @@ land.
 outranking age, inn/swarm interleaving, claim release on removal, the upgrade
 check, the soundness of the summed-area bound, blocked ground, the supply
 radius, and the engine-derived rates.
+
+## Carrier cost calibration
+
+Relocating an inn or swarm is worth its rebuild only if the carriers it saves
+repay the cost, so distance has to be priced in worker-ticks. Rather than derive
+that from unit speed tables, the engine times real round trips: when a carrier
+leaves a building after a delivery it stamps `Unit::fetchStartTick`, remembers
+the cell it harvests, and on the next delivery `Building::recordDeliveryTrip`
+adds the trip's ticks and its wrap-safe Chebyshev distance from the harvested
+cell to the footprint edge. Those counters are diagnostics only: never saved,
+never checksummed, and read solely by Maxima's `food_delivery` telemetry, which
+publishes them cumulatively on every building pass next to the ledger's
+per-building `food_consumer` quality.
+
+`tools/calibrate_maxima_carrier_cost.py` joins the two streams per building and
+fits the windows between ledger samples:
+
+```bash
+build/src/glob2 -test-games-nox 2 --map Garden_3 \
+    --matchup maxima,maxima,maxima,maxima -maxima-telemetry > garden3.log
+python3 tools/calibrate_maxima_carrier_cost.py garden3.log triangle.log ...
+```
+
+Seven all-Maxima headless games (Garden 3 x2, Triangle x2, balanced_for_2 x2,
+Isles), 19 896 timed round trips in 1 663 windows, measured on 2026-09-12:
+
+| Fit | Intercept | Slope | Weighted R^2 |
+| --- | --- | --- | --- |
+| trip ticks vs harvest tiles, all | 105 | 46.2 per tile | 0.66 |
+| trip ticks vs harvest tiles, inns | 42 | 44.9 per tile | 0.72 |
+| trip ticks vs harvest tiles, swarms | 107 | 51.4 per tile | 0.55 |
+
+The binned medians rise monotonically from ~95 ticks at 0-2 tiles to ~860 at
+14-16, so the line is not an artefact of outliers. That gives
+**`carrier_ticks_per_tile` = 23** (half the round-trip slope) and
+**`carrier_fixed_ticks_per_trip` = 105** (42 for inns; a busy swarm's carriers
+queue at the door). Median carrier utilisation was 0.76, so idle time is not
+inflating the trips.
+
+The same data tests the proxy the relocation policy prices with. Ledger
+`quality` is the route distance to the *protected* wheat that would cover full
+demand, and carriers do not harvest protected cells; they harvest whatever the
+gradient finds nearest, mostly the spread around the farms.
+
+| Kind | harvest tiles vs quality tiles | Weighted R^2 | Median harvest tiles by quality band |
+| --- | --- | --- | --- |
+| inn | 1.9 + 1.55 x | 0.12 | 5.3 (0-2), 8.0 (2-4), 9.9 (4-6), 12.2 (6-8), 14.8 (8-10) |
+| swarm | 6.6 + 0.02 x | 0.00 | 5.5 (2-4), 7.4 (4-6), 6.6 (6-8), 5.4 (8-10), 8.5 (10-12) |
+
+For inns quality is a usable proxy: each tile of quality is about 1.5 tiles of
+real walking, monotonically. For swarms it predicts nothing. A swarm's twenty-odd
+carriers strip the nearby spread and walk 5-8 tiles wherever the protected
+stacks are, so moving a swarm closer to protected wheat does not shorten its
+trips; what a swarm gains from a better site is *coverage*, i.e. enough supply
+to keep those carriers delivering at all. The relocation policy therefore
+realises distance savings per kind (`food.relocation_distance_realisation_percent`,
+155 for inns, 0 for swarms) and prices coverage shortfall separately.

--- a/src/AIMaxima.cpp
+++ b/src/AIMaxima.cpp
@@ -5684,6 +5684,21 @@ void Maxima::update_food_retirement(Context& echo,
 			<<"\tsupported_swarms="<<food_supported_swarms
 			<<"\tburdened="<<food_burden_since.size();
 		emit_telemetry(echo,"food_ledger",fields.str());
+		for(size_t i=0;i<ledger.consumers.size();++i)
+		{
+			const AIMaximaFoodLedger::ConsumerResult& value=ledger.consumers[i];
+			std::ostringstream consumer;
+			consumer<<"\tkey="<<value.key
+				<<"\tkind="<<(value.kind==AIMaximaFoodLedger::InnConsumer?"inn":"swarm")
+				<<"\tcolony="<<(value.colony?1:0)
+				<<"\tretirable="<<(value.retirable?1:0)
+				<<"\tdemand="<<value.demand<<"\tclaimed="<<value.claimed
+				<<"\tavailable="<<value.available
+				<<"\tcoverage="<<value.coveragePercent
+				<<"\tquality="<<value.quality<<"\tquality_band="<<value.qualityBand
+				<<"\torder="<<value.order;
+			emit_telemetry(echo,"food_consumer",consumer.str());
+		}
 	}
 
 	if(!budget.food_retirement_enabled)return;
@@ -5838,6 +5853,29 @@ int Maxima::staff_building(Context& echo, int id)
 			<<"\tfill_average="<<state.cornAverage
 			<<"\tenrolled_average="<<state.enrolledAverage;
 		emit_telemetry(echo,"staffing_control",fields.str());
+	}
+	// Calibration sample: deliveries are cumulative, so the analysis can diff
+	// them over any window without the AI holding state that is not saved.
+	if(globalContainer && globalContainer->maximaTelemetry)
+	{
+		long long deliveries=0;
+		for(int resource=0; resource<MAX_NB_RESOURCES; ++resource)
+			deliveries+=building->resourceDeliveries[resource];
+		std::ostringstream fields;
+		fields<<"\tbuilding_id="<<id
+			<<"\tkind="<<(building->type->shortTypeNum==IntBuildingType::SWARM_BUILDING
+				? "swarm" : "inn")
+			<<"\tlevel="<<building->type->level
+			<<"\tenrolled="<<echo.get_building_register().get_enrolled(id)
+			<<"\tassigned="<<request
+			<<"\tcorn="<<building->resources[CORN]
+			<<"\tcapacity="<<building->type->maxResource[CORN]
+			<<"\tcorn_deliveries="<<building->resourceDeliveries[CORN]
+			<<"\tdeliveries="<<deliveries
+			<<"\ttrip_samples="<<building->deliveryTripSamples
+			<<"\ttrip_ticks="<<building->deliveryTripTicks
+			<<"\ttrip_tiles="<<building->deliveryTripTiles;
+		emit_telemetry(echo,"food_delivery",fields.str());
 	}
 	return request;
 }

--- a/src/building/Building.h
+++ b/src/building/Building.h
@@ -560,6 +560,18 @@ public:
 	/// will be changed to point to the global resources Team::teamResources instead of localResources.
 	Sint32* resources;
 	Sint32 wishedResources[MAX_NB_RESOURCES];
+	/// Diagnostics only: unit deliveries of each resource since this building
+	/// was created, loaded or started construction. Never saved or checksummed,
+	/// so it cannot affect the simulation; Maxima's telemetry reads it to
+	/// calibrate carrier cost against harvesting distance.
+	Sint32 resourceDeliveries[MAX_NB_RESOURCES];
+	/// Diagnostics only, like resourceDeliveries: round trips that started at
+	/// this building, their total duration in ticks and their total harvesting
+	/// distance in tiles from the harvested cell to the footprint edge.
+	Sint32 deliveryTripSamples;
+	Sint32 deliveryTripTicks;
+	Sint32 deliveryTripTiles;
+	void recordDeliveryTrip(Sint32 ticks, int harvestX, int harvestY);
 
 	// quality parameters
 	Sint32 hp; // (Uint16)

--- a/src/building/Construction.cpp
+++ b/src/building/Construction.cpp
@@ -219,6 +219,9 @@ void Building::cancelConstruction(Sint32 unitWorking)
 		hp=type->hpInit;
 
 	productionTimeout=type->unitProductionTime;
+	for (int i=0; i<MAX_NB_RESOURCES; i++)
+		resourceDeliveries[i]=0;
+	deliveryTripSamples=deliveryTripTicks=deliveryTripTiles=0;
 
 	if (type->unitProductionTime)
 		owner->swarms.push_back(this);

--- a/src/building/Lifecycle.cpp
+++ b/src/building/Lifecycle.cpp
@@ -97,7 +97,11 @@ Building::Building(int x, int y, Uint16 gid, Sint32 typeNum, Team *team, Buildin
 
 	// building specific :
 	for(int i=0; i<MAX_NB_RESOURCES; i++)
+	{
 		localResource[i]=0;
+		resourceDeliveries[i]=0;
+	}
+	deliveryTripSamples=deliveryTripTicks=deliveryTripTiles=0;
 	updateResourcesPointer();
 
 	// quality parameters
@@ -279,7 +283,9 @@ void Building::load(GAGCore::InputStream *stream, BuildingsTypes *types, Team *o
 		std::ostringstream oss;
 		oss << "localRessource[" << i << "]";
 		localResource[i] = stream->readSint32(oss.str().c_str());
+		resourceDeliveries[i] = 0;
 	}
+	deliveryTripSamples=deliveryTripTicks=deliveryTripTiles=0;
 
 	// quality parameters
 	hp = stream->readSint32("hp");

--- a/src/building/Misc.cpp
+++ b/src/building/Misc.cpp
@@ -190,8 +190,28 @@ void Building::updateResourcesPointer()
 
 
 
+void Building::recordDeliveryTrip(Sint32 ticks, int harvestX, int harvestY)
+{
+	// Wrap-safe Chebyshev distance from the harvested cell to the footprint.
+	const int w=owner->map->getW();
+	const int h=owner->map->getH();
+	const auto axisGap=[](int cell, int origin, int size, int extent)
+	{
+		const int offset=((cell-origin)%extent+extent)%extent;
+		if (offset<size)
+			return 0;
+		return std::min(offset-size+1, extent-offset);
+	};
+	const int gapX=axisGap(harvestX, posX, type->width, w);
+	const int gapY=axisGap(harvestY, posY, type->height, h);
+	deliveryTripSamples+=1;
+	deliveryTripTicks+=std::max<Sint32>(0, ticks);
+	deliveryTripTiles+=std::max(gapX, gapY);
+}
+
 void Building::addResourceIntoBuilding(int resourceType)
 {
+	resourceDeliveries[resourceType]+=1;
 	resources[resourceType]+=type->multiplierResource[resourceType];
 	//You can not exceed the maximum amount
 	resources[resourceType] = std::min(resources[resourceType], type->maxResource[resourceType]);

--- a/src/unit/Unit.cpp
+++ b/src/unit/Unit.cpp
@@ -109,6 +109,8 @@ void Unit::init(int x, int y, Uint16 gid, Sint32 typeNum, Team *team, int level)
 	destinationPurpose=UNIT_DEST_PURPOSE_NONE;
 	carriedResource=UNIT_CARRIED_RESOURCE_NONE;
 	jobTimer = 0;
+	fetchStartTick = -1;
+	harvestX = harvestY = -1;
 
 	previousClearingArea=std::nullopt;
 	previousClearingAreaDistance=0;
@@ -204,6 +206,7 @@ void Unit::subscriptionSuccess(Building* building, bool inside)
 					else
 					{
 						displacement=DIS_GOING_TO_RESOURCE;
+						fetchStartTick=-1;
 						targetBuilding=NULL;
 						owner->map->resourceAvailableUpdate(owner->teamNumber, destinationPurpose, swimClass(), posX, posY, &targetX, &targetY, NULL);
 						validTarget=true;

--- a/src/unit/Unit.h
+++ b/src/unit/Unit.h
@@ -275,6 +275,13 @@ public:
 	/// This counts 32 ticks to wait for a job before a unit goes off
 	/// to upgrade or heal when it is otherwise doing nothing.
 	Sint32 jobTimer;
+	/// Diagnostics only, never saved or checksummed: the tick this unit left
+	/// its building to fetch a resource, and the cell it harvested. The
+	/// delivery records them on the building so Maxima can calibrate carrier
+	/// cost per tile of harvesting distance.
+	Sint32 fetchStartTick;
+	Sint32 harvestX;
+	Sint32 harvestY;
 	
 	// gui
 	int levelUpAnimation;

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -54,6 +54,8 @@ void Unit::handleDisplacement(void)
 			{
 				// we got the resource.
 				carriedResource=destinationPurpose;
+				harvestX=posX+dx;
+				harvestY=posY+dy;
 				owner->map->decResource(posX+dx, posY+dy, carriedResource);
 				assert(movement == MOV_HARVESTING);
 				movement = MOV_RANDOM_GROUND; // we do this to avoid the handleMovement() to additionally decResource() the same resource.
@@ -124,6 +126,12 @@ void Unit::handleDisplacement(void)
 				{
 					if (verbose)
 						printf("guid=(%d) Giving resource (%d) to building gbid=(%d) old-amount=(%d)\n", gid, destinationPurpose, targetBuilding->gid, targetBuilding->resources[carriedResource]);
+					// Record before the delivery: completing a construction site
+					// inside addResourceIntoBuilding can detach this unit.
+					if (fetchStartTick>=0 && harvestX>=0 && owner->game)
+						targetBuilding->recordDeliveryTrip(
+							Sint32(owner->game->stepCounter)-fetchStartTick, harvestX, harvestY);
+					fetchStartTick=-1;
 					targetBuilding->addResourceIntoBuilding(carriedResource);
 					carriedResource=UNIT_CARRIED_RESOURCE_NONE;
 				}
@@ -221,6 +229,7 @@ void Unit::handleDisplacement(void)
 								else
 								{
 									int dummyDist;
+									fetchStartTick = owner->game ? Sint32(owner->game->stepCounter) : -1;
 									if (auto off = owner->map->doesUnitTouchResource(this, destinationPurpose))
 									{
 										dx = off->dx;

--- a/test/MaximaEconomyRegressionTest.cpp
+++ b/test/MaximaEconomyRegressionTest.cpp
@@ -477,6 +477,28 @@ void trackerLogicalCadence()
     }
 }
 
+// The engine's delivery diagnostics measure each round trip from the harvested
+// cell to the building's footprint edge, wrap-safe, and start at zero.
+void deliveryTripRecordsFootprintDistance()
+{
+    Fixture f;
+    Building* b=f.swarm(10,10);
+    assert(b->deliveryTripSamples==0 && b->deliveryTripTicks==0 && b->deliveryTripTiles==0);
+    const int w=b->type->width, h=b->type->height;
+    b->recordDeliveryTrip(100, b->posX, b->posY);            // inside: 0 tiles
+    b->recordDeliveryTrip(100, b->posX+w-1, b->posY+h-1);    // far corner: 0 tiles
+    assert(b->deliveryTripSamples==2 && b->deliveryTripTicks==200 && b->deliveryTripTiles==0);
+    b->recordDeliveryTrip(50, b->posX-1, b->posY+1);         // adjacent west: 1
+    b->recordDeliveryTrip(50, b->posX+w+2, b->posY);         // three east: 3
+    b->recordDeliveryTrip(50, b->posX+1, b->posY+h+4);       // five south: 5
+    assert(b->deliveryTripSamples==5 && b->deliveryTripTicks==350 && b->deliveryTripTiles==9);
+    // Wrapping around the map edge is the short way round, and a clock that
+    // ran backwards cannot subtract time.
+    const int mapW=f.game.map.getW();
+    b->recordDeliveryTrip(-7, (b->posX-2+mapW)%mapW, b->posY);
+    assert(b->deliveryTripSamples==6 && b->deliveryTripTicks==350 && b->deliveryTripTiles==11);
+}
+
 void holidayHarvestCapacity()
 {
     Game game(NULL);
@@ -553,5 +575,6 @@ int main()
     completionReallocatesColony();
     trackerLogicalCadence();
     holidayHarvestCapacity();
+    deliveryTripRecordsFootprintDistance();
     std::cout<<"Maxima economy regression tests passed\n";
 }

--- a/test/MaximaLiteralManifest.json
+++ b/test/MaximaLiteralManifest.json
@@ -3,8 +3,8 @@
   "algorithm": "sorted-comment-string-stripped-numeric-token-sha256",
   "sources": {
     "src/AIMaxima.cpp": {
-      "tokens": 1698,
-      "sha256": "31bd1e1dd24664fc4dd9156670dd759fd5b99ce7c463f3129306e14d4d96fe5c",
+      "tokens": 1705,
+      "sha256": "d8de80172ae4231a43e0b98804b95b4cbc2742390ac33e7f4361e667c7dba317",
       "classifications": [
         "live selection authorization, swimming-builder counts, and shared reactive-defense reserve",
         "schema-backed strategy member use",

--- a/tools/calibrate_maxima_carrier_cost.py
+++ b/tools/calibrate_maxima_carrier_cost.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Fit Maxima's carrier cost per harvesting tile from headless telemetry.
+
+Maxima's relocation policy prices distance in worker-ticks: each unit of wheat
+an inn or swarm consumes costs one carrier round trip, and the trip takes
+`carrier_fixed_ticks_per_trip + 2 * distance * carrier_ticks_per_tile`. Neither
+constant is derived from unit speed tables; both are measured here, the way
+`food.ticks_per_meal` was.
+
+Generate a log with the game itself, from a tree built in place:
+
+    build/src/glob2 -test-games-nox 1 --map Garden_3 \\
+        --matchup maxima,maxima,maxima,maxima -maxima-telemetry > garden3.log
+
+The engine times every round trip that starts at a building: the tick a carrier
+leaves after a delivery, the cell it harvests, and the tick it delivers again
+(`Unit::fetchStartTick`, `Building::recordDeliveryTrip`). Maxima's
+`food_delivery` telemetry publishes the building's cumulative trip count, trip
+ticks and trip tiles on every building pass; `food_consumer` publishes the food
+ledger's `quality` for the same building every ~1000 ticks, the supply-weighted
+mean route distance in hundredths of a tile that the relocation policy will use.
+
+Each window between consecutive `food_consumer` samples yields the mean trip
+duration and the mean harvesting distance of the trips completed inside it.
+Two weighted least-squares lines are reported:
+
+- trip ticks against actual harvesting tiles: the slope is the round-trip cost
+  per tile (`carrier_ticks_per_tile` is half of it), the intercept the fixed
+  cost of harvesting and delivering (`carrier_fixed_ticks_per_trip`);
+- actual harvesting tiles against ledger quality: how much of a change in the
+  policy's proxy is realised as a change in the distance carriers walk. Its
+  slope is the default for `food.relocation_distance_realisation_percent`.
+"""
+import argparse
+import csv
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def parse_log(path):
+    """Yield (tick, team, event, fields) for every Maxima telemetry line."""
+    with open(path, "rt", errors="replace") as handle:
+        for line in handle:
+            if not line.startswith("MAXIMA_TELEMETRY\t"):
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 4:
+                continue
+            fields = {}
+            for item in parts[4:]:
+                key, _, value = item.partition("=")
+                fields[key] = value
+            try:
+                yield int(parts[1]), int(parts[2]), parts[3], fields
+            except ValueError:
+                continue
+
+
+def collect_windows(paths, min_coverage, min_trips):
+    passes = defaultdict(list)     # (game, team, id) -> delivery samples
+    consumers = defaultdict(list)  # (game, team, id) -> ledger samples
+    for game, path in enumerate(paths):
+        for tick, team, event, f in parse_log(path):
+            try:
+                if event == "food_delivery":
+                    passes[(game, team, int(f["building_id"]))].append((
+                        tick, int(f["trip_samples"]), int(f["trip_ticks"]),
+                        int(f["trip_tiles"]), int(f["enrolled"]),
+                        int(f["level"]), f["kind"]))
+                elif event == "food_consumer" and int(f["key"]) >= 0:
+                    consumers[(game, team, int(f["key"]))].append((
+                        tick, int(f["quality"]), int(f["coverage"]), f["kind"]))
+            except (KeyError, ValueError):
+                continue
+
+    windows = []
+    for key, samples in consumers.items():
+        samples.sort()
+        building_passes = sorted(passes.get(key, ()))
+        if len(building_passes) < 2:
+            continue
+        for start, end in zip(samples, samples[1:]):
+            t0, quality, coverage, kind = start
+            t1 = end[0]
+            inside = [p for p in building_passes if t0 <= p[0] <= t1]
+            if len(inside) < 2 or inside[0][5] != inside[-1][5]:
+                continue  # too few passes, or an upgrade completed inside
+            trips = inside[-1][1] - inside[0][1]
+            ticks = inside[-1][2] - inside[0][2]
+            tiles = inside[-1][3] - inside[0][3]
+            span = inside[-1][0] - inside[0][0]
+            if trips < min_trips or span <= 0 or coverage < min_coverage:
+                continue
+            enrolled_area = sum(a[4] * (b[0] - a[0]) for a, b in zip(inside, inside[1:]))
+            windows.append({
+                "game": key[0], "team": key[1], "building": key[2], "kind": kind,
+                "level": inside[0][5], "tick": t0, "span": span,
+                "quality_tiles": quality / 100.0, "coverage": coverage,
+                "trips": trips, "trip_ticks": ticks / trips, "trip_tiles": tiles / trips,
+                "enrolled": enrolled_area / span,
+                # Share of enrolled carrier time spent on timed round trips.
+                "utilisation": ticks / enrolled_area if enrolled_area > 0 else float("nan"),
+            })
+    return windows
+
+
+def weighted_fit(points):
+    """Weighted least squares of y on x. Points are (x, y, weight)."""
+    sw = sum(w for _, _, w in points)
+    if sw <= 0 or len(points) < 3:
+        return None
+    mx = sum(w * x for x, _, w in points) / sw
+    my = sum(w * y for _, y, w in points) / sw
+    sxx = sum(w * (x - mx) ** 2 for x, _, w in points)
+    sxy = sum(w * (x - mx) * (y - my) for x, y, w in points)
+    if sxx <= 0:
+        return None
+    slope = sxy / sxx
+    intercept = my - slope * mx
+    ss_tot = sum(w * (y - my) ** 2 for _, y, w in points)
+    ss_res = sum(w * (y - intercept - slope * x) ** 2 for x, y, w in points)
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return intercept, slope, r2, mx
+
+
+def binned_medians(windows, x_key, out):
+    bins = defaultdict(list)
+    for w in windows:
+        bins[int(w[x_key] // 2) * 2].append(w["trip_ticks"])
+    for low in sorted(bins):
+        values = bins[low]
+        print(f"     {low:>3}-{low + 2:<3} tiles  median {statistics.median(values):7.1f} ticks"
+              f"  ({len(values)} windows)", file=out)
+
+
+def report(label, windows, out):
+    trips = sum(w["trips"] for w in windows)
+    print(f"== {label}: {len(windows)} windows, {trips} round trips", file=out)
+    actual = weighted_fit([(w["trip_tiles"], w["trip_ticks"], w["trips"]) for w in windows])
+    if actual:
+        intercept, slope, r2, mean_x = actual
+        print(f"   trip_ticks = {intercept:.1f} + {slope:.2f} * harvest_tiles"
+              f"   (weighted R^2 {r2:.3f}, mean {mean_x:.1f} tiles)", file=out)
+        print(f"   -> carrier_fixed_ticks_per_trip ~ {intercept:.0f}, "
+              f"carrier_ticks_per_tile ~ {slope / 2:.1f} (half the round-trip slope)", file=out)
+        binned_medians(windows, "trip_tiles", out)
+    else:
+        print("   not enough spread in harvesting distance to fit", file=out)
+    proxy = weighted_fit([(w["quality_tiles"], w["trip_tiles"], w["trips"]) for w in windows])
+    if proxy:
+        intercept, slope, r2, mean_x = proxy
+        print(f"   harvest_tiles = {intercept:.2f} + {slope:.2f} * ledger_quality_tiles"
+              f"   (weighted R^2 {r2:.3f}, mean quality {mean_x:.1f} tiles)", file=out)
+        print(f"   -> relocation_distance_realisation_percent ~ {100 * slope:.0f}", file=out)
+        bins = defaultdict(list)
+        for w in windows:
+            bins[int(w["quality_tiles"] // 2) * 2].append(w["trip_tiles"])
+        for low in sorted(bins):
+            values = bins[low]
+            print(f"     quality {low:>3}-{low + 2:<3}  median harvest {statistics.median(values):5.1f} tiles"
+                  f"  ({len(values)} windows)", file=out)
+    utilisation = [w["utilisation"] for w in windows if w["utilisation"] == w["utilisation"]]
+    if utilisation:
+        print(f"   median carrier utilisation {statistics.median(utilisation):.2f}", file=out)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--min-coverage", type=int, default=0,
+                        help="drop windows whose ledger coverage is below this percent")
+    parser.add_argument("--min-trips", type=int, default=3,
+                        help="drop windows with fewer completed round trips")
+    parser.add_argument("--csv", type=Path, help="write every retained window here")
+    args = parser.parse_args()
+    windows = collect_windows(args.logs, args.min_coverage, args.min_trips)
+    if not windows:
+        print("no usable windows: was the game run with -maxima-telemetry?", file=sys.stderr)
+        return 1
+    report("all buildings", windows, sys.stdout)
+    for kind in ("inn", "swarm"):
+        subset = [w for w in windows if w["kind"] == kind]
+        if subset:
+            report(kind, subset, sys.stdout)
+    if args.csv:
+        with open(args.csv, "w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(windows[0]))
+            writer.writeheader()
+            writer.writerows(windows)
+        print(f"wrote {len(windows)} windows to {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #267. Phase 2 of the inn/swarm relocation work: calibrate how much a tile of harvesting distance costs in worker-ticks before the relocation policy prices it.

## Intended result

- The engine times real carrier round trips (leave building after a delivery → harvest cell → next delivery) and accumulates ticks and wrap-safe footprint-edge distance per building (`Unit::fetchStartTick`, `Building::recordDeliveryTrip`). Diagnostics only: never saved or checksummed, read only by Maxima's telemetry.
- Maxima publishes the counters in a `food_delivery` event every building pass and the food ledger's per-building quality/coverage in a `food_consumer` event, so they can be joined offline.
- `tools/calibrate_maxima_carrier_cost.py` does the join and fits the windows between ledger samples. Method, commands and numbers are recorded in `doc/MaximaFoodLedger.md` ("Carrier cost calibration").

## Results (7 all-Maxima headless games, 19 896 timed round trips)

| Fit | Intercept | Slope | Weighted R² |
|---|---|---|---|
| trip ticks vs harvest tiles, all | 105 | 46.2 / tile | 0.66 |
| inns | 42 | 44.9 / tile | 0.72 |
| swarms | 107 | 51.4 / tile | 0.55 |

→ `carrier_ticks_per_tile` = 23, `carrier_fixed_ticks_per_trip` = 105. Binned medians rise monotonically from ~95 ticks (0–2 tiles) to ~860 (14–16).

The same data shows the ledger's `quality` tracks real harvesting distance for inns (1.55 real tiles per quality tile, monotonic) but not for swarms (slope 0.02): swarm carriers strip the nearby spread and walk 5–8 tiles wherever the protected stacks sit. The relocation policy will realise distance savings per kind and price swarm coverage separately.

## Compatibility / feel

No simulation change: the new counters are outside save, checksum and every decision path. Telemetry lines only appear with `-maxima-telemetry`. Save version unchanged (99, from #267).

## Verification

- `scons` build; all 15 native Maxima regression programs and 76 Python tests pass. New `deliveryTripRecordsFootprintDistance` checks the wrap-safe footprint distance and the non-negative clamp.
- The first attempt crashed at ~tick 3950: `addResourceIntoBuilding` can complete a construction site and detach the unit, nulling `targetBuilding`; the trip is now recorded before the delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfax2ecD9Y3vnLhocZFYxp
