### PR TITLE
Discussion: cap wheat fetchers at what the map has left, to stop crowds on one tile

### DIFF
--- a/docs/headless-replays.md
+++ b/docs/headless-replays.md
@@ -171,6 +171,41 @@ GLOB2_GAME_END ticks=2483 winner_team=1 seed=1777219846 map="Playground" orders=
 The format is intended for grep/regex consumption — fields are
 space-separated key=value, with `map` quoted.
 
+## Resource-Fetch Metrics
+
+`GLOB2_HARVEST_METRICS=1` counts how workers fetch map resources and prints,
+next to the summary line, one line per team and resource that saw any activity,
+plus one per team about idle workers and wheat demand. `GLOB2_HARVEST_METRICS_EVERY=N`
+also prints the cumulative lines every `N` ticks, so a game that ends early can
+still be compared over a window. The hooks only read game state
+(`src/HarvestMetrics.h`), so the final checksum is the same with the metrics
+on or off.
+
+```
+GLOB2_HARVEST tick=30000 team=1 res=CORN commits=3175 harvests=2230 deliveries=2129 steps=17924 reversals=776 retargets=... lost=1051 ghosts=... abandoned=7 trips=2230 tripTicks=355134 goingTicks=345784 doomedTicks=155966 maxCrowd=16
+GLOB2_IDLE tick=30000 team=1 ticks=... idleWorkerTicks=... demandTicks=... idleWhenDemandTicks=... boundTicks=... idleWhenBoundTicks=... supplySum=... fetcherSum=... wantedSum=...
+```
+
+- `commits`, `harvests`, `deliveries` — fetches started, resources taken from
+  the map, resources put into a building
+- `steps`, `reversals`, `retargets` — steps walked towards a resource, steps
+  turning more than 90° from the previous one, steps after which the gradient
+  destination moved
+- `lost` — the gradient offered no step and the unit stepped at random;
+  `ghosts` are the ones standing on a tile the gradient still takes for the
+  resource (a field not yet rebuilt). `abandoned` — the unit gave up the job
+- `trips`, `tripTicks` — fetches that reached a harvest, and ticks from start to harvest
+- `goingTicks`, `doomedTicks`, `maxCrowd` — unit-ticks heading to a resource;
+  of those, the ones heading to a tile already outnumbered by the units heading
+  there; the most units ever heading to one tile
+- `GLOB2_IDLE` — per tick, summed: free workers without a job, whether a
+  building wanted wheat, and (for `GLOB2_PROTO_SUPPLY_CAP`) whether as many
+  wheat fetchers were out as the swim class 0 field counted wheat
+
+`GLOB2_SAVE_AT_END=<path>` writes the game reached at the `--nox` step limit
+with `GameGUI::save()`, so a moment of a headless game can be opened later from
+the GUI's Load Game menu (put the file in the profile's `games/` directory).
+
 For cross-codebase testing, the canonical baselines live in `glob2/tests/baselines/`. See [`docs/replay-verification.md`](../../docs/replay-verification.md) at the workspace root for the full verification workflows and the regeneration procedure.
 
 The `ReplayWriter` records live during gameplay:

--- a/src/EngineRun.cpp
+++ b/src/EngineRun.cpp
@@ -5,6 +5,7 @@
 
 #include "AINames.h"
 #include "ChecksumSidecar.h"
+#include "HarvestMetrics.h"
 #include "DatasetWriter.h"
 #include "Engine.h"
 #include "EngineTiming.h"
@@ -272,6 +273,7 @@ void Engine::printAutomaticEndingSummary()
 	int seconds = (time / GAME_TICKS_PER_SECOND) % 60;
 	int minutes = (time / GAME_TICKS_PER_SECOND) / 60;
 	std::cout << "automaticEndingGame ended: " << time << " ticks, " << minutes << " minutes, " << seconds << " seconds" << std::endl;
+	HarvestMetrics::report(gui.game);
 
 	// Machine-parseable summary line for the AI-trainer pipeline (and any
 	// external driver scraping headless output). One line, key=value pairs,
@@ -537,6 +539,9 @@ void Engine::runOneGameSession(bool& doRunOnceAgain)
 				gui.isRunning = false;
 				automaticGameEndTick = SDL_GetTicks64();
 				printf("nox::gui.game.checkSum() = %08x\n", gui.game.checkSum());
+				// PROTOTYPE: keep the state reached, to open it later in the GUI.
+				if (const char* savePath = getenv("GLOB2_SAVE_AT_END"))
+					saveInitialGameStateOrExit(savePath, "GLOB2_SAVE_AT_END", gui.game.mapHeader.getMapName());
 			}
 		}
 

--- a/src/Game_sync.cpp
+++ b/src/Game_sync.cpp
@@ -3,6 +3,7 @@
 
 
 #include "AICastor.h"
+#include "HarvestMetrics.h"
 
 #include <assert.h>
 #include <string.h>
@@ -180,6 +181,7 @@ void Game::syncStep(Sint32 localTeam)
 
 		Uint64 endTick=SDL_GetTicks64();
 		ticksGameSum[stepCounter&(TICK_PROFILE_BUF_LEN-1)]+=static_cast<Sint64>(endTick) - static_cast<Sint64>(startTick);
+		HarvestMetrics::sample(*this);
 		stepCounter++;
 	}
 }

--- a/src/HarvestMetrics.cpp
+++ b/src/HarvestMetrics.cpp
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "HarvestMetrics.h"
+
+#include "Game.h"
+#include "GlobalContainer.h"
+#include "Ressource.h"
+#include "RessourceType.h"
+#include "Team.h"
+#include "Unit.h"
+#include "Building.h"
+#include "BuildingType.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <unordered_map>
+
+namespace
+{
+	const char *const kResourceNames[MAX_RESOURCES] = {
+		"WOOD", "CORN", "PAPYRUS", "STONE", "ALGA", "CHERRY", "ORANGE", "PRUNE"
+	};
+
+	struct Counters
+	{
+		Uint64 commits = 0;     // fetches started
+		Uint64 harvests = 0;    // resources taken from the map
+		Uint64 deliveries = 0;  // resources put into a building
+		Uint64 steps = 0;       // steps walked towards a resource
+		Uint64 reversals = 0;   // steps turning more than 90 degrees from the previous one
+		Uint64 retargets = 0;   // steps after which the gradient destination moved
+		Uint64 lost = 0;        // no gradient step, the job kept
+		Uint64 ghosts = 0;      // of lost: standing where the gradient still sees the resource
+		Uint64 abandoned = 0;   // no gradient step, the job given up
+		Uint64 trips = 0;       // commits that reached a harvest
+		Uint64 tripTicks = 0;   // ticks from commit to harvest, summed over trips
+		Uint64 goingTicks = 0;  // unit-ticks spent heading to a resource
+		Uint64 doomedTicks = 0; // unit-ticks heading to a tile already outnumbered
+		Uint32 maxCrowd = 0;    // most units ever heading to one tile at once
+	};
+
+	struct UnitTrack
+	{
+		Uint32 commitTick = 0;
+		Sint8 lastDx = 0;
+		Sint8 lastDy = 0;
+		bool committed = false;
+	};
+
+	Counters counters[Team::MAX_COUNT][MAX_RESOURCES];
+
+	// Whether idle workers coincide with wheat being wanted, and with as many
+	// wheat fetchers out as there is wheat on the map (swim class 0 supply).
+	struct IdleCounters
+	{
+		Uint64 ticks = 0;
+		Uint64 idleWorkerTicks = 0;      // worker-ticks free and without a job
+		Uint64 demandTicks = 0;          // ticks some building wants wheat
+		Uint64 idleWhenDemandTicks = 0;  // idle worker-ticks while wheat is wanted
+		Uint64 boundTicks = 0;           // ticks wheat is wanted and fetchers >= wheat supply
+		Uint64 idleWhenBoundTicks = 0;   // idle worker-ticks during those ticks
+		Uint64 supplySum = 0;            // wheat on the map, summed over ticks
+		Uint64 fetcherSum = 0;           // wheat fetchers out, summed over ticks
+		Uint64 wantedSum = 0;            // wheat wanted by buildings, summed over ticks
+	};
+	IdleCounters idleCounters[Team::MAX_COUNT];
+	UnitTrack tracks[Team::MAX_COUNT][Unit::MAX_COUNT];
+	std::unordered_map<Uint64, Uint32> crowd;
+
+	const int reportEvery = [] {
+		const char *every = std::getenv("GLOB2_HARVEST_METRICS_EVERY");
+		return every ? std::atoi(every) : 0;
+	}();
+
+	bool trackable(const Unit *unit, int resource)
+	{
+		return resource >= 0 && resource < MAX_RESOURCES
+			&& unit->owner->teamNumber >= 0 && unit->owner->teamNumber < Team::MAX_COUNT;
+	}
+
+	UnitTrack &trackOf(const Unit *unit)
+	{
+		return tracks[unit->owner->teamNumber][Unit::GIDtoID(unit->gid)];
+	}
+
+	// How many more units a tile can still serve for this resource.
+	Uint32 capacity(const Map &map, int x, int y, int resource)
+	{
+		const Resource &r = map.getTile(x, y).resource;
+		if (r.type != resource || r.amount == 0)
+			return 0;
+		const ResourceType *type = globalContainer->resourcesTypes.get(resource);
+		return type->granular ? r.amount : 1;
+	}
+
+	bool isFetchingFromMap(const Unit *unit)
+	{
+		return unit->activity == Unit::ACT_FILLING
+			&& unit->displacement == Unit::DIS_GOING_TO_RESOURCE
+			&& unit->ownExchangeBuilding == NULL
+			&& unit->destinationPurpose >= 0 && unit->destinationPurpose < MAX_RESOURCES;
+	}
+}
+
+namespace HarvestMetrics
+{
+	const bool enabled = std::getenv("GLOB2_HARVEST_METRICS") != NULL;
+
+	void onCommit(const Unit *unit)
+	{
+		if (!enabled || !trackable(unit, unit->destinationPurpose))
+			return;
+		counters[unit->owner->teamNumber][unit->destinationPurpose].commits++;
+		UnitTrack &track = trackOf(unit);
+		track.commitTick = unit->owner->game->stepCounter;
+		track.lastDx = track.lastDy = 0;
+		track.committed = true;
+	}
+
+	void onStep(const Unit *unit, bool retargeted)
+	{
+		if (!enabled || !trackable(unit, unit->destinationPurpose))
+			return;
+		Counters &c = counters[unit->owner->teamNumber][unit->destinationPurpose];
+		if (retargeted)
+			c.retargets++;
+		if (unit->dx == 0 && unit->dy == 0)
+			return;
+		c.steps++;
+		UnitTrack &track = trackOf(unit);
+		if (track.lastDx * unit->dx + track.lastDy * unit->dy < 0)
+			c.reversals++;
+		track.lastDx = unit->dx;
+		track.lastDy = unit->dy;
+	}
+
+	void onLost(const Unit *unit, bool abandoned, bool ghost)
+	{
+		if (!enabled || !trackable(unit, unit->destinationPurpose))
+			return;
+		Counters &c = counters[unit->owner->teamNumber][unit->destinationPurpose];
+		if (abandoned)
+			c.abandoned++;
+		else
+		{
+			c.lost++;
+			if (ghost)
+				c.ghosts++;
+		}
+	}
+
+	void onHarvest(const Unit *unit, int resource)
+	{
+		if (!enabled || !trackable(unit, resource))
+			return;
+		Counters &c = counters[unit->owner->teamNumber][resource];
+		c.harvests++;
+		UnitTrack &track = trackOf(unit);
+		if (track.committed)
+		{
+			c.trips++;
+			c.tripTicks += unit->owner->game->stepCounter - track.commitTick;
+			track.committed = false;
+		}
+	}
+
+	void onDeliver(const Unit *unit, int resource)
+	{
+		if (!enabled || !trackable(unit, resource))
+			return;
+		counters[unit->owner->teamNumber][resource].deliveries++;
+	}
+
+	void sample(const Game &game)
+	{
+		if (!enabled)
+			return;
+		const Map &map = game.map;
+		for (int t = 0; t < game.teamsCount() && t < Team::MAX_COUNT; t++)
+		{
+			const Team *team = game.teams[t];
+			if (!team)
+				continue;
+			crowd.clear();
+			Uint32 idle = 0, cornFetchers = 0;
+			for (int i = 0; i < Unit::MAX_COUNT; i++)
+			{
+				const Unit *unit = team->myUnits[i];
+				if (unit && unit->typeNum == WORKER && unit->activity == Unit::ACT_RANDOM && unit->medical == Unit::MED_FREE)
+					idle++;
+				if (!unit || !isFetchingFromMap(unit))
+					continue;
+				if (unit->destinationPurpose == CORN)
+					cornFetchers++;
+				Uint64 key = (Uint64(unit->destinationPurpose) << 32) | map.coordToIndex(unit->targetX, unit->targetY);
+				crowd[key]++;
+			}
+			Uint32 wanted = 0;
+			for (int b = 0; b < Building::MAX_COUNT; b++)
+				if (const Building *building = team->myBuildings[b])
+				{
+					int need = building->type->maxResource[CORN] - building->resources[CORN] + 1 - building->type->multiplierResource[CORN];
+					if (need > 0)
+						wanted += need;
+				}
+			const Uint32 supply = map.getResourceSupply(t, CORN, 0);
+			IdleCounters &ic = idleCounters[t];
+			ic.ticks++;
+			ic.idleWorkerTicks += idle;
+			ic.supplySum += supply;
+			ic.fetcherSum += cornFetchers;
+			ic.wantedSum += wanted;
+			if (wanted > 0)
+			{
+				ic.demandTicks++;
+				ic.idleWhenDemandTicks += idle;
+				if (cornFetchers >= supply)
+				{
+					ic.boundTicks++;
+					ic.idleWhenBoundTicks += idle;
+				}
+			}
+			for (const auto &entry : crowd)
+			{
+				int resource = int(entry.first >> 32);
+				size_t index = size_t(entry.first & 0xFFFFFFFF);
+				int x = int(index & map.wMask);
+				int y = int(index >> map.wDec);
+				Uint32 going = entry.second;
+				Uint32 room = capacity(map, x, y, resource);
+				Counters &c = counters[t][resource];
+				c.goingTicks += going;
+				if (going > room)
+					c.doomedTicks += going - room;
+				if (going > c.maxCrowd)
+					c.maxCrowd = going;
+			}
+		}
+		if (reportEvery > 0 && game.stepCounter > 0 && game.stepCounter % reportEvery == 0)
+			report(game);
+	}
+
+	void report(const Game &game)
+	{
+		if (!enabled)
+			return;
+		for (int t = 0; t < game.teamsCount() && t < Team::MAX_COUNT; t++)
+			for (int r = 0; r < MAX_RESOURCES; r++)
+			{
+				const Counters &c = counters[t][r];
+				if (c.commits == 0 && c.harvests == 0 && c.deliveries == 0)
+					continue;
+				std::printf("GLOB2_HARVEST tick=%u team=%d res=%s commits=%llu harvests=%llu deliveries=%llu"
+					" steps=%llu reversals=%llu retargets=%llu lost=%llu ghosts=%llu abandoned=%llu trips=%llu tripTicks=%llu"
+					" goingTicks=%llu doomedTicks=%llu maxCrowd=%u\n",
+					game.stepCounter, t, kResourceNames[r],
+					(unsigned long long)c.commits, (unsigned long long)c.harvests, (unsigned long long)c.deliveries,
+					(unsigned long long)c.steps, (unsigned long long)c.reversals, (unsigned long long)c.retargets,
+					(unsigned long long)c.lost, (unsigned long long)c.ghosts,
+					(unsigned long long)c.abandoned, (unsigned long long)c.trips, (unsigned long long)c.tripTicks,
+					(unsigned long long)c.goingTicks, (unsigned long long)c.doomedTicks, c.maxCrowd);
+			}
+		for (int t = 0; t < game.teamsCount() && t < Team::MAX_COUNT; t++)
+		{
+			const IdleCounters &ic = idleCounters[t];
+			std::printf("GLOB2_IDLE tick=%u team=%d ticks=%llu idleWorkerTicks=%llu demandTicks=%llu idleWhenDemandTicks=%llu"
+				" boundTicks=%llu idleWhenBoundTicks=%llu supplySum=%llu fetcherSum=%llu wantedSum=%llu\n",
+				game.stepCounter, t, (unsigned long long)ic.ticks, (unsigned long long)ic.idleWorkerTicks,
+				(unsigned long long)ic.demandTicks, (unsigned long long)ic.idleWhenDemandTicks,
+				(unsigned long long)ic.boundTicks, (unsigned long long)ic.idleWhenBoundTicks,
+				(unsigned long long)ic.supplySum, (unsigned long long)ic.fetcherSum, (unsigned long long)ic.wantedSum);
+		}
+		std::fflush(stdout);
+	}
+
+	unsigned long long deliveries(int teamNumber, int resource)
+	{
+		if (teamNumber < 0 || teamNumber >= Team::MAX_COUNT || resource < 0 || resource >= MAX_RESOURCES)
+			return 0;
+		return counters[teamNumber][resource].deliveries;
+	}
+}

--- a/src/HarvestMetrics.h
+++ b/src/HarvestMetrics.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef __HARVEST_METRICS_H
+#define __HARVEST_METRICS_H
+
+// Optional counters for measuring how workers fetch map resources: how often
+// they reach a resource, deliver it, turn back, or walk towards a tile that
+// has fewer resources left than units heading for it. Enabled by setting
+// GLOB2_HARVEST_METRICS in the environment; GLOB2_HARVEST_METRICS_EVERY=N also
+// prints cumulative totals every N ticks.
+//
+// Measurement only: every hook reads game state and writes nothing but this
+// module's own tables, so a run's checksum is the same with the metrics on or
+// off. Hooks return at once when the metrics are off.
+
+class Unit;
+class Game;
+
+namespace HarvestMetrics
+{
+	extern const bool enabled;
+
+	//! The unit set out to fetch its destinationPurpose from the map.
+	void onCommit(const Unit *unit);
+	//! The unit took a step towards the resource it is fetching; retargeted
+	//! when that step also moved its gradient destination.
+	void onStep(const Unit *unit, bool retargeted);
+	//! The resource gradient gave no step. abandoned: the unit gave up the job.
+	//! ghost: it stands on a tile the gradient still takes for the resource.
+	void onLost(const Unit *unit, bool abandoned, bool ghost);
+	void onHarvest(const Unit *unit, int resource);
+	void onDeliver(const Unit *unit, int resource);
+	//! Once per simulated tick, before the step counter advances.
+	void sample(const Game &game);
+	//! Cumulative totals, one line per team and resource with any activity.
+	void report(const Game &game);
+	//! Resources of this type delivered by the team so far.
+	unsigned long long deliveries(int teamNumber, int resource);
+}
+
+#endif

--- a/src/SConscript
+++ b/src/SConscript
@@ -107,6 +107,7 @@ Game.cpp
 Game_orders.cpp
 Game_io.cpp
 Game_sync.cpp
+HarvestMetrics.cpp
 Game_editor.cpp
 render/GameRender.cpp
 render/GameRenderUnits.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -681,6 +681,12 @@ if not env['server'] and 'hiring-bucket-test' in COMMAND_LINE_TARGETS:
     hiring_sources += local.Object('HiringBucketHarness.o', '#test/HiringBucketHarness.cpp')
     local.Alias('hiring-bucket-test', local.Program('HiringBucketHarness', hiring_sources))
 
+# Measure inn workers crowding the few ripe tiles of a checkerboard farm.
+if not env['server'] and 'wheat-crowding-harness' in COMMAND_LINE_TARGETS:
+    wheat_sources = [source for source in source_files if source != 'Glob2.cpp']
+    wheat_sources += local.Object('WheatCrowdingHarness.o', '#test/WheatCrowdingHarness.cpp')
+    local.Alias('wheat-crowding-harness', local.Program('WheatCrowdingHarness', wheat_sources))
+
 if not env['server'] and 'custom-setup-test' in COMMAND_LINE_TARGETS:
     custom_sources = [source for source in source_files if source != 'Glob2.cpp']
     custom_sources += local.Object('CustomGameSetupHarness.o', '#test/CustomGameSetupHarness.cpp')

--- a/src/building/Step.cpp
+++ b/src/building/Step.cpp
@@ -122,6 +122,11 @@ bool Building::considerUnitForResource(Unit* unit, int wantedResource, int* dist
 			noteUnitFailing(unit, UnitCantAccessFruit);
 		return false;
 	}
+	if(owner->resourceOversubscribed(wantedResource, unit->swimClass()))
+	{
+		noteUnitFailing(unit, UnitCantAccessResource);
+		return false;
+	}
 	if(distResource >= timeLeft)
 	{
 		if(wantedResource<BASIC_COUNT)
@@ -307,6 +312,9 @@ bool Building::subscribeToBringResourcesStep()
 
 		if (sel.choosen)
 		{
+			const int purpose = sel.choosen->destinationPurpose;
+			if (Team::supplyCapEnabled() && sel.choosen->carriedResource != purpose && purpose >= 0 && purpose < MAX_RESOURCES)
+				owner->fetchersGoing[purpose][sel.choosen->swimClass()]++;
 			unitsWorking.push_back(sel.choosen);
 			sel.choosen->subscriptionSuccess(this, false);
 			owner->swapTask(sel.choosen);

--- a/src/map/Map.cpp
+++ b/src/map/Map.cpp
@@ -49,6 +49,7 @@ Map::Map()
 			for (int s=0; s<SWIM_CLASS_COUNT; s++)
 			{
 				resourcesGradient[t][r][s] = NULL;
+				resourceSupply[t][r][s] = 0;
 				gradientUpdated[t][r][s] = false;
 			}
 	for (int t=0; t<Team::MAX_COUNT; t++)

--- a/src/map/Map.h
+++ b/src/map/Map.h
@@ -632,6 +632,12 @@ public:
 	template<typename T>
 	bool isGradientPeak(const T *gradient, int x, int y) const;
 
+	//! PROTOTYPE: resources left on the goal tiles at the field's last rebuild.
+	Uint32 getResourceSupply(int teamNumber, int resourceType, int swimClass) const
+	{
+		return resourceSupply[teamNumber][resourceType][swimClass];
+	}
+
 	Uint16 getGradient(int teamNumber, Uint8 resourceType, int swimClass, int x, int y)
 	{
 		return getResourceGradient(teamNumber, resourceType, swimClass)[coordToIndex(x, y)];
@@ -758,6 +764,8 @@ protected:
 	// Used to go to resources
 	//[int team][int resourceNumber][int swimClass]
 	Uint16 *resourcesGradient[Team::MAX_COUNT][MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
+	// PROTOTYPE: resources left on the goal tiles of each field at its last rebuild.
+	Uint32 resourceSupply[Team::MAX_COUNT][MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
 	
 	// Used to go out of forbidden areas
 	Uint16 *forbiddenGradient[Team::MAX_COUNT][SWIM_CLASS_COUNT];

--- a/src/map/gradient/MapGradientGlobal.cpp
+++ b/src/map/gradient/MapGradientGlobal.cpp
@@ -125,6 +125,8 @@ void Map::updateResourcesGradient(int teamNumber, Uint8 resourceType, int swimCl
 
 	Uint32 teamMask=Team::teamNumberToMask(teamNumber);
 	assert(globalContainer);
+	const ResourceType *fullType=globalContainer->resourcesTypes.get(resourceType);
+	Uint32 supply=0;
 	for (size_t i=0; i<size; i++)
 	{
 		const Tile& c=tiles[i];
@@ -146,11 +148,16 @@ void Map::updateResourcesGradient(int teamNumber, Uint8 resourceType, int swimCl
 			if (globalContainer->resourcesTypes.get(resourceType)->visibleToBeCollected && !(fogOfWar[i]&teamMask))
 				gradient[i]=GRADIENT_FORBIDDEN;
 			else
+			{
 				gradient[i]=GRADIENT_AT_GOAL;
+				if (c.resource.amount>0)
+					supply+=fullType->granular ? c.resource.amount : 1;
+			}
 		}
 		else
 			gradient[i]=GRADIENT_FORBIDDEN;
 	}
+	resourceSupply[teamNumber][resourceType][swimClass]=supply;
 
 	propagateGradient(gradient, swimClass);
 }

--- a/src/team/Team.cpp
+++ b/src/team/Team.cpp
@@ -58,6 +58,10 @@ void Team::init(void)
 	for (int i=0; i<Building::MAX_COUNT; i++)
 		myBuildings[i]=NULL;
 
+	for (int r=0; r<MAX_NB_RESOURCES; r++)
+		for (int s=0; s<SWIM_CLASS_COUNT; s++)
+			fetchersGoing[r][s]=0;
+
 	startPosX=startPosY=0;
 	startPosSet=START_POS_UNSET;
 

--- a/src/team/Team.h
+++ b/src/team/Team.h
@@ -145,6 +145,12 @@ public:
 	Map *map;
 
 	Unit **myUnits;
+	// PROTOTYPE: units on their way to fetch each resource, per swim class.
+	int fetchersGoing[MAX_NB_RESOURCES][SWIM_CLASS_COUNT];
+	void countFetchersGoing();
+	static bool supplyCapEnabled();
+	//! PROTOTYPE: as many units already fetch this resource as are left on the map.
+	bool resourceOversubscribed(int resource, int swimClass) const;
 
 	Building **myBuildings;
 

--- a/src/team/TeamStep.cpp
+++ b/src/team/TeamStep.cpp
@@ -142,6 +142,34 @@ void Team::removeBuildingNeedingWork(Building* b, Sint32 priority)
 
 
 
+void Team::countFetchersGoing()
+{
+	for (int r = 0; r < MAX_NB_RESOURCES; r++)
+		for (int s = 0; s < SWIM_CLASS_COUNT; s++)
+			fetchersGoing[r][s] = 0;
+	if (!supplyCapEnabled())
+		return;
+	for (int i = 0; i < Unit::MAX_COUNT; i++)
+	{
+		const Unit *u = myUnits[i];
+		if (u && u->activity == Unit::ACT_FILLING && u->displacement == Unit::DIS_GOING_TO_RESOURCE
+			&& u->ownExchangeBuilding == NULL && u->destinationPurpose >= 0 && u->destinationPurpose < MAX_NB_RESOURCES)
+			fetchersGoing[u->destinationPurpose][u->swimClass()]++;
+	}
+}
+
+bool Team::supplyCapEnabled()
+{
+	static const bool enabled = getenv("GLOB2_PROTO_SUPPLY_CAP") != NULL;
+	return enabled;
+}
+
+bool Team::resourceOversubscribed(int resource, int swimClass) const
+{
+	return supplyCapEnabled() && resource >= 0 && resource < MAX_RESOURCES
+		&& (Uint32)fetchersGoing[resource][swimClass] >= map->getResourceSupply(teamNumber, resource, swimClass);
+}
+
 void Team::updateAllBuildingTasks()
 {
 	for(std::map<int, std::vector<Building*>, std::greater<int> >::iterator i = buildingsNeedingUnits.begin(); i!=buildingsNeedingUnits.end(); ++i)
@@ -436,6 +464,7 @@ void Team::syncStep(void)
 			++it;
 	}
 
+	countFetchersGoing();
 	updateAllBuildingTasks();
 	for (int k = 0; k < SWAP_CHECKS_PER_TICK; k++)
 		swapTask(myUnits[(game->stepCounter * SWAP_CHECKS_PER_TICK + k) % Unit::MAX_COUNT]);

--- a/src/team/TeamStep.cpp
+++ b/src/team/TeamStep.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "BuildingType.h"
+#include "HarvestMetrics.h"
 #include "Game.h"
 #include "GameGUI.h"
 #include "Map.h"
@@ -283,6 +284,7 @@ namespace
 			u->displacement = Unit::DIS_GOING_TO_RESOURCE;
 			u->setTargetBuilding(NULL);
 			b->owner->map->resourceAvailableUpdate(b->owner->teamNumber, resource, u->swimClass(), u->posX, u->posY, &u->targetX, &u->targetY, NULL);
+			HarvestMetrics::onCommit(u);
 		}
 		u->validTarget = true;
 	}

--- a/src/unit/Unit.cpp
+++ b/src/unit/Unit.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2001-2004 Stephane Magnenat & Luc-Olivier de Charrière
 
 #include "Unit.h"
+#include "HarvestMetrics.h"
 #include "Race.h"
 #include "Team.h"
 #include "Map.h"
@@ -207,6 +208,7 @@ void Unit::subscriptionSuccess(Building* building, bool inside)
 						targetBuilding=NULL;
 						owner->map->resourceAvailableUpdate(owner->teamNumber, destinationPurpose, swimClass(), posX, posY, &targetX, &targetY, NULL);
 						validTarget=true;
+						HarvestMetrics::onCommit(this);
 					}
 				}
 				break;

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include "Unit.h"
+#include "HarvestMetrics.h"
 #include "Race.h"
 #include "Team.h"
 #include "Map.h"
@@ -54,6 +55,7 @@ void Unit::handleDisplacement(void)
 			{
 				// we got the resource.
 				carriedResource=destinationPurpose;
+				HarvestMetrics::onHarvest(this, carriedResource);
 				owner->map->decResource(posX+dx, posY+dy, carriedResource);
 				assert(movement == MOV_HARVESTING);
 				movement = MOV_RANDOM_GROUND; // we do this to avoid the handleMovement() to additionally decResource() the same resource.
@@ -124,6 +126,7 @@ void Unit::handleDisplacement(void)
 				{
 					if (verbose)
 						printf("guid=(%d) Giving resource (%d) to building gbid=(%d) old-amount=(%d)\n", gid, destinationPurpose, targetBuilding->gid, targetBuilding->resources[carriedResource]);
+					HarvestMetrics::onDeliver(this, carriedResource);
 					targetBuilding->addResourceIntoBuilding(carriedResource);
 					carriedResource=UNIT_CARRIED_RESOURCE_NONE;
 				}
@@ -235,11 +238,13 @@ void Unit::handleDisplacement(void)
 										dy = off->dy;
 										displacement=DIS_HARVESTING;
 										validTarget=false;
+										HarvestMetrics::onCommit(this);
 									}
 									else if (map->resourceAvailableUpdate(teamNumber, destinationPurpose, swimClass(), posX, posY, &targetX, &targetY, &dummyDist))
 									{
 										displacement=DIS_GOING_TO_RESOURCE;
 										validTarget=true;
+										HarvestMetrics::onCommit(this);
 									}
 									else
 									{

--- a/src/unit/UnitDisplacement.cpp
+++ b/src/unit/UnitDisplacement.cpp
@@ -161,11 +161,17 @@ void Unit::handleDisplacement(void)
 								if (need>0)
 								{
 									int distToResource;
-									bool available=map->roundTripDistance(attachedBuilding, r, swimClass(), posX, posY, &distToResource);
-									if (available)
-										distToResource=(distToResource+1)/2; // half the round trip: the unit is at the building
-									else
-										available=map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource);
+									// With GLOB2_PROTO_SUPPLY_CAP, skip fetching from the map while as many
+									// units already fetch r as the map has left; a market still counts.
+									bool available=false;
+									if (!owner->resourceOversubscribed(r, swimClass()))
+									{
+										available=map->roundTripDistance(attachedBuilding, r, swimClass(), posX, posY, &distToResource);
+										if (available)
+											distToResource=(distToResource+1)/2; // half the round trip: the unit is at the building
+										else
+											available=map->resourceAvailable(teamNumber, r, swimClass(), posX, posY, &distToResource);
+									}
 									if (available)
 									{
 										if ((distToResource<<1)>=timeLeft)
@@ -209,6 +215,8 @@ void Unit::handleDisplacement(void)
 							if (bestResource>=0)
 							{
 								destinationPurpose=bestResource;
+								if (Team::supplyCapEnabled() && !takeInExchangeBuilding && bestResource < MAX_RESOURCES)
+									owner->fetchersGoing[bestResource][swimClass()]++;
 								assert(activity==ACT_FILLING);
 								if (takeInExchangeBuilding)
 								{

--- a/src/unit/UnitMovement.cpp
+++ b/src/unit/UnitMovement.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2001-2004 Stephane Magnenat & Luc-Olivier de Charrière
 
 #include "Unit.h"
+#include "HarvestMetrics.h"
 #include "Race.h"
 #include "Team.h"
 #include "Map.h"
@@ -563,6 +564,7 @@ void Unit::handleMovementGoingToResource()
 	{
 		directionFromDxDy();
 		movement=MOV_GOING_DX_DY;
+		const Sint32 previousTargetX = targetX, previousTargetY = targetY;
 		// targetX/Y (also the debug path line, hotkey T) were set once, by
 		// ascending a gradient, when the fetch task started. pathfindResource
 		// above re-reads whichever gradient actually governs the step fresh
@@ -578,9 +580,12 @@ void Unit::handleMovementGoingToResource()
 			? roundTrip : map->getResourceGradient(teamNumber, destinationPurpose, swim);
 		if (!map->isGradientPeak(gradient, targetX, targetY))
 			map->getGlobalGradientDestination(gradient, posX, posY, &targetX, &targetY);
+		HarvestMetrics::onStep(this, targetX != previousTargetX || targetY != previousTargetY);
 	}
 	else
 	{
+		HarvestMetrics::onLost(this, stopWork, HarvestMetrics::enabled
+			&& map->getResourceGradient(teamNumber, destinationPurpose, swim)[map->coordToIndex(posX, posY)] == GRADIENT_AT_GOAL);
 		if (stopWork)
 			stopAttachedForBuilding(false);
 		movement=MOV_RANDOM_GROUND;

--- a/test/README.md
+++ b/test/README.md
@@ -408,3 +408,28 @@ keyboard file formats remain unchanged.
 settings, language, persistence, keyboard, multiplayer eligibility and camera
 cadence regressions without starting the unrelated engine/replay scenarios.
 The full invocation remains available and reports buffered diagnostics on timeout.
+
+## Wheat crowding harness
+
+`WheatCrowdingHarness` builds a fertile checkerboard farm on a peninsula (water
+on three sides, forbidden squares holding protected wheat seeds) next to six
+empty inns of eight workers each, and runs real simulation ticks. It is a
+measurement scenario, not a pass/fail regression: it prints the
+`GLOB2_HARVEST` counters described in
+[docs/headless-replays.md](../docs/headless-replays.md) and a `WHEAT_RESULT`
+line with the checksum.
+
+```sh
+scons -j8 release=1 server=0 wheat-crowding-harness
+GLOB2_HARVEST_METRICS=1 ./build/src/WheatCrowdingHarness 12000 checker 6 8 1 7
+```
+
+Arguments: ticks, seed pattern (`checker`, `dots`, `sparse`), inns, workers per
+inn, sink, and the width of the centred square the seeds are confined to.
+`sink=1` empties the inns and keeps the workers fed every tick, so demand never
+runs out and the workforce stays constant. A seed square of 7 or less keeps the
+farm bare, so every ripe tile is rushed as it appears: all 48 workers head for
+one tile, and most of them then abandon the job. The full 13-wide farm stays
+stocked instead. `WHEAT_SEED=N` gives another deterministic run of the same
+farm, `WHEAT_TIMELINE_EVERY=N` a progress line every `N` ticks, and
+`GLOB2_PROTO_SUPPLY_CAP=1` runs the prototype fetcher cap.

--- a/test/WheatCrowdingHarness.cpp
+++ b/test/WheatCrowdingHarness.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// A fertile checkerboard farm fetched from by many inn workers. Each forbidden
+// square holds a protected wheat seed; wheat spreads from the seeds into the
+// open squares one unit at a time, and a single harvest clears a new tile, so
+// every worker is drawn to the same few ripe tiles. This is the crowding the
+// scenario measures.
+//
+// Usage: WheatCrowdingHarness [ticks] [checker|dots|sparse] [inns] [workersPerInn] [sink] [seedSpan]
+//   checker: every other square is a seed; dots: one in four; sparse: one in sixteen.
+//   seedSpan (odd, default 13) confines the seeds to a centred square that many
+//   tiles wide, leaving the rest of the farm open ground: the same farm, less wheat.
+//   sink=1 (default) empties the inns and keeps the workers fed every tick, so
+//   demand never runs out and the workforce stays constant: deliveries then
+//   measure fetch throughput alone. sink=0 leaves the colony to itself.
+// Set GLOB2_HARVEST_METRICS=1 for the fetch counters and WHEAT_TIMELINE_EVERY=N
+// for a WHEAT_TICK line every N ticks, WHEAT_SEED=N for another random run. The final WHEAT_RESULT line carries the
+// checksum, so two builds can be compared for identical simulation.
+#include "GlobalContainer.h"
+#include "Game.h"
+#include "GameGUI.h"
+#include "HarvestMetrics.h"
+#include "Unit.h"
+#include "Building.h"
+#include "BuildingType.h"
+#include "IntBuildingType.h"
+#include "Race.h"
+#include "Ressource.h"
+#include "Utilities.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+GlobalContainer* globalContainer = nullptr;
+
+static void require(bool ok, const char* message)
+{
+	if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+namespace
+{
+	// 64x64, all water apart from a base island and a farm peninsula joined
+	// by a land bridge. The farm has water on three sides within 8 tiles, so
+	// the random water probe in Map::growResources nearly always succeeds.
+	constexpr int BASE_X0 = 4, BASE_X1 = 26, BASE_Y0 = 14, BASE_Y1 = 50;
+	constexpr int BRIDGE_X1 = 33, BRIDGE_Y0 = 30, BRIDGE_Y1 = 34;
+	constexpr int FARM_X0 = 33, FARM_X1 = 47, FARM_Y0 = 25, FARM_Y1 = 39;
+
+	constexpr int FARM_CX = (FARM_X0 + FARM_X1) / 2, FARM_CY = (FARM_Y0 + FARM_Y1) / 2;
+
+	enum class Pattern { Checker, Dots, Sparse };
+
+	int seedSpan = FARM_X1 - FARM_X0 - 1;
+
+	bool isSeed(int x, int y, Pattern pattern)
+	{
+		// Leave a one-tile open border so workers can walk around the farm.
+		if (x <= FARM_X0 || x >= FARM_X1 || y <= FARM_Y0 || y >= FARM_Y1)
+			return false;
+		if (std::abs(x - FARM_CX) > seedSpan / 2 || std::abs(y - FARM_CY) > seedSpan / 2)
+			return false;
+		switch (pattern)
+		{
+			case Pattern::Checker: return (x + y) % 2 == 0;
+			case Pattern::Dots: return x % 2 == 0 && y % 2 == 0;
+			case Pattern::Sparse: return x % 4 == 0 && y % 4 == 0;
+		}
+		return false;
+	}
+
+	void paintGrass(Game& game, int x0, int x1, int y0, int y1)
+	{
+		for (int y = y0; y <= y1; ++y)
+			for (int x = x0; x <= x1; ++x)
+				game.map.setUMatPos(x, y, GRASS, 1);
+	}
+}
+
+int main(int argc, char** argv)
+{
+	const int ticks = argc > 1 ? std::atoi(argv[1]) : 12000;
+	const std::string patternName = argc > 2 ? argv[2] : "checker";
+	const int innCount = argc > 3 ? std::atoi(argv[3]) : 6;
+	const int workersPerInn = argc > 4 ? std::atoi(argv[4]) : 8;
+	const bool sink = argc > 5 ? std::atoi(argv[5]) != 0 : true;
+	if (argc > 6)
+		seedSpan = std::atoi(argv[6]);
+	require(patternName == "checker" || patternName == "dots" || patternName == "sparse", "pattern is checker, dots or sparse");
+	const Pattern pattern = patternName == "checker" ? Pattern::Checker : patternName == "dots" ? Pattern::Dots : Pattern::Sparse;
+	require(ticks > 0 && innCount > 0 && innCount <= 6 && workersPerInn > 0 && seedSpan > 0,
+		"usage: [ticks] [checker|dots|sparse] [inns<=6] [workersPerInn] [sink] [seedSpan]");
+
+	GlobalContainer globals;
+	globalContainer = &globals;
+	globals.runNoX = true;
+	globals.settings.rememberUnit = false;
+	globals.buildingsTypes.init();
+	IntBuildingType::init();
+	Race::loadDefault();
+
+	// WHEAT_SEED picks a different, still deterministic, run of the same farm.
+	if (const char* seed = std::getenv("WHEAT_SEED"))
+		setSyncRandSeed((Uint32)std::strtoul(seed, nullptr, 10));
+
+	GameGUI gui;
+	Game& game = gui.game;
+	game.map.setSize(6, 6, WATER);
+	game.map.setGame(&game);
+	game.addTeam(0);
+	Team* team = game.teams[0];
+	// The gradient scheduler expects an in-use field; allocation is lazy.
+	game.map.getResourceGradient(0, CORN, 0);
+
+	paintGrass(game, BASE_X0, BASE_X1, BASE_Y0, BASE_Y1);
+	paintGrass(game, BASE_X1, BRIDGE_X1, BRIDGE_Y0, BRIDGE_Y1);
+	paintGrass(game, FARM_X0, FARM_X1, FARM_Y0, FARM_Y1);
+
+	int seeds = 0;
+	for (int y = FARM_Y0; y <= FARM_Y1; ++y)
+		for (int x = FARM_X0; x <= FARM_X1; ++x)
+			if (isSeed(x, y, pattern))
+			{
+				game.map.addForbidden(x, y, 0);
+				require(game.map.incResource(x, y, CORN, 0), "plant a wheat seed");
+				for (int grow = 0; grow < 4; ++grow)
+					game.map.incResource(x, y, CORN, 0);
+				++seeds;
+			}
+
+	// Empty inns in two columns by the bridge, each staffed well past what the
+	// farm can feed.
+	const int innType = globalContainer->buildingsTypes.getTypeNum("inn", 0, false);
+	require(innType >= 0, "inn type exists");
+	const int innYs[6] = {16, 22, 28, 34, 40, 46};
+	const int innXs[2] = {20, 14};
+	for (int i = 0; i < innCount; ++i)
+	{
+		Building* inn = game.addBuilding(innXs[i / 3 % 2], innYs[(i * 2 + 1) % 6], innType, 0, workersPerInn, workersPerInn);
+		require(inn != nullptr, "inn placed");
+		game.map.setBuilding(inn->posX, inn->posY, inn->type->width, inn->type->height, inn->gid);
+		inn->resources[CORN] = 0;
+		inn->update();
+	}
+
+	// Idle workers spread over the base island.
+	const int workers = innCount * workersPerInn;
+	int placed = 0, fed = 0;
+	for (int y = BASE_Y0 + 1; y < BASE_Y1 && placed < workers; y += 2)
+		for (int x = BASE_X0 + 1; x < 12 && placed < workers; x += 2)
+			if (Unit* unit = game.addUnit(x, y, 0, WORKER, 0, 0, 0, 0))
+			{
+				fed = unit->hungry;
+				++placed;
+			}
+	require(placed == workers, "every worker placed");
+	require(game.integrity(), "scenario setup is consistent");
+
+	std::printf("WHEAT_SETUP pattern=%s seedSpan=%d seeds=%d inns=%d workersPerInn=%d workers=%d ticks=%d sink=%d\n",
+		patternName.c_str(), seedSpan, seeds, innCount, workersPerInn, workers, ticks, sink ? 1 : 0);
+
+	const int every = std::getenv("WHEAT_TIMELINE_EVERY") ? std::atoi(std::getenv("WHEAT_TIMELINE_EVERY")) : 0;
+	for (int i = 0; i <= ticks; ++i)
+	{
+		const bool last = i == ticks;
+		if (last || (every > 0 && i % every == 0))
+		{
+			int alive = 0, fetching = 0, harvesting = 0, carrying = 0;
+			for (int u = 0; u < Unit::MAX_COUNT; ++u)
+				if (const Unit* unit = team->myUnits[u])
+				{
+					++alive;
+					if (unit->activity == Unit::ACT_FILLING && unit->displacement == Unit::DIS_GOING_TO_RESOURCE)
+						++fetching;
+					else if (unit->displacement == Unit::DIS_HARVESTING)
+						++harvesting;
+					else if (unit->carriedResource == CORN)
+						++carrying;
+				}
+			int innWheat = 0;
+			for (int b = 0; b < Building::MAX_COUNT; ++b)
+				if (team->myBuildings[b])
+					innWheat += team->myBuildings[b]->resources[CORN];
+			int openTiles = 0, openWheat = 0;
+			for (int y = FARM_Y0; y <= FARM_Y1; ++y)
+				for (int x = FARM_X0; x <= FARM_X1; ++x)
+				{
+					const Resource& r = game.map.getTile(x, y).resource;
+					if (r.type == CORN && !isSeed(x, y, pattern))
+					{
+						++openTiles;
+						openWheat += r.amount;
+					}
+				}
+			if (last)
+			{
+				require(game.integrity(), "integrity after the run");
+				HarvestMetrics::report(game);
+			}
+			std::printf("%s ticks=%u delivered=%llu alive=%d fetching=%d harvesting=%d carrying=%d innWheat=%d openWheatTiles=%d openWheat=%d checksum=%08x\n",
+				last ? "WHEAT_RESULT" : "WHEAT_TICK", game.stepCounter, HarvestMetrics::deliveries(0, CORN),
+				alive, fetching, harvesting, carrying, innWheat, openTiles, openWheat, game.checkSum());
+		}
+		if (last)
+			break;
+
+		game.syncStep(0);
+		if (sink)
+		{
+			for (int b = 0; b < Building::MAX_COUNT; ++b)
+				if (Building* inn = team->myBuildings[b])
+					if (inn->resources[CORN] > 0)
+					{
+						inn->resources[CORN] = 0;
+						inn->update();
+					}
+			for (int u = 0; u < Unit::MAX_COUNT; ++u)
+				if (Unit* unit = team->myUnits[u])
+					unit->hungry = fed;
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION
**For discussion, not merge.** @Giszmo, this is one possible answer to workers crowding a single tile of wheat. We aren't sure it's a satisfactory one and would like your read before going further.

## The problem

With many inn workers and little ripe wheat, they all head for the same tile. A few get it, it vanishes, and the rest turn around together. The cause is that every fetcher of a team follows the same resource gradient to the nearest wheat, and nothing tells unit #2 that unit #1 already has that grain covered.

## What this PR contains

Three commits, meant to be read separately:

1. **Prototype fetcher cap**, opt-in via `GLOB2_PROTO_SUPPLY_CAP=1`. Without the variable the simulation is unchanged.
   - Each resource gradient rebuild already visits every tile; it now also sums what the goal tiles still hold (`Map::resourceSupply`, per team, resource and swim class).
   - Before hiring, `Team::syncStep` counts the units already on their way to fetch each resource.
   - With the cap on, a building doesn't hire another fetcher for a map resource, and a unit that just delivered doesn't go back out for it, while as many units are already fetching it as the map has left. Markets are still offered.
2. **Measurement tooling**, `GLOB2_HARVEST_METRICS=1`. Per team and resource it prints fetches started, harvests, deliveries, steps with no gradient step (and how many of those stood on a tile the field hadn't caught up with yet), abandoned jobs, destination changes, and the share of fetch time spent heading to a tile already outnumbered by the units heading there. It only reads game state. `GLOB2_SAVE_AT_END=<path>` saves a `--nox` game at its step limit so the moment can be opened in the GUI. Documented in `docs/headless-replays.md`.
3. **`WheatCrowdingHarness`**: a checkerboard farm on a peninsula (forbidden seed squares, water on three sides) beside 6 inns × 8 workers, run for real ticks. It's a measurement scenario, not pass/fail. Documented in `test/README.md`.

## Evidence

**Neutrality.** On FourSquares, 4 AIs, 30,000 ticks, the checksum is `f0bf6f73` on master and on this branch with the cap off, metrics off and on.

**Repro harness.** 12,000 ticks, 10 paired seeds (`WHEAT_SEED=1..10`), cap off vs on, 95% intervals:

| farm | wheat deliveries | abandoned jobs | fetches started | max workers on one tile |
|---|---|---|---|---|
| checker, 7-wide seed square: farm stays bare, each grain rushed | **+15.5% ± 7.5%** (up in 9/10) | 1652 → 1 | −69% | 48 → 28 |
| sparse seeds | +8.9% ± 12% (not significant) | 1437 → 1 | −72% | 48 → 28 |
| checker, full farm: stays stocked | 0.0% ± 1.9% | 0 → 0 | −1% | 48 → 33 |
| dots, full farm: stays stocked | **−2.2% ± 1.8%** | 0 → 0 | −3% | 48 → 32 |

In the bare-farm cases, deliveries rise mainly because grains survive long enough to grow and spread, instead of being stripped the moment they appear by a crowd that also stands on the tiles wheat would grow into.

Reproduce:

```sh
scons -j8 release=1 server=0 wheat-crowding-harness
GLOB2_HARVEST_METRICS=1 WHEAT_SEED=1 ./build/src/WheatCrowdingHarness 12000 checker 6 8 1 7
GLOB2_HARVEST_METRICS=1 WHEAT_SEED=1 GLOB2_PROTO_SUPPLY_CAP=1 ./build/src/WheatCrowdingHarness 12000 checker 6 8 1 7
```

**Real games. This is where we're unsure.** On FourSquares with 4× Nicowar and 4× Econo (seeds 1–4, `GLOB2_TEST_SEED` + `--save-game-as`, master behaviour, tick 30k → end) wheat crowding is severe:

- 16–62 workers heading for one wheat tile, with 65–79% of wheat fetch time aimed at an outnumbered tile (stone: 0–2%).
- It isn't the harness regime: abandoned jobs are rare (64–310 across 4 games against ~28k–43k harvests).
- Most of the waste is workers with no gradient step, 2.2–3.6 per harvest. Only 12–16% of those are on a tile the field hadn't caught up with; the rest are boxed in by other workers and take a random step.

From a Nicowar save at tick 40,000, run 10,000 more ticks: each team has ~1,200 wheat on the map against 12–52 fetchers, so **the cap is essentially never binding in a real game**. The ~1% of ticks where it appears to bind are all right after loading; see limitations. A multi-seed FourSquares A/B with the cap on hasn't been run yet.

## Known limitations

- **Load continuity.** `resourceSupply` isn't saved. After a load it reads 0 until each field rebuilds, and the cap blocks fetching for those ticks, so a loaded game diverges from a continued one when the cap is on. A real version would need to save the count or derive it safely.
- **It limits how many workers go, not where they go.** The fetchers that do go still converge on the nearest tile.
- **The team-wide supply ignores distance.** Wheat on a far farm lets fetchers go to a near farm that can't serve them all.
- **Swim classes.** Supply is per swim class, so a class whose field hasn't been built yet counts as empty.
- **Conflict.** #269 renames `CORN` to `WHEAT`; whichever lands second needs a trivial rebase.

## Feel

In the bare-farm harness the counters say far fewer workers set out for each grain and almost none abandon (not yet looked at by eye). In a FourSquares Nicowar game at ~27 min with the cap on, workers around the farms still looked like they were milling around chaotically rather than going for the wheat that's there. That fits the numbers: the cap barely binds there, and most lost steps are workers boxed in by other workers. In that save the cap-on run also averaged more idle workers (team 0: 7.7 → 12.3), but one pair of diverging runs can't tell whether that's the cap. Not yet played by a human beyond that look.

## Questions for you

1. Is capping hiring at the supply the right layer, or should this be per-tile claims, where each fetcher heads to a distinct ripe tile?
2. Is the bare-farm rush worth solving on its own, given real games mostly suffer from congestion (boxed-in workers stepping at random) rather than over-hiring?
3. If you'd keep any of it: the metrics and harness are independent of the cap except the `GLOB2_IDLE` line, which reads `Map::getResourceSupply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5GEG5t9ithd47SFm6PTDZ
